### PR TITLE
fix: decrement memberWithdrawableBalance and safetyNetBalance on withdrawal execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "forge build",
     "build:optimized": "FOUNDRY_PROFILE=optimized forge build",
-    "coverage": "forge coverage --report summary --report lcov --match-path 'test/unit/*'",
+    "coverage": "forge coverage --ir-minimum --report summary --report lcov --match-path 'test/unit/*'",
     "deploy:gnosis": "bash -c 'source .env && forge script Deploy --rpc-url $GNOSIS_RPC --private-key $GNOSIS_PK --broadcast --verify --chain gnosis -vvvvv'",
     "deploy:optimism": "bash -c 'source .env && forge script Deploy --rpc-url $OPTIMISM_RPC --private-key $OPTIMISM_PK --broadcast --verify --chain optimism -vvvvv'",
     "deploy:sepolia": "bash -c 'source .env && forge script Deploy --rpc-url $SEPOLIA_RPC --private-key $SEPOLIA_PK --broadcast --verify --chain sepolia -vvvvv'",

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -63,8 +63,9 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     epochMemberDeposits;
 
   /// @notice Tracks the number of small withdrawals performed in a Safety Net from a member during one epoch
-  mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => uint256 smallWithdrawsCount)))
-    public smallWithdrawsCount;
+  mapping(
+    uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => uint256 smallWithdrawsCount))
+  ) public smallWithdrawsCount;
 
   /// @notice Thrown if a transfer fails
   error TransferFailed();
@@ -445,12 +446,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
       emit FundsWithdrawn(_id, _member, _withdrawAmount);
     } else {
       Request memory _request = Request({
-        owner: _member,
-        safetyNetId: _id,
-        timestamp: block.timestamp,
-        yesVotes: 0,
-        noVotes: 0,
-        amount: _withdrawAmount
+        owner: _member, safetyNetId: _id, timestamp: block.timestamp, yesVotes: 0, noVotes: 0, amount: _withdrawAmount
       });
       uint256 _idRequest = _createRequest(_request);
       emit WithdrawalPending(_idRequest, _member, _withdrawAmount);

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -230,6 +230,13 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     // Can only auto-execute if contest window has passed and request was not contested
     if (!_isContestable(_idRequest) && !isContested[_idRequest]) {
+      if (memberWithdrawableBalance[_request.safetyNetId][_request.owner] < _request.amount) {
+        revert NotWithdrawable();
+      }
+
+      memberWithdrawableBalance[_request.safetyNetId][_request.owner] -= _request.amount;
+      safetyNetBalance[_request.safetyNetId] -= _request.amount;
+
       isExecuted[_idRequest] = true;
       emit WithdrawalAutoExecuted(_idRequest, _request.owner, _request.amount);
       if (!IERC20(_safetyNet.token).transfer(_request.owner, _request.amount)) revert TransferFailed();
@@ -256,6 +263,13 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     if (_request.yesVotes > _safetyNet.members.length * _safetyNet.consensusThreshold / 100) {
       // Consensus reached - execute withdrawal immediately
+      if (memberWithdrawableBalance[_request.safetyNetId][_request.owner] < _request.amount) {
+        revert NotWithdrawable();
+      }
+
+      memberWithdrawableBalance[_request.safetyNetId][_request.owner] -= _request.amount;
+      safetyNetBalance[_request.safetyNetId] -= _request.amount;
+
       isExecuted[_requestId] = true;
       emit WithdrawalApproved(_requestId, _request.owner, _request.amount);
       if (!IERC20(_safetyNet.token).transfer(_request.owner, _request.amount)) revert TransferFailed();

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -75,6 +75,15 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     _;
   }
 
+  /// @dev Ensures member has enough withdrawable balance and deducts it from both member and SafetyNet
+  function _deduct(uint256 _safetyNetId, address _member, uint256 _amount) private {
+    if (memberWithdrawableBalance[_safetyNetId][_member] < _amount) {
+      revert NotWithdrawable();
+    }
+    memberWithdrawableBalance[_safetyNetId][_member] -= _amount;
+    safetyNetBalance[_safetyNetId] -= _amount;
+  }
+
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
     _disableInitializers();
@@ -230,15 +239,11 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     // Can only auto-execute if contest window has passed and request was not contested
     if (!_isContestable(_idRequest) && !isContested[_idRequest]) {
-      if (memberWithdrawableBalance[_request.safetyNetId][_request.owner] < _request.amount) {
-        revert NotWithdrawable();
-      }
-
-      memberWithdrawableBalance[_request.safetyNetId][_request.owner] -= _request.amount;
-      safetyNetBalance[_request.safetyNetId] -= _request.amount;
+      _deduct(_request.safetyNetId, _request.owner, _request.amount);
 
       isExecuted[_idRequest] = true;
       emit WithdrawalAutoExecuted(_idRequest, _request.owner, _request.amount);
+
       if (!IERC20(_safetyNet.token).transfer(_request.owner, _request.amount)) revert TransferFailed();
     }
   }
@@ -263,12 +268,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     if (_request.yesVotes > _safetyNet.members.length * _safetyNet.consensusThreshold / 100) {
       // Consensus reached - execute withdrawal immediately
-      if (memberWithdrawableBalance[_request.safetyNetId][_request.owner] < _request.amount) {
-        revert NotWithdrawable();
-      }
-
-      memberWithdrawableBalance[_request.safetyNetId][_request.owner] -= _request.amount;
-      safetyNetBalance[_request.safetyNetId] -= _request.amount;
+      _deduct(_request.safetyNetId, _request.owner, _request.amount);
 
       isExecuted[_requestId] = true;
       emit WithdrawalApproved(_requestId, _request.owner, _request.amount);

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -197,7 +197,12 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /// @inheritdoc ISafetyNet
-  function createRequest(Request memory _request) external override onlyMemberOf(_request.safetyNetId) returns (uint256) {
+  function createRequest(Request memory _request)
+    external
+    override
+    onlyMemberOf(_request.safetyNetId)
+    returns (uint256)
+  {
     if (_request.owner != msg.sender) revert InvalidOwner();
     if (safetyNets[_request.safetyNetId].owner == address(0)) revert NotCommissioned();
     if (_request.amount == 0) revert InvalidRequest();
@@ -481,7 +486,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     return _safetyNet.owner == address(0);
   }
 
-  /// @dev Deducts `_amount` from a member’s withdrawable balance and the Safety Net’s total balance. 
+  /// @dev Deducts `_amount` from a member’s withdrawable balance and the Safety Net’s total balance.
   ///      Reverts with `NotWithdrawable` if balance is insufficient.
   function _deduct(uint256 _safetyNetId, address _member, uint256 _amount) private {
     if (memberWithdrawableBalance[_safetyNetId][_member] < _amount) {

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -75,15 +75,6 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     _;
   }
 
-  /// @dev Ensures member has enough withdrawable balance and deducts it from both member and SafetyNet
-  function _deduct(uint256 _safetyNetId, address _member, uint256 _amount) private {
-    if (memberWithdrawableBalance[_safetyNetId][_member] < _amount) {
-      revert NotWithdrawable();
-    }
-    memberWithdrawableBalance[_safetyNetId][_member] -= _amount;
-    safetyNetBalance[_safetyNetId] -= _amount;
-  }
-
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
     _disableInitializers();
@@ -488,5 +479,15 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @dev Return if a specified Safety Net is decommissioned by checking if an owner is set
   function _isDecommissioned(SafetyNet memory _safetyNet) internal pure returns (bool) {
     return _safetyNet.owner == address(0);
+  }
+
+  /// @dev Deducts `_amount` from a member’s withdrawable balance and the Safety Net’s total balance. 
+  ///      Reverts with `NotWithdrawable` if balance is insufficient.
+  function _deduct(uint256 _safetyNetId, address _member, uint256 _amount) private {
+    if (memberWithdrawableBalance[_safetyNetId][_member] < _amount) {
+      revert NotWithdrawable();
+    }
+    memberWithdrawableBalance[_safetyNetId][_member] -= _amount;
+    safetyNetBalance[_safetyNetId] -= _amount;
   }
 }

--- a/src/interfaces/ISafetyNet.sol
+++ b/src/interfaces/ISafetyNet.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.28;
 /// @author @exo404
 /// @author @valeriooconte
 /// @author @RonTuretzky
- interface ISafetyNet {
+interface ISafetyNet {
   /*///////////////////////////////////////////////////////////////
                             STRUCTS
   //////////////////////////////////////////////////////////////*/

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-
-
 // ───────────────────────────── Imports ─────────────────────────────
-import {Test} from "forge-std/Test.sol";
-import {SafetyNet} from "src/contracts/SafetyNet.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/proxy/transparent/ProxyAdmin.sol";
-import {MockERC20} from "test/mocks/MockERC20.sol";
+
+import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {Test} from 'forge-std/Test.sol';
+import {SafetyNet} from 'src/contracts/SafetyNet.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+
+import {MockERC20} from 'test/mocks/MockERC20.sol';
 
 /// @notice Shared base for all fuzz suites: deploys proxy + token, provides defaults & helpers.
 abstract contract SafetyNetFuzzBase is Test {
@@ -60,23 +60,23 @@ abstract contract SafetyNetFuzzBase is Test {
     defaultMembers = _threeMembers();
 
     // token
-    token = new MockERC20("Mock", "MOCK");
-    vm.label(address(token), "MockERC20");
+    token = new MockERC20('Mock', 'MOCK');
+    vm.label(address(token), 'MockERC20');
 
     // implementation + proxy admin
     implementation = new SafetyNet();
-    vm.label(address(implementation), "SafetyNet_Impl");
+    vm.label(address(implementation), 'SafetyNet_Impl');
     proxyAdmin = new ProxyAdmin(owner_);
-    vm.label(address(proxyAdmin), "ProxyAdmin");
+    vm.label(address(proxyAdmin), 'ProxyAdmin');
 
     // proxy (initialize owner)
     bytes memory initData = abi.encodeWithSelector(SafetyNet.initialize.selector, owner_);
     proxy = new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
-    vm.label(address(proxy), "SafetyNet_Proxy");
+    vm.label(address(proxy), 'SafetyNet_Proxy');
 
     // use proxy via impl ABI
     safetyNet = SafetyNet(address(proxy));
-    vm.label(address(safetyNet), "SafetyNet");
+    vm.label(address(safetyNet), 'SafetyNet');
 
     // allow token
     safetyNet.setTokenAllowed(address(token), true);
@@ -103,10 +103,10 @@ abstract contract SafetyNetFuzzBase is Test {
     safeCfg = cfg;
 
     // labels (nice for traces)
-    vm.label(owner_, "Owner");
-    vm.label(member1, "Member1");
-    vm.label(member2, "Member2");
-    vm.label(member3, "Member3");
+    vm.label(owner_, 'Owner');
+    vm.label(member1, 'Member1');
+    vm.label(member2, 'Member2');
+    vm.label(member3, 'Member3');
   }
 
   // ───────────── Helpers (reused across suites) ─────────────
@@ -114,14 +114,16 @@ abstract contract SafetyNetFuzzBase is Test {
   /// @dev Returns the canonical three default members.
   function _threeMembers() internal view returns (address[] memory m) {
     m = new address[](3);
-    m[0] = member1; m[1] = member2; m[2] = member3;
+    m[0] = member1;
+    m[1] = member2;
+    m[2] = member3;
   }
 
   /// @dev Deterministically generates `n` pseudo-members for fuzzing.
   function _makeMembers(uint256 n) internal pure returns (address[] memory m) {
     m = new address[](n);
     for (uint256 i = 0; i < n; i++) {
-      m[i] = address(uint160(uint256(keccak256(abi.encodePacked(i, "SAFETYNET_MEMBER")))));
+      m[i] = address(uint160(uint256(keccak256(abi.encodePacked(i, 'SAFETYNET_MEMBER')))));
     }
   }
 
@@ -148,22 +150,21 @@ abstract contract SafetyNetFuzzBase is Test {
    * Useful for tests that need independent economics (e.g., ratio experiments).
    */
   function _deployIsolatedFund() internal returns (SafetyNet localFund, MockERC20 localToken) {
-    localToken = new MockERC20("TestToken", "TST");
-    vm.label(address(localToken), "Local_TestToken");
+    localToken = new MockERC20('TestToken', 'TST');
+    vm.label(address(localToken), 'Local_TestToken');
 
     SafetyNet impl = new SafetyNet();
-    vm.label(address(impl), "Local_SafetyNet_Impl");
+    vm.label(address(impl), 'Local_SafetyNet_Impl');
     bytes memory init = abi.encodeWithSelector(SafetyNet.initialize.selector, address(this));
 
     address proxyAdminAddr = address(0xA11C3);
-    vm.label(proxyAdminAddr, "Local_ProxyAdmin");
+    vm.label(proxyAdminAddr, 'Local_ProxyAdmin');
 
-    TransparentUpgradeableProxy localProxy =
-      new TransparentUpgradeableProxy(address(impl), proxyAdminAddr, init);
-    vm.label(address(localProxy), "Local_SafetyNet_Proxy");
+    TransparentUpgradeableProxy localProxy = new TransparentUpgradeableProxy(address(impl), proxyAdminAddr, init);
+    vm.label(address(localProxy), 'Local_SafetyNet_Proxy');
 
     localFund = SafetyNet(address(localProxy));
-    vm.label(address(localFund), "Local_SafetyNet");
+    vm.label(address(localFund), 'Local_SafetyNet');
     localFund.setTokenAllowed(address(localToken), true);
   }
 
@@ -180,14 +181,9 @@ abstract contract SafetyNetFuzzBase is Test {
     return arr[seed % arr.length];
   }
 
-
-
-
   /// @dev Helper to ensure the per-epoch small-withdraw counter never exceeds the limit.
-  function _assertSmallCounterBound(
-    uint256 _id, uint256 epochIdx, address who, uint256 limit
-  ) internal view {
+  function _assertSmallCounterBound(uint256 _id, uint256 epochIdx, address who, uint256 limit) internal view {
     uint256 cnt = safetyNet.smallWithdrawsCount(_id, epochIdx, who);
-    assertLe(cnt, limit, "small-withdraw counter bounded by limit");
+    assertLe(cnt, limit, 'small-withdraw counter bounded by limit');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-
-import {SafetyNetFuzzBase} from "./SafetyNetFuzzBase.t.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
-import {MockERC20} from "test/mocks/MockERC20.sol";
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
 
 contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
   function testFuzz_LotsOfSafetyNetCreations(uint8 nRaw, uint8 consensusBase) public {
@@ -22,11 +21,11 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
       cfg.members = _threeMembers();
 
       uint256 id = safetyNet.create(cfg);
-      assertEq(id, success, "id matches successes so far");
+      assertEq(id, success, 'id matches successes so far');
       success++;
     }
 
-    assertEq(safetyNet.nextId(), success, "nextId equals the number of successful creations");
+    assertEq(safetyNet.nextId(), success, 'nextId equals the number of successful creations');
   }
 
   function test_Create_RevertsOnZeroAddressMember() public {
@@ -43,7 +42,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
     ISafetyNet.SafetyNet memory cfg = safeCfg;
     cfg.safetyNetStart = block.timestamp + 1;
 
-    MockERC20 tmp = new MockERC20("Tmp", "TMP");
+    MockERC20 tmp = new MockERC20('Tmp', 'TMP');
     cfg.token = address(tmp);
 
     vm.expectRevert(ISafetyNet.TokenNotAllowed.selector);
@@ -51,6 +50,6 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
 
     safetyNet.setTokenAllowed(address(tmp), true);
     uint256 idAllowed = safetyNet.create(cfg);
-    assertEq(idAllowed, 0, "first successful creation gets id 0");
+    assertEq(idAllowed, 0, 'first successful creation gets id 0');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-
-import {SafetyNetFuzzBase} from "./SafetyNetFuzzBase.t.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 
 contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
@@ -19,7 +18,10 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
   ///  - Dust remainder stays inside the contract.
   /// -------------------------------------------------------------------------
   function testFuzz_CrazyDecommissions_DistributeOnMissedPayments(
-    uint256 dep1Raw, uint256 dep2Raw, uint256 dep3Raw, uint8 skipEpochsRaw
+    uint256 dep1Raw,
+    uint256 dep2Raw,
+    uint256 dep3Raw,
+    uint8 skipEpochsRaw
   ) public {
     uint256 dep1 = bound(dep1Raw, 1e17, 5e19);
     uint256 dep2 = bound(dep2Raw, 1e17, 5e19);
@@ -50,7 +52,7 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
 
     // Advance further epochs → fund should now be decommissionable
     vm.warp(block.timestamp + cfg.epochDuration * skipEpochs + 1);
-    assertTrue(safetyNet.isDecommissionable(id), "decommissionable after a missed epoch");
+    assertTrue(safetyNet.isDecommissionable(id), 'decommissionable after a missed epoch');
 
     // Snapshot before decommission
     uint256 cBalBefore = token.balanceOf(address(safetyNet));
@@ -59,7 +61,7 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
     uint256 w3 = safetyNet.memberWithdrawableBalance(id, member3);
     uint256 sumW = w1 + w2 + w3;
 
-    assertGe(cBalBefore, sumW, "contract covers withdrawables here");
+    assertGe(cBalBefore, sumW, 'contract covers withdrawables here');
 
     // Split of remainder among 3 members (equal share)
     uint256 remaining = cBalBefore - sumW;
@@ -93,6 +95,6 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
 
     // Dust remainder (if any) stays in the contract
     uint256 cBalAfter = token.balanceOf(address(safetyNet));
-    assertEq(cBalAfter, remainder, "dust remainder retained");
+    assertEq(cBalAfter, remainder, 'dust remainder retained');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {SafetyNetFuzzBase} from "./SafetyNetFuzzBase.t.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 
 contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
-  function testFuzz_Soak_ManyDepositsAndWithdrawals(
-    uint8 epochsRaw, uint8 opsRaw, uint256 extraSeed
-  ) public {
+  function testFuzz_Soak_ManyDepositsAndWithdrawals(uint8 epochsRaw, uint8 opsRaw, uint256 extraSeed) public {
     uint256 epochs = bound(uint256(epochsRaw), 2, 12);
-    uint256 ops    = bound(uint256(opsRaw),    5, 40);
+    uint256 ops = bound(uint256(opsRaw), 5, 40);
 
     ISafetyNet.SafetyNet memory cfg = safeCfg;
     cfg.safetyNetStart = block.timestamp;
-    cfg.members        = defaultMembers;
-    cfg.ratio          = 1;
+    cfg.members = defaultMembers;
+    cfg.ratio = 1;
     uint256 id = safetyNet.create(cfg);
 
     _mintApprove(member1, 1e24, address(safetyNet));
@@ -40,47 +38,47 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
   // ── Case 1: Deposits — 1 per member per epoch; flag set; balance increases
   function _caseDeposit(uint256 id, address actor, uint256 seed) external {
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
-    uint256 beforeW  = safetyNet.memberWithdrawableBalance(id, actor);
-    uint256 v        = 1e18 + (seed % 1e18);
-    bool already     = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
+    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
+    uint256 v = 1e18 + (seed % 1e18);
+    bool already = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
 
     vm.prank(actor);
     if (already) {
       vm.expectRevert(ISafetyNet.AlreadyDeposited.selector);
-      try safetyNet.deposit(id, v) { } catch {}
+      try safetyNet.deposit(id, v) {} catch {}
       return;
     }
 
     safetyNet.deposit(id, v);
-    assertTrue(safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx), "epoch flag set");
+    assertTrue(safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx), 'epoch flag set');
     uint256 afterW = safetyNet.memberWithdrawableBalance(id, actor);
-    assertEq(afterW, beforeW + v, "withdrawable += v");
+    assertEq(afterW, beforeW + v, 'withdrawable += v');
   }
 
   // ── Case 2: Small withdrawals — within limit, ≤ autoThreshold, and ≤ balance
   function _caseSmallWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
-    uint256 contrib  = safetyNet.safetyNetMemberContribute(id, actor);
-    uint256 beforeW  = safetyNet.memberWithdrawableBalance(id, actor);
+    uint256 contrib = safetyNet.safetyNetMemberContribute(id, actor);
+    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
 
     uint256 daysReq = 1 + (seed % 3);
-    uint256 want    = (contrib / 30) * daysReq;
+    uint256 want = (contrib / 30) * daysReq;
 
-    uint256 cntBefore  = safetyNet.smallWithdrawsCount(id, epochIdx, actor);
-    uint256 balBefore  = token.balanceOf(actor);
-    bool withinLimit   = cntBefore < cfg.smallWithdrawsLimit;
-    bool smallByAmt    = (want <= cfg.autoThreshold);
+    uint256 cntBefore = safetyNet.smallWithdrawsCount(id, epochIdx, actor);
+    uint256 balBefore = token.balanceOf(actor);
+    bool withinLimit = cntBefore < cfg.smallWithdrawsLimit;
+    bool smallByAmt = (want <= cfg.autoThreshold);
     bool enoughBalance = (want <= beforeW);
 
     vm.prank(actor);
     try safetyNet.withdraw(id, daysReq) {
-      uint256 nowW  = safetyNet.memberWithdrawableBalance(id, actor);
+      uint256 nowW = safetyNet.memberWithdrawableBalance(id, actor);
       uint256 balNow = token.balanceOf(actor);
       uint256 cntNow = safetyNet.smallWithdrawsCount(id, epochIdx, actor);
 
       if (want == 0) {
         // Intentional: zero-amount small withdraw still increments counter (balance unchanged)
-        assertEq(nowW,  beforeW);
+        assertEq(nowW, beforeW);
         assertEq(balNow, balBefore);
         assertEq(cntNow, cntBefore + 1);
         _assertSmallCounterBound(id, epochIdx, actor, cfg.smallWithdrawsLimit);
@@ -90,17 +88,17 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
         assertEq(cntNow, cntBefore + 1);
         _assertSmallCounterBound(id, epochIdx, actor, cfg.smallWithdrawsLimit);
       } else {
-        assertTrue(false, "withdraw succeeded though conditions not met");
+        assertTrue(false, 'withdraw succeeded though conditions not met');
       }
     } catch { /* many branches legitimately revert */ }
   }
 
   // ── Case 3: Large withdrawals — create a request; execution after contest window
   function _caseLargeWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
-    uint256 contrib  = safetyNet.safetyNetMemberContribute(id, actor);
-    uint256 beforeW  = safetyNet.memberWithdrawableBalance(id, actor);
-    uint256 daysReq  = 40 + (seed % 40);
-    uint256 want     = (contrib / 30) * daysReq;
+    uint256 contrib = safetyNet.safetyNetMemberContribute(id, actor);
+    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
+    uint256 daysReq = 40 + (seed % 40);
+    uint256 want = (contrib / 30) * daysReq;
 
     uint256 reqsBefore = safetyNet.nextIdRequest();
 
@@ -109,10 +107,9 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
       uint256 reqsAfter = safetyNet.nextIdRequest();
       if (want > cfg.autoThreshold) {
         if (want <= beforeW && want > 0) {
-          assertEq(reqsAfter, reqsBefore + 1, "large creates request");
+          assertEq(reqsAfter, reqsBefore + 1, 'large creates request');
           uint256 reqId = reqsAfter - 1;
-          (address owner,, uint256 ts, uint256 yesVotes, uint256 noVotes, uint256 amount) =
-            safetyNet.requests(reqId);
+          (address owner,, uint256 ts, uint256 yesVotes, uint256 noVotes, uint256 amount) = safetyNet.requests(reqId);
           assertEq(owner, actor);
           assertEq(amount, want);
           assertEq(yesVotes, 0);
@@ -125,13 +122,13 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
             vm.prank(actor);
             try safetyNet.executeContestedWithdrawal(reqId) {
               assertTrue(safetyNet.isExecuted(reqId));
-            } catch { }
+            } catch {}
           }
         } else {
-          assertEq(safetyNet.nextIdRequest(), reqsBefore, "no request if insufficient");
+          assertEq(safetyNet.nextIdRequest(), reqsBefore, 'no request if insufficient');
         }
       }
-    } catch { }
+    } catch {}
   }
 
   // ── Case 4: Request execution attempt — only possible after contest window
@@ -142,7 +139,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 reqId = nReq - 1;
     vm.warp(block.timestamp + cfg.contestWindow + 1);
     vm.prank(actor);
-    try safetyNet.executeContestedWithdrawal(reqId) { } catch {}
+    try safetyNet.executeContestedWithdrawal(reqId) {} catch {}
   }
 
   /// Small-withdraw limit fuzzing
@@ -153,7 +150,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     cfg.safetyNetStart = block.timestamp;
     uint256 id = safetyNet.create(cfg);
 
-    uint256 daysRequested  = bound(uint256(daysReqRaw), 1, 3);
+    uint256 daysRequested = bound(uint256(daysReqRaw), 1, 3);
     uint256 extraWithdraws = bound(uint256(extraWithdrawsRaw), 0, 2);
 
     // craft deposit size so each withdraw is under autoThreshold

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -60,7 +60,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
   // ── Case 2: Small withdrawals — within limit, ≤ autoThreshold, and ≤ balance
   function _caseSmallWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
-    uint256 contrib  = safetyNet.memberContribute(id, actor);
+    uint256 contrib  = safetyNet.safetyNetMemberContribute(id, actor);
     uint256 beforeW  = safetyNet.memberWithdrawableBalance(id, actor);
 
     uint256 daysReq = 1 + (seed % 3);
@@ -97,7 +97,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
 
   // ── Case 3: Large withdrawals — create a request; execution after contest window
   function _caseLargeWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
-    uint256 contrib  = safetyNet.memberContribute(id, actor);
+    uint256 contrib  = safetyNet.safetyNetMemberContribute(id, actor);
     uint256 beforeW  = safetyNet.memberWithdrawableBalance(id, actor);
     uint256 daysReq  = 40 + (seed % 40);
     uint256 want     = (contrib / 30) * daysReq;

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-
-
-import {SafetyNetFuzzBase} from "./SafetyNetFuzzBase.t.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 
 contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
@@ -14,20 +12,18 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   ///  - After contest window elapses, an execution call succeeds.
   ///  - Beneficiary's balance increases; request marked executed.
   /// -------------------------------------------------------------------------
-  function testFuzz_LargeWithdrawal_RequestAndAutoExecute(
-    uint256 depositValueRaw, uint8 extraDaysRaw
-  ) public {
+  function testFuzz_LargeWithdrawal_RequestAndAutoExecute(uint256 depositValueRaw, uint8 extraDaysRaw) public {
     uint256 depositValue = bound(depositValueRaw, 5e18, 1e22);
 
     ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = defaultMembers; 
-    cfg.ratio = 1; 
+    cfg.members = defaultMembers;
+    cfg.ratio = 1;
     cfg.safetyNetStart = block.timestamp;
     uint256 id = safetyNet.create(cfg);
 
     uint256 totalNeeded = depositValue + cfg.initialDeposit + cfg.fixedDeposit;
     _mintApprove(member1, totalNeeded, address(safetyNet));
-    vm.prank(member1); 
+    vm.prank(member1);
     safetyNet.deposit(id, depositValue);
 
     // Choose a daysRequested that ensures "large" classification.
@@ -36,14 +32,14 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     if (daysRequested > 30) daysRequested = 30;
     if (minDaysToBeLarge > 30) daysRequested = 30;
 
-    vm.prank(member1); 
+    vm.prank(member1);
     safetyNet.withdraw(id, daysRequested);
     uint256 reqId = safetyNet.nextIdRequest() - 1;
 
     vm.warp(block.timestamp + cfg.contestWindow + 1);
 
     uint256 balBefore = token.balanceOf(member1);
-    vm.prank(member2); 
+    vm.prank(member2);
     safetyNet.executeContestedWithdrawal(reqId);
     uint256 balAfter = token.balanceOf(member1);
 
@@ -56,10 +52,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   /// For m members and threshold T%, exactly floor(m*T/100) YES must NOT execute;
   /// strictly more than that must execute.
   /// -------------------------------------------------------------------------
-  function testFuzz_Voting_ThresholdBoundary(
-    uint8 membersRaw,
-    uint8 consensusPctRaw
-  ) public {
+  function testFuzz_Voting_ThresholdBoundary(uint8 membersRaw, uint8 consensusPctRaw) public {
     uint256 m = bound(uint256(membersRaw), 3, 20);
     uint256 consensus = bound(uint256(consensusPctRaw), 1, 99);
 
@@ -105,14 +98,14 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       vm.prank(members[i]);
       safetyNet.vote(reqId, true);
     }
-    assertFalse(safetyNet.isExecuted(reqId), "== threshold must not execute");
+    assertFalse(safetyNet.isExecuted(reqId), '== threshold must not execute');
 
     // One more YES crosses the threshold.
     if (needed + 1 < m) {
       uint256 balBefore = token.balanceOf(members[0]);
       vm.prank(members[needed + 1]);
       safetyNet.vote(reqId, true);
-      assertTrue(safetyNet.isExecuted(reqId), "> threshold executes");
+      assertTrue(safetyNet.isExecuted(reqId), '> threshold executes');
       uint256 balAfter = token.balanceOf(members[0]);
       assertGt(balAfter, balBefore);
     }
@@ -125,10 +118,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   ///  - Contested requests must NOT auto-execute on timeout,
   ///    and executeContestedWithdrawal should not succeed.
   /// -------------------------------------------------------------------------
-  function testFuzz_Voting_Windows_And_Contest_BlockAutoExec(
-    uint32 votingSecsRaw,
-    uint32 contestSecsRaw
-  ) public {
+  function testFuzz_Voting_Windows_And_Contest_BlockAutoExec(uint32 votingSecsRaw, uint32 contestSecsRaw) public {
     uint256 votingWin = bound(uint256(votingSecsRaw), 1 hours, 3 days);
     uint256 contestWin = bound(uint256(contestSecsRaw), 1 hours, 3 days);
 
@@ -191,10 +181,9 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     // Attempt execution; it should not mark executed for contested request.
     vm.prank(member3);
-    try safetyNet.executeContestedWithdrawal(req2) { } catch { }
-    assertFalse(safetyNet.isExecuted(req2), "contested request must not auto-execute");
+    try safetyNet.executeContestedWithdrawal(req2) {} catch {}
+    assertFalse(safetyNet.isExecuted(req2), 'contested request must not auto-execute');
   }
-
 
   /// -------------------------------------------------------------------------
   /// Scenario: Vote-heavy fuzz — random voting with bias until consensus or timeout.
@@ -204,7 +193,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   ///  - If consensus not reached by votes, allow post-window execution attempt.
   /// -------------------------------------------------------------------------
   function testFuzz_Voting_ConsensusOrTimeout(
-    uint8 memberCountRaw, uint8 consensusPctRaw, uint8 yesBiasRaw, uint256 randSeed
+    uint8 memberCountRaw,
+    uint8 consensusPctRaw,
+    uint8 yesBiasRaw,
+    uint256 randSeed
   ) public {
     uint256 m = bound(uint256(memberCountRaw), 3, 20);
     uint256 consensus = bound(uint256(consensusPctRaw), 1, 99);
@@ -212,29 +204,32 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     address[] memory members = _makeMembers(m);
     ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members; 
-    cfg.minimumMembers = 2; 
+    cfg.members = members;
+    cfg.minimumMembers = 2;
     cfg.maximumMembers = m;
-    cfg.consensusThreshold = consensus; 
+    cfg.consensusThreshold = consensus;
     cfg.safetyNetStart = block.timestamp;
-    cfg.votingWindow = 1 days; 
+    cfg.votingWindow = 1 days;
     cfg.contestWindow = 1 days;
     uint256 id = safetyNet.create(cfg);
 
     // Seed balances; ignore per-member deposit failure to keep exploring.
     for (uint256 i = 0; i < m; i++) {
       _mintApprove(members[i], 5e21, address(safetyNet));
-      vm.prank(members[i]); try safetyNet.deposit(id, 5e18) { } catch { }
+      vm.prank(members[i]);
+      try safetyNet.deposit(id, 5e18) {} catch {}
     }
 
     uint256 depositValue = 5e18;
     uint256 totalNeeded = depositValue + cfg.initialDeposit + cfg.fixedDeposit;
     _mintApprove(members[0], totalNeeded, address(safetyNet));
-    vm.prank(members[0]); try safetyNet.deposit(id, depositValue) { } catch { }
+    vm.prank(members[0]);
+    try safetyNet.deposit(id, depositValue) {} catch {}
     uint256 minDaysToBeLarge = (cfg.autoThreshold * 30) / depositValue + 1;
     uint256 daysRequested = minDaysToBeLarge + 3;
 
-    vm.prank(members[0]); safetyNet.withdraw(id, daysRequested);
+    vm.prank(members[0]);
+    safetyNet.withdraw(id, daysRequested);
     uint256 reqId = safetyNet.nextIdRequest() - 1;
 
     // Randomized voting pass
@@ -242,13 +237,15 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       address voter = members[i];
       randSeed = uint256(keccak256(abi.encodePacked(randSeed, i)));
       bool voteYes = (randSeed % 100) < yesBias;
-      vm.prank(voter); try safetyNet.vote(reqId, voteYes) { } catch { }
+      vm.prank(voter);
+      try safetyNet.vote(reqId, voteYes) {} catch {}
     }
 
     // If not executed by consensus, try after contest window.
     if (!safetyNet.isExecuted(reqId)) {
       vm.warp(block.timestamp + cfg.contestWindow + 1);
-      vm.prank(members[m-1]); try safetyNet.executeContestedWithdrawal(reqId) { } catch { }
+      vm.prank(members[m - 1]);
+      try safetyNet.executeContestedWithdrawal(reqId) {} catch {}
     }
 
     assertTrue(true); // sanity: no catastrophic revert

--- a/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
@@ -1,21 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-
-
-import {SafetyNetFuzzBase} from "./SafetyNetFuzzBase.t.sol";
-import {ISafetyNet} from "src/interfaces/ISafetyNet.sol";
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 
 contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
   /// Fuzz: deposits across epochs for variable members.
   /// -------------------------------------------------------------------------
-  function testFuzz_Deposits_AcrossEpochs(
-    uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed
-  ) public {
-    uint256 m      = bound(uint256(membersRaw), 3, 25);
-    uint256 epochs = bound(uint256(epochsRaw),  2, 8);
-    uint256 ops    = bound(uint256(opsRaw),     5, 30);
+  function testFuzz_Deposits_AcrossEpochs(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
+    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 epochs = bound(uint256(epochsRaw), 2, 8);
+    uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(m);
     ISafetyNet.SafetyNet memory cfg = safeCfg;
@@ -45,12 +41,10 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
   /// Fuzz: small withdrawals (1–3 days) across epochs.
   /// -------------------------------------------------------------------------
-  function testFuzz_SmallWithdraws_AcrossEpochs(
-    uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed
-  ) public {
-    uint256 m      = bound(uint256(membersRaw), 3, 25);
-    uint256 epochs = bound(uint256(epochsRaw),  2, 8);
-    uint256 ops    = bound(uint256(opsRaw),     5, 30);
+  function testFuzz_SmallWithdraws_AcrossEpochs(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
+    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 epochs = bound(uint256(epochsRaw), 2, 8);
+    uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(m);
     ISafetyNet.SafetyNet memory cfg = safeCfg;
@@ -82,12 +76,10 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
   /// Fuzz: large withdrawals (40–79 days) that may create requests.
   /// -------------------------------------------------------------------------
-  function testFuzz_LargeWithdraws_CreateRequests(
-    uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed
-  ) public {
-    uint256 m      = bound(uint256(membersRaw), 3, 25);
-    uint256 epochs = bound(uint256(epochsRaw),  2, 8);
-    uint256 ops    = bound(uint256(opsRaw),     5, 30);
+  function testFuzz_LargeWithdraws_CreateRequests(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
+    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 epochs = bound(uint256(epochsRaw), 2, 8);
+    uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(m);
     ISafetyNet.SafetyNet memory cfg = safeCfg;
@@ -120,11 +112,14 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// Fuzz: execute the latest request after contest window.
   /// -------------------------------------------------------------------------
   function testFuzz_ExecuteLatestRequest_WhenWindowElapsed(
-    uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed
+    uint8 membersRaw,
+    uint8 epochsRaw,
+    uint8 opsRaw,
+    uint256 seed
   ) public {
-    uint256 m      = bound(uint256(membersRaw), 3, 25);
-    uint256 epochs = bound(uint256(epochsRaw),  2, 8);
-    uint256 ops    = bound(uint256(opsRaw),     5, 30);
+    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 epochs = bound(uint256(epochsRaw), 2, 8);
+    uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(m);
     ISafetyNet.SafetyNet memory cfg = safeCfg;

--- a/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
@@ -76,7 +76,12 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// -------------------------------------------------------------------------
   /// Fuzz: large withdrawals (40–79 days) that may create requests.
   /// -------------------------------------------------------------------------
-  function testFuzz_LargeWithdraws_CreateRequests(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
+  function testFuzz_LargeWithdraws_CreateRequests(
+    uint8 membersRaw,
+    uint8 epochsRaw,
+    uint8 opsRaw,
+    uint256 seed
+  ) public {
     uint256 m = bound(uint256(membersRaw), 3, 25);
     uint256 epochs = bound(uint256(epochsRaw), 2, 8);
     uint256 ops = bound(uint256(opsRaw), 5, 30);

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -267,7 +267,7 @@ contract SafetyNetUnit is Test {
     _sn.create(sn);
   }
 
-  function test_CreateWhenMembersArrayContainsDuplicates_reverts() external {
+  function test_CreateWhenMembersArrayContainsDuplicates() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {Test} from 'forge-std/Test.sol';
+import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {stdError} from 'forge-std/StdError.sol';
+import {Test} from 'forge-std/Test.sol';
 import {SafetyNet} from 'src/contracts/SafetyNet.sol';
 import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 import {MockERC20} from 'test/mocks/MockERC20.sol';
-import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
-import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
 
 contract FailERC20 {
   string public name = 'FailERC20';
@@ -38,11 +38,7 @@ contract SafetyNetUnit is Test {
     address impl = address(new SafetyNet());
     address admin = address(new ProxyAdmin(_owner));
     address proxy = address(
-      new TransparentUpgradeableProxy(
-        impl,
-        admin,
-        abi.encodeWithSelector(SafetyNet.initialize.selector, _owner)
-      )
+      new TransparentUpgradeableProxy(impl, admin, abi.encodeWithSelector(SafetyNet.initialize.selector, _owner))
     );
     _sn = SafetyNet(proxy);
     _token = new MockERC20('Mock', 'MOCK');
@@ -255,7 +251,7 @@ contract SafetyNetUnit is Test {
     sn.members = new address[](0);
     uint256 id = _sn.create(sn);
     assertEq(id, 0);
-    (address[] memory members, ) = _sn.getMemberBalances(id);
+    (address[] memory members,) = _sn.getMemberBalances(id);
     assertEq(members.length, 0);
   }
 
@@ -270,9 +266,9 @@ contract SafetyNetUnit is Test {
   function test_CreateWhenMembersArrayContainsDuplicates() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    
+
     // Duplicate
-    sn.members[1] = _alice; 
+    sn.members[1] = _alice;
 
     vm.expectRevert(ISafetyNet.DuplicateMember.selector);
     _sn.create(sn);
@@ -620,9 +616,9 @@ contract SafetyNetUnit is Test {
   function test_WithdrawWhenWithdrawalAmountIsBelowThreshold() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    
+
     // Small path
-    sn.autoThreshold = 100 ether; 
+    sn.autoThreshold = 100 ether;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
     _sn.deposit(id, 30 ether);
@@ -637,18 +633,18 @@ contract SafetyNetUnit is Test {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     // Any withdraw > 1 wei goes to request path
-    sn.autoThreshold = 1; 
+    sn.autoThreshold = 1;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
     _sn.deposit(id, 30 ether);
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertEq(_sn.nextIdRequest(), 1);
-    (address reqOwner, uint256 reqSafetyNetId, , , , ) = _sn.requests(0);
+    (address reqOwner, uint256 reqSafetyNetId,,,,) = _sn.requests(0);
     assertEq(reqOwner, _alice);
     assertEq(reqSafetyNetId, id);
   }
-  
+
   // ---------- createRequest / contest / execute / vote (happy paths) ----------
   function _createFundAndRequest() internal returns (uint256 id, uint256 reqId) {
     _allowToken(address(_token));
@@ -664,7 +660,7 @@ contract SafetyNetUnit is Test {
     vm.prank(_alice);
 
     // Large enough for request
-    _sn.withdraw(id, 2); 
+    _sn.withdraw(id, 2);
     reqId = 0;
   }
 
@@ -698,8 +694,8 @@ contract SafetyNetUnit is Test {
     (, uint256 reqId) = _createFundAndRequest();
 
     // Beyond window
-    vm.warp(block.timestamp + 10 days); 
-    (address rqOwner, , , , , uint256 rqAmount) = _sn.requests(reqId);
+    vm.warp(block.timestamp + 10 days);
+    (address rqOwner,,,,, uint256 rqAmount) = _sn.requests(reqId);
     vm.expectEmit(true, true, false, true);
     emit ISafetyNet.WithdrawalAutoExecuted(reqId, rqOwner, rqAmount);
     _sn.executeContestedWithdrawal(reqId);
@@ -726,9 +722,8 @@ contract SafetyNetUnit is Test {
       initialDeposit: 100 ether,
       fixedDeposit: 10 ether,
       ratio: 1,
-
       // Force request path
-      autoThreshold: 1, 
+      autoThreshold: 1,
       contestWindow: 3 days,
       votingWindow: 30 days,
       currentEpoch: 0,
@@ -741,7 +736,7 @@ contract SafetyNetUnit is Test {
     vm.prank(_alice);
 
     // Creates request 0
-    _sn.withdraw(id, 1); 
+    _sn.withdraw(id, 1);
     uint256 reqId = 0;
 
     // Vote yes by alice then bob (2/3 = 66% > 60%)
@@ -853,19 +848,19 @@ contract SafetyNetUnit is Test {
     uint256 id = _sn.create(sn);
 
     // Before start
-    assertEq(_sn.getCurrentEpochIndex(id), 0); 
+    assertEq(_sn.getCurrentEpochIndex(id), 0);
     vm.warp(sn.safetyNetStart);
 
     // At start
-    assertEq(_sn.getCurrentEpochIndex(id), 0); 
+    assertEq(_sn.getCurrentEpochIndex(id), 0);
     vm.warp(sn.safetyNetStart + 1);
 
     // Just after start
-    assertEq(_sn.getCurrentEpochIndex(id), 0); 
+    assertEq(_sn.getCurrentEpochIndex(id), 0);
     vm.warp(sn.safetyNetStart + sn.epochDuration);
 
     // Exactly one epoch
-    assertEq(_sn.getCurrentEpochIndex(id), 1); 
+    assertEq(_sn.getCurrentEpochIndex(id), 1);
     vm.warp(sn.safetyNetStart + 5 * sn.epochDuration + 10);
     assertEq(_sn.getCurrentEpochIndex(id), 5);
   }

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -267,14 +267,15 @@ contract SafetyNetUnit is Test {
     _sn.create(sn);
   }
 
-  function test_CreateWhenMembersArrayContainsDuplicates() external {
+  function test_CreateWhenMembersArrayContainsDuplicates_reverts() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     
     // Duplicate
     sn.members[1] = _alice; 
-    uint256 id = _sn.create(sn);
-    assertTrue(_sn.isMember(id, _alice));
+
+    vm.expectRevert(ISafetyNet.DuplicateMember.selector);
+    _sn.create(sn);
   }
 
   function test_CreateWhenConsensusThresholdIsZero() external {


### PR DESCRIPTION
Closes #38

This PR ensures that both `memberWithdrawableBalance` and `safetyNetBalance` are decremented when a withdrawal request is executed (small, auto-executed, or consensus-approved). 

