### PR TITLE
Enforce exact per-epoch dues; clarify deposit/epoch flags

### DIFF
--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -58,7 +58,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Tracks if a request has been executed
   mapping(uint256 id => bool executed) public isExecuted;
 
-  /// @notice Tracks which members have deposited in each epoch
+  /// @notice (DEPRECATED) Tracks which members have deposited in each epoch
+  ///         Do not use for logic; use `epochMemberDepositedAmount` instead.
   mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => bool))) public
     epochMemberDeposits;
 
@@ -328,7 +329,10 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     address _member,
     uint256 _epochIndex
   ) external view override returns (bool) {
-    return epochMemberDeposits[_safetyNetId][_epochIndex][_member];
+    SafetyNet memory sn = safetyNets[_safetyNetId];
+    if (sn.owner == address(0) || sn.fixedDeposit == 0) return false;
+    uint256 paid = epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member];
+    return paid >= sn.fixedDeposit;
   }
 
   /// @notice Returns how much a member still needs to pay this epoch to reach their fixedDeposit dues
@@ -362,7 +366,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     for (uint256 epochIndex = 0; epochIndex < currentEpochIndex; epochIndex++) {
       for (uint256 i = 0; i < safetyNet.members.length; i++) {
-        if (!epochMemberDeposits[_safetyNetId][epochIndex][safetyNet.members[i]]) {
+        address m = safetyNet.members[i];
+        if (epochMemberDepositedAmount[_safetyNetId][epochIndex][m] < safetyNet.fixedDeposit) {
           return true;
         }
       }
@@ -387,11 +392,6 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     if (block.timestamp < _safetyNet.safetyNetStart) revert DepositBeforeSafetyNetStart();
 
     uint256 currentEpochIndex = getCurrentEpochIndex(_id);
-
-    if (epochMemberDeposits[_id][currentEpochIndex][_member]) {
-      revert AlreadyDeposited();
-    }
-
     uint256 epochTarget = _safetyNet.fixedDeposit;
 
     bool chargeInitial = false;
@@ -414,10 +414,6 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     uint256 newCumulative = contributedSoFar + _value;
     epochMemberDepositedAmount[_id][currentEpochIndex][_member] = newCumulative;
-
-    if (newCumulative == epochTarget) {
-      epochMemberDeposits[_id][currentEpochIndex][_member] = true;
-    }
 
     if (!IERC20(_safetyNet.token).transferFrom(_member, address(this), totalTransfer)) revert TransferFailed();
 

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -334,8 +334,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     return epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member] >= sn.fixedDeposit;
   }
 
-  /// @notice Returns how much a member still needs to pay this epoch to reach their fixedDeposit dues
-  function duesRemainingThisEpoch(uint256 _id, address _member) external view returns (uint256) {
+  /// @inheritdoc ISafetyNet
+  function duesRemainingThisEpoch(uint256 _id, address _member) external view override returns (uint256) {
     uint256 epochIndex = getCurrentEpochIndex(_id);
     uint256 paid = epochMemberDepositedAmount[_id][epochIndex][_member];
     uint256 target = safetyNets[_id].fixedDeposit;

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -58,11 +58,6 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Tracks if a request has been executed
   mapping(uint256 id => bool executed) public isExecuted;
 
-  /// @notice (DEPRECATED) Tracks which members have deposited in each epoch
-  ///         Do not use for logic; use `epochMemberDepositedAmount` instead.
-  mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => bool))) public
-    epochMemberDeposits;
-
   /// @notice Per-epoch cumulative amount deposited by a member (their own savings) toward the exact dues
   mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => uint256))) public
     epochMemberDepositedAmount;

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -324,9 +324,9 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     address _member,
     uint256 _epochIndex
   ) external view override returns (bool) {
-    ISafetyNet.SafetyNet storage sn = safetyNets[_safetyNetId];
-    if (sn.owner == address(0)) return false;
-    return epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member] >= sn.fixedDeposit;
+    ISafetyNet.SafetyNet storage _safetyNet = safetyNets[_safetyNetId];
+    if (_safetyNet.owner == address(0)) return false;
+    return epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member] >= _safetyNet.fixedDeposit;
   }
 
   /// @inheritdoc ISafetyNet
@@ -360,8 +360,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     for (uint256 epochIndex = 0; epochIndex < currentEpochIndex; epochIndex++) {
       for (uint256 i = 0; i < safetyNet.members.length; i++) {
-        address m = safetyNet.members[i];
-        if (epochMemberDepositedAmount[_safetyNetId][epochIndex][m] < safetyNet.fixedDeposit) {
+        address _member = safetyNet.members[i];
+        if (epochMemberDepositedAmount[_safetyNetId][epochIndex][_member] < safetyNet.fixedDeposit) {
           return true;
         }
       }
@@ -378,11 +378,11 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
    *      Partial deposits are allowed until the epoch sum == fixedDeposit.
    */
   function _deposit(uint256 _id, uint256 _value, address _member) internal {
-    SafetyNet storage sn = safetyNets[_id];
+    SafetyNet storage _safetyNet = safetyNets[_id];
 
-    if (sn.owner == address(0)) revert NotCommissioned();
+    if (_safetyNet.owner == address(0)) revert NotCommissioned();
     if (!isMember[_id][_member]) revert NotMember();
-    if (block.timestamp < sn.safetyNetStart) revert DepositBeforeSafetyNetStart();
+    if (block.timestamp < _safetyNet.safetyNetStart) revert DepositBeforeSafetyNetStart();
     if (_value == 0) revert InvalidDepositAmount();
 
     uint256 epoch = getCurrentEpochIndex(_id);
@@ -391,26 +391,26 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     uint256 epochPaid = epochMemberDepositedAmount[_id][epoch][_member];
 
     if (!initialDone) {
-      uint256 initial = sn.initialDeposit;
+      uint256 initial = _safetyNet.initialDeposit;
       // First month: must be first payment in the epoch AND exactly initialDeposit (no partials/multi-tx)
       if (epochPaid != 0 || _value != initial) revert InvalidDepositAmount();
 
       hasMadeFirstDeposit[_id][_member] = true;
-      safetyNetMemberContribute[_id][_member] = sn.fixedDeposit;
+      safetyNetMemberContribute[_id][_member] = _safetyNet.fixedDeposit;
 
       // Set epoch paid to full initial
       epochPaid = initial;
     } else {
       // Subsequent months: partials allowed up to fixedDeposit
-      if (epochPaid + _value > sn.fixedDeposit) revert ExceedsDepositAmount();
+      if (epochPaid + _value > _safetyNet.fixedDeposit) revert ExceedsDepositAmount();
       epochPaid += _value;
     }
 
     safetyNetBalance[_id] += _value;
-    memberWithdrawableBalance[_id][_member] += _value * sn.ratio;
+    memberWithdrawableBalance[_id][_member] += _value * _safetyNet.ratio;
     epochMemberDepositedAmount[_id][epoch][_member] = epochPaid;
 
-    if (!IERC20(sn.token).transferFrom(_member, address(this), _value)) revert TransferFailed();
+    if (!IERC20(_safetyNet.token).transferFrom(_member, address(this), _value)) revert TransferFailed();
 
     emit FundsDeposited(_id, _member, _value);
   }

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -377,46 +377,47 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
   /**
    * @dev Make a deposit for monthly contribute
-   *      If it's the first deposit, initialDeposit amount is added to the total amount
+   *      If it's the first deposit, initialDeposit is the total amount
    *      The method "transferFrom()" requires "approve()" front-end side
-   *      Each epoch, a member must pay exactly `fixedDeposit`.
+   *      Each epoch after initial deposit, a member must pay exactly `fixedDeposit`.
    *      Partial deposits are allowed until the epoch sum == fixedDeposit.
    */
   function _deposit(uint256 _id, uint256 _value, address _member) internal {
-    SafetyNet storage _safetyNet = safetyNets[_id];
+    SafetyNet storage sn = safetyNets[_id];
 
-    if (_safetyNet.owner == address(0)) revert NotCommissioned();
+    if (sn.owner == address(0)) revert NotCommissioned();
     if (!isMember[_id][_member]) revert NotMember();
-    if (_value <= 0) revert InvalidDepositAmount();
-    if (block.timestamp < _safetyNet.safetyNetStart) revert DepositBeforeSafetyNetStart();
+    if (block.timestamp < sn.safetyNetStart) revert DepositBeforeSafetyNetStart();
+    if (_value == 0) revert InvalidDepositAmount();
 
-    uint256 currentEpochIndex = getCurrentEpochIndex(_id);
-    uint256 epochTarget = _safetyNet.fixedDeposit;
+    uint256 epoch = getCurrentEpochIndex(_id);
+    bool initialDone = hasMadeFirstDeposit[_id][_member];
 
-    bool chargeInitial = false;
-    if (!hasMadeFirstDeposit[_id][_member]) {
+    uint256 epochPaid = epochMemberDepositedAmount[_id][epoch][_member];
+
+    if (!initialDone) {
+      uint256 initial = sn.initialDeposit;
+      // First month: must be first payment in the epoch AND exactly initialDeposit (no partials/multi-tx)
+      if (epochPaid != 0 || _value != initial) revert InvalidDepositAmount();
+
       hasMadeFirstDeposit[_id][_member] = true;
-      safetyNetMemberContribute[_id][_member] = epochTarget;
-      chargeInitial = true;
+      safetyNetMemberContribute[_id][_member] = sn.fixedDeposit;
+
+      // Set epoch paid to full initial
+      epochPaid = initial;
+    } else {
+      // Subsequent months: partials allowed up to fixedDeposit
+      if (epochPaid + _value > sn.fixedDeposit) revert ExceedsDepositAmount();
+      epochPaid += _value;
     }
 
-    uint256 contributedSoFar = epochMemberDepositedAmount[_id][currentEpochIndex][_member];
-    if (contributedSoFar + _value > epochTarget) {
-      revert ExceedsDepositAmount();
-    }
+    safetyNetBalance[_id] += _value;
+    memberWithdrawableBalance[_id][_member] += _value * sn.ratio;
+    epochMemberDepositedAmount[_id][epoch][_member] = epochPaid;
 
-    uint256 totalTransfer = _value + (chargeInitial ? _safetyNet.initialDeposit : 0);
+    if (!IERC20(sn.token).transferFrom(_member, address(this), _value)) revert TransferFailed();
 
-    safetyNetBalance[_id] += totalTransfer;
-
-    memberWithdrawableBalance[_id][_member] += _value * _safetyNet.ratio;
-
-    uint256 newCumulative = contributedSoFar + _value;
-    epochMemberDepositedAmount[_id][currentEpochIndex][_member] = newCumulative;
-
-    if (!IERC20(_safetyNet.token).transferFrom(_member, address(this), totalTransfer)) revert TransferFailed();
-
-    emit FundsDeposited(_id, _member, totalTransfer);
+    emit FundsDeposited(_id, _member, _value);
   }
 
   /**

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -43,9 +43,6 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Indicates whether a specific ERC20 token is allowed for use in Safety Nets
   mapping(address token => bool status) public allowedTokens;
 
-  /// @notice Tracks whether a member has made their first deposit in a specific Safety Net
-  mapping(uint256 id => mapping(address member => bool hasDeposited)) public hasMadeFirstDeposit;
-
   /// @notice Lists all requests indexed by their unique ID
   mapping(uint256 idReq => Request request) public requests;
 
@@ -386,16 +383,15 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     if (_value == 0) revert InvalidDepositAmount();
 
     uint256 epoch = getCurrentEpochIndex(_id);
-    bool initialDone = hasMadeFirstDeposit[_id][_member];
-
     uint256 epochPaid = epochMemberDepositedAmount[_id][epoch][_member];
+    // Onboarding status is derived: not onboarded if no monthly contribution set yet.
+    bool onboarding = (safetyNetMemberContribute[_id][_member] == 0);
 
-    if (!initialDone) {
+    if (onboarding) {
       uint256 initial = _safetyNet.initialDeposit;
       // First month: must be first payment in the epoch AND exactly initialDeposit (no partials/multi-tx)
       if (epochPaid != 0 || _value != initial) revert InvalidDepositAmount();
 
-      hasMadeFirstDeposit[_id][_member] = true;
       safetyNetMemberContribute[_id][_member] = _safetyNet.fixedDeposit;
 
       // Set epoch paid to full initial

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -62,6 +62,10 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => bool))) public
     epochMemberDeposits;
 
+  /// @notice Per-epoch cumulative amount deposited by a member (their own savings) toward the exact dues
+  mapping(uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => uint256))) public
+    epochMemberDepositedAmount;
+
   /// @notice Tracks the number of small withdrawals performed in a Safety Net from a member during one epoch
   mapping(
     uint256 safetyNetId => mapping(uint256 epochIndex => mapping(address member => uint256 smallWithdrawsCount))
@@ -327,6 +331,14 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     return epochMemberDeposits[_safetyNetId][_epochIndex][_member];
   }
 
+  /// @notice Returns how much a member still needs to pay this epoch to reach their fixedDeposit dues
+  function dueRemainingThisEpoch(uint256 _id, address _member) external view returns (uint256) {
+    uint256 epochIndex = getCurrentEpochIndex(_id);
+    uint256 paid = epochMemberDepositedAmount[_id][epochIndex][_member];
+    uint256 target = safetyNets[_id].fixedDeposit;
+    return paid >= target ? 0 : (target - paid);
+  }
+
   /// @inheritdoc ISafetyNet
   function getCurrentEpochIndex(uint256 _safetyNetId) public view override returns (uint256) {
     SafetyNet memory safetyNet = safetyNets[_safetyNetId];
@@ -363,6 +375,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
    * @dev Make a deposit for monthly contribute
    *      If it's the first deposit, initialDeposit amount is added to the total amount
    *      The method "transferFrom()" requires "approve()" front-end side
+   *      Each epoch, a member must pay exactly `fixedDeposit`.
+   *      Partial deposits are allowed until the epoch sum == fixedDeposit.
    */
   function _deposit(uint256 _id, uint256 _value, address _member) internal {
     SafetyNet storage _safetyNet = safetyNets[_id];
@@ -378,22 +392,36 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
       revert AlreadyDeposited();
     }
 
-    uint256 _totalDeposit = _value + _safetyNet.fixedDeposit;
+    uint256 epochTarget = _safetyNet.fixedDeposit;
 
+    bool chargeInitial = false;
     if (!hasMadeFirstDeposit[_id][_member]) {
-      safetyNetMemberContribute[_id][_member] = _value;
-      _totalDeposit += _safetyNet.initialDeposit;
       hasMadeFirstDeposit[_id][_member] = true;
+      safetyNetMemberContribute[_id][_member] = epochTarget;
+      chargeInitial = true;
     }
 
-    safetyNetBalance[_id] += _totalDeposit;
+    uint256 contributedSoFar = epochMemberDepositedAmount[_id][currentEpochIndex][_member];
+    if (contributedSoFar + _value > epochTarget) {
+      revert ExceedsDepositAmount();
+    }
+
+    uint256 totalTransfer = _value + (chargeInitial ? _safetyNet.initialDeposit : 0);
+
+    safetyNetBalance[_id] += totalTransfer;
+
     memberWithdrawableBalance[_id][_member] += _value * _safetyNet.ratio;
 
-    epochMemberDeposits[_id][currentEpochIndex][_member] = true;
+    uint256 newCumulative = contributedSoFar + _value;
+    epochMemberDepositedAmount[_id][currentEpochIndex][_member] = newCumulative;
 
-    if (!IERC20(_safetyNet.token).transferFrom(_member, address(this), _totalDeposit)) revert TransferFailed();
+    if (newCumulative == epochTarget) {
+      epochMemberDeposits[_id][currentEpochIndex][_member] = true;
+    }
 
-    emit FundsDeposited(_id, _member, _totalDeposit);
+    if (!IERC20(_safetyNet.token).transferFrom(_member, address(this), totalTransfer)) revert TransferFailed();
+
+    emit FundsDeposited(_id, _member, totalTransfer);
   }
 
   /**
@@ -441,6 +469,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
         revert ExceedsSmallWithdrawalLimit();
       }
       memberWithdrawableBalance[_id][_member] -= _withdrawAmount;
+      safetyNetBalance[_id] -= _withdrawAmount;
       if (!IERC20(_safetyNet.token).transfer(_member, _withdrawAmount)) revert TransferFailed();
 
       emit FundsWithdrawn(_id, _member, _withdrawAmount);

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -329,7 +329,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     address _member,
     uint256 _epochIndex
   ) external view override returns (bool) {
-    SafetyNet memory sn = safetyNets[_safetyNetId];
+    ISafetyNet.SafetyNet storage sn = safetyNets[_safetyNetId];
     if (sn.owner == address(0)) return false;
     return epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member] >= sn.fixedDeposit;
   }

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -330,13 +330,12 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     uint256 _epochIndex
   ) external view override returns (bool) {
     SafetyNet memory sn = safetyNets[_safetyNetId];
-    if (sn.owner == address(0) || sn.fixedDeposit == 0) return false;
-    uint256 paid = epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member];
-    return paid >= sn.fixedDeposit;
+    if (sn.owner == address(0)) return false;
+    return epochMemberDepositedAmount[_safetyNetId][_epochIndex][_member] >= sn.fixedDeposit;
   }
 
   /// @notice Returns how much a member still needs to pay this epoch to reach their fixedDeposit dues
-  function dueRemainingThisEpoch(uint256 _id, address _member) external view returns (uint256) {
+  function duesRemainingThisEpoch(uint256 _id, address _member) external view returns (uint256) {
     uint256 epochIndex = getCurrentEpochIndex(_id);
     uint256 paid = epochMemberDepositedAmount[_id][epochIndex][_member];
     uint256 target = safetyNets[_id].fixedDeposit;

--- a/src/interfaces/ISafetyNet.sol
+++ b/src/interfaces/ISafetyNet.sol
@@ -318,6 +318,12 @@ interface ISafetyNet {
   /// @return epochIndex The current epoch index based on time elapsed
   function getCurrentEpochIndex(uint256 safetyNetId) external view returns (uint256);
 
+  /// @notice Returns how much a member still needs to pay this epoch to reach their fixedDeposit dues
+  /// @param id Safety Net ID
+  /// @param member Member address
+  /// @return remaining Amount left to reach the fixed deposit in the current epoch
+  function duesRemainingThisEpoch(uint256 id, address member) external view returns (uint256 remaining);
+
   /// @notice Checks if a Safety Net is eligible for decommission
   /// @param safetyNetId The Safety Net ID
   /// @return decommissionable True if the safetyNet can be decommissioned (when someone missed a payment)

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -137,7 +137,7 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /// @dev Convenience: mint + approve, then deposit `value` for `who` into fund `id`.
   function _depositAs(address who, uint256 id, uint256 value) internal {
-    uint256 due = safetyNet.dueRemainingThisEpoch(id, who);
+    uint256 due = safetyNet.duesRemainingThisEpoch(id, who);
     if (due == 0) return;
 
     uint256 amt = value > due ? due : value;

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -36,10 +36,10 @@ abstract contract SafetyNetFuzzBase is Test {
   uint256 internal constant SAFE_MIN_MEMBERS = 3;
   uint256 internal constant SAFE_MAX_MEMBERS = 10;
   uint256 internal constant SAFE_CONSENSUS = 51; // percentage
-  uint256 internal constant SAFE_INITIAL_DEPOSIT = 1e16;
-  uint256 internal constant SAFE_FIXED_DEPOSIT = 1e16;
+  uint256 internal constant SAFE_INITIAL_DEPOSIT = 225e18;
+  uint256 internal constant SAFE_FIXED_DEPOSIT = 50e18;
   uint256 internal constant SAFE_RATIO = 1; // 1x
-  uint256 internal constant SAFE_AUTO_THRESHOLD = 5e17;
+  uint256 internal constant SAFE_AUTO_THRESHOLD = 150e18;
   uint256 internal constant SAFE_CONTEST_WINDOW = 1 days;
   uint256 internal constant SAFE_VOTING_WINDOW = 3 days;
   uint256 internal constant SAFE_EPOCH_DURATION = 30 days;
@@ -112,18 +112,18 @@ abstract contract SafetyNetFuzzBase is Test {
   // ───────────── Helpers (reused across suites) ─────────────
 
   /// @dev Returns the canonical three default members.
-  function _threeMembers() internal view returns (address[] memory m) {
-    m = new address[](3);
-    m[0] = member1;
-    m[1] = member2;
-    m[2] = member3;
+  function _threeMembers() internal view returns (address[] memory _member) {
+    _member = new address[](3);
+    _member[0] = member1;
+    _member[1] = member2;
+    _member[2] = member3;
   }
 
   /// @dev Deterministically generates `n` pseudo-members for fuzzing.
-  function _makeMembers(uint256 n) internal pure returns (address[] memory m) {
-    m = new address[](n);
+  function _makeMembers(uint256 n) internal pure returns (address[] memory _member) {
+    _member = new address[](n);
     for (uint256 i = 0; i < n; i++) {
-      m[i] = address(uint160(uint256(keccak256(abi.encodePacked(i, 'SAFETYNET_MEMBER')))));
+      _member[i] = address(uint160(uint256(keccak256(abi.encodePacked(i, 'SAFETYNET_MEMBER')))));
     }
   }
 
@@ -141,6 +141,10 @@ abstract contract SafetyNetFuzzBase is Test {
     if (due == 0) return;
 
     uint256 amt = value > due ? due : value;
+    // Onboarding: first deposit must be exactly initialDeposit
+    if (!safetyNet.hasMadeFirstDeposit(id, who)) {
+      amt = safeCfg.initialDeposit;
+    }
 
     uint256 needed = amt + safeCfg.fixedDeposit + safeCfg.initialDeposit;
     token.mint(who, needed);

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -14,9 +14,9 @@ import {MockERC20} from 'test/mocks/MockERC20.sol';
 /// @notice Shared base for all fuzz suites: deploys proxy + token, provides defaults & helpers.
 abstract contract SafetyNetFuzzBase is Test {
   // Implementation / proxy
-  SafetyNet internal implementation;
-  SafetyNet internal safetyNet;
-  ProxyAdmin internal proxyAdmin;
+  SafetyNet internal _implementation;
+  SafetyNet internal _safetyNet;
+  ProxyAdmin internal _proxyAdmin;
   TransparentUpgradeableProxy internal proxy;
 
   // Token
@@ -33,17 +33,17 @@ abstract contract SafetyNetFuzzBase is Test {
   ISafetyNet.SafetyNet internal safeCfg;
 
   // Defaults (chosen to be permissive but safe for fuzzing)
-  uint256 internal constant SAFE_MIN_MEMBERS = 3;
-  uint256 internal constant SAFE_MAX_MEMBERS = 10;
-  uint256 internal constant SAFE_CONSENSUS = 51; // percentage
-  uint256 internal constant SAFE_INITIAL_DEPOSIT = 225e18;
-  uint256 internal constant SAFE_FIXED_DEPOSIT = 50e18;
-  uint256 internal constant SAFE_RATIO = 1; // 1x
-  uint256 internal constant SAFE_AUTO_THRESHOLD = 150e18;
-  uint256 internal constant SAFE_CONTEST_WINDOW = 1 days;
-  uint256 internal constant SAFE_VOTING_WINDOW = 3 days;
-  uint256 internal constant SAFE_EPOCH_DURATION = 30 days;
-  uint256 internal constant SAFE_SMALL_WITHDRAWS_LIMIT = 3;
+  uint256 internal constant _SAFE_MIN_MEMBERS = 3;
+  uint256 internal constant _SAFE_MAX_MEMBERS = 10;
+  uint256 internal constant _SAFE_CONSENSUS = 51; // percentage
+  uint256 internal constant _SAFE_INITIAL_DEPOSIT = 225e18;
+  uint256 internal constant _SAFE_FIXED_DEPOSIT = 50e18;
+  uint256 internal constant _SAFE_RATIO = 1; // 1x
+  uint256 internal constant _SAFE_AUTO_THRESHOLD = 150e18;
+  uint256 internal constant _SAFE_CONTEST_WINDOW = 1 days;
+  uint256 internal constant _SAFE_VOTING_WINDOW = 3 days;
+  uint256 internal constant _SAFE_EPOCH_DURATION = 30 days;
+  uint256 internal constant _SAFE_SMALL_WITHDRAWS_LIMIT = 3;
 
   /**
    * setUp
@@ -64,42 +64,42 @@ abstract contract SafetyNetFuzzBase is Test {
     vm.label(address(token), 'MockERC20');
 
     // implementation + proxy admin
-    implementation = new SafetyNet();
-    vm.label(address(implementation), 'SafetyNet_Impl');
-    proxyAdmin = new ProxyAdmin(owner_);
-    vm.label(address(proxyAdmin), 'ProxyAdmin');
+    _implementation = new SafetyNet();
+    vm.label(address(_implementation), 'SafetyNet_Impl');
+    _proxyAdmin = new ProxyAdmin(owner_);
+    vm.label(address(_proxyAdmin), 'ProxyAdmin');
 
     // proxy (initialize owner)
     bytes memory initData = abi.encodeWithSelector(SafetyNet.initialize.selector, owner_);
-    proxy = new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+    proxy = new TransparentUpgradeableProxy(address(_implementation), address(_proxyAdmin), initData);
     vm.label(address(proxy), 'SafetyNet_Proxy');
 
     // use proxy via impl ABI
-    safetyNet = SafetyNet(address(proxy));
-    vm.label(address(safetyNet), 'SafetyNet');
+    _safetyNet = SafetyNet(address(proxy));
+    vm.label(address(_safetyNet), 'SafetyNet');
 
     // allow token
-    safetyNet.setTokenAllowed(address(token), true);
+    _safetyNet.setTokenAllowed(address(token), true);
 
     // default config template
     ISafetyNet.SafetyNet memory cfg;
     cfg.id = 0;
     cfg.owner = owner_;
-    cfg.minimumMembers = SAFE_MIN_MEMBERS;
-    cfg.maximumMembers = SAFE_MAX_MEMBERS;
-    cfg.consensusThreshold = SAFE_CONSENSUS;
+    cfg.minimumMembers = _SAFE_MIN_MEMBERS;
+    cfg.maximumMembers = _SAFE_MAX_MEMBERS;
+    cfg.consensusThreshold = _SAFE_CONSENSUS;
     cfg.safetyNetStart = block.timestamp + 1 days; // future by default
     cfg.token = address(token);
     cfg.members = defaultMembers;
-    cfg.initialDeposit = SAFE_INITIAL_DEPOSIT;
-    cfg.fixedDeposit = SAFE_FIXED_DEPOSIT;
-    cfg.ratio = SAFE_RATIO;
-    cfg.autoThreshold = SAFE_AUTO_THRESHOLD;
-    cfg.contestWindow = SAFE_CONTEST_WINDOW;
-    cfg.votingWindow = SAFE_VOTING_WINDOW;
+    cfg.initialDeposit = _SAFE_INITIAL_DEPOSIT;
+    cfg.fixedDeposit = _SAFE_FIXED_DEPOSIT;
+    cfg.ratio = _SAFE_RATIO;
+    cfg.autoThreshold = _SAFE_AUTO_THRESHOLD;
+    cfg.contestWindow = _SAFE_CONTEST_WINDOW;
+    cfg.votingWindow = _SAFE_VOTING_WINDOW;
     cfg.currentEpoch = 0;
-    cfg.epochDuration = SAFE_EPOCH_DURATION;
-    cfg.smallWithdrawsLimit = SAFE_SMALL_WITHDRAWS_LIMIT;
+    cfg.epochDuration = _SAFE_EPOCH_DURATION;
+    cfg.smallWithdrawsLimit = _SAFE_SMALL_WITHDRAWS_LIMIT;
     safeCfg = cfg;
 
     // labels (nice for traces)
@@ -137,12 +137,12 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /// @dev Convenience: mint + approve, then deposit `value` for `who` into fund `id`.
   function _depositAs(address who, uint256 id, uint256 value) internal {
-    uint256 due = safetyNet.duesRemainingThisEpoch(id, who);
+    uint256 due = _safetyNet.duesRemainingThisEpoch(id, who);
     if (due == 0) return;
 
     uint256 amt = value > due ? due : value;
     // Onboarding: first deposit must be exactly initialDeposit
-    if (!safetyNet.hasMadeFirstDeposit(id, who)) {
+    if (!_safetyNet.hasMadeFirstDeposit(id, who)) {
       amt = safeCfg.initialDeposit;
     }
 
@@ -150,8 +150,8 @@ abstract contract SafetyNetFuzzBase is Test {
     token.mint(who, needed);
 
     vm.startPrank(who);
-    token.approve(address(safetyNet), type(uint256).max);
-    safetyNet.deposit(id, amt);
+    token.approve(address(_safetyNet), type(uint256).max);
+    _safetyNet.deposit(id, amt);
     vm.stopPrank();
   }
 
@@ -193,7 +193,7 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /// @dev Helper to ensure the per-epoch small-withdraw counter never exceeds the limit.
   function _assertSmallCounterBound(uint256 _id, uint256 epochIdx, address who, uint256 limit) internal view {
-    uint256 cnt = safetyNet.smallWithdrawsCount(_id, epochIdx, who);
+    uint256 cnt = _safetyNet.smallWithdrawsCount(_id, epochIdx, who);
     assertLe(cnt, limit, 'small-withdraw counter bounded by limit');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -142,7 +142,7 @@ abstract contract SafetyNetFuzzBase is Test {
 
     uint256 amt = value > due ? due : value;
     // Onboarding: first deposit must be exactly initialDeposit
-    if (!_safetyNet.hasMadeFirstDeposit(id, who)) {
+    if (_safetyNet.safetyNetMemberContribute(id, who) == 0) {
       amt = safeCfg.initialDeposit;
     }
 

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -17,20 +17,20 @@ abstract contract SafetyNetFuzzBase is Test {
   SafetyNet internal _implementation;
   SafetyNet internal _safetyNet;
   ProxyAdmin internal _proxyAdmin;
-  TransparentUpgradeableProxy internal proxy;
+  TransparentUpgradeableProxy internal _proxy;
 
   // Token
-  MockERC20 internal token;
+  MockERC20 internal _token;
 
   // Baseline members
-  address internal owner_;
-  address internal member1;
-  address internal member2;
-  address internal member3;
-  address[] internal defaultMembers;
+  address internal _owner;
+  address internal _member1;
+  address internal _member2;
+  address internal _member3;
+  address[] internal _defaultMembers;
 
   // Safe default template (filled in setUp)
-  ISafetyNet.SafetyNet internal safeCfg;
+  ISafetyNet.SafetyNet internal _safeCfg;
 
   // Defaults (chosen to be permissive but safe for fuzzing)
   uint256 internal constant _SAFE_MIN_MEMBERS = 3;
@@ -47,50 +47,50 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /**
    * setUp
-   * - Creates a proxy-admin + proxy-wrapped SafetyNet, initialized with `owner_`.
+   * - Creates a proxy-admin + proxy-wrapped SafetyNet, initialized with `_owner`.
    * - Deploys and allow-lists a MockERC20 used across tests.
    * - Prepares a baseline config `safeCfg` reused by fuzz suites.
    */
   function setUp() public virtual {
     // actors
-    member1 = address(0xA11CE);
-    member2 = address(0xB0B);
-    member3 = address(0xC0C0A);
-    owner_ = address(this);
-    defaultMembers = _threeMembers();
+    _member1 = address(0xA11CE);
+    _member2 = address(0xB0B);
+    _member3 = address(0xC0C0A);
+    _owner = address(this);
+    _defaultMembers = _threeMembers();
 
     // token
-    token = new MockERC20('Mock', 'MOCK');
-    vm.label(address(token), 'MockERC20');
+    _token = new MockERC20('Mock', 'MOCK');
+    vm.label(address(_token), 'MockERC20');
 
     // implementation + proxy admin
     _implementation = new SafetyNet();
     vm.label(address(_implementation), 'SafetyNet_Impl');
-    _proxyAdmin = new ProxyAdmin(owner_);
+    _proxyAdmin = new ProxyAdmin(_owner);
     vm.label(address(_proxyAdmin), 'ProxyAdmin');
 
     // proxy (initialize owner)
-    bytes memory initData = abi.encodeWithSelector(SafetyNet.initialize.selector, owner_);
-    proxy = new TransparentUpgradeableProxy(address(_implementation), address(_proxyAdmin), initData);
-    vm.label(address(proxy), 'SafetyNet_Proxy');
+    bytes memory initData = abi.encodeWithSelector(SafetyNet.initialize.selector, _owner);
+    _proxy = new TransparentUpgradeableProxy(address(_implementation), address(_proxyAdmin), initData);
+    vm.label(address(_proxy), 'SafetyNet_Proxy');
 
     // use proxy via impl ABI
-    _safetyNet = SafetyNet(address(proxy));
+    _safetyNet = SafetyNet(address(_proxy));
     vm.label(address(_safetyNet), 'SafetyNet');
 
     // allow token
-    _safetyNet.setTokenAllowed(address(token), true);
+    _safetyNet.setTokenAllowed(address(_token), true);
 
     // default config template
     ISafetyNet.SafetyNet memory cfg;
     cfg.id = 0;
-    cfg.owner = owner_;
+    cfg.owner = _owner;
     cfg.minimumMembers = _SAFE_MIN_MEMBERS;
     cfg.maximumMembers = _SAFE_MAX_MEMBERS;
     cfg.consensusThreshold = _SAFE_CONSENSUS;
     cfg.safetyNetStart = block.timestamp + 1 days; // future by default
-    cfg.token = address(token);
-    cfg.members = defaultMembers;
+    cfg.token = address(_token);
+    cfg.members = _defaultMembers;
     cfg.initialDeposit = _SAFE_INITIAL_DEPOSIT;
     cfg.fixedDeposit = _SAFE_FIXED_DEPOSIT;
     cfg.ratio = _SAFE_RATIO;
@@ -100,13 +100,13 @@ abstract contract SafetyNetFuzzBase is Test {
     cfg.currentEpoch = 0;
     cfg.epochDuration = _SAFE_EPOCH_DURATION;
     cfg.smallWithdrawsLimit = _SAFE_SMALL_WITHDRAWS_LIMIT;
-    safeCfg = cfg;
+    _safeCfg = cfg;
 
     // labels (nice for traces)
-    vm.label(owner_, 'Owner');
-    vm.label(member1, 'Member1');
-    vm.label(member2, 'Member2');
-    vm.label(member3, 'Member3');
+    vm.label(_owner, 'Owner');
+    vm.label(_member1, 'Member1');
+    vm.label(_member2, 'Member2');
+    vm.label(_member3, 'Member3');
   }
 
   // ───────────── Helpers (reused across suites) ─────────────
@@ -114,9 +114,9 @@ abstract contract SafetyNetFuzzBase is Test {
   /// @dev Returns the canonical three default members.
   function _threeMembers() internal view returns (address[] memory _member) {
     _member = new address[](3);
-    _member[0] = member1;
-    _member[1] = member2;
-    _member[2] = member3;
+    _member[0] = _member1;
+    _member[1] = _member2;
+    _member[2] = _member3;
   }
 
   /// @dev Deterministically generates `n` pseudo-members for fuzzing.
@@ -129,9 +129,9 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /// @dev Mint `amount` tokens to `who` and grant unlimited approval to `spender`.
   function _mintApprove(address who, uint256 amount, address spender) internal {
-    token.mint(who, amount);
+    _token.mint(who, amount);
     vm.startPrank(who);
-    token.approve(spender, type(uint256).max);
+    _token.approve(spender, type(uint256).max);
     vm.stopPrank();
   }
 
@@ -143,14 +143,14 @@ abstract contract SafetyNetFuzzBase is Test {
     uint256 amt = value > due ? due : value;
     // Onboarding: first deposit must be exactly initialDeposit
     if (_safetyNet.safetyNetMemberContribute(id, who) == 0) {
-      amt = safeCfg.initialDeposit;
+      amt = _safeCfg.initialDeposit;
     }
 
-    uint256 needed = amt + safeCfg.fixedDeposit + safeCfg.initialDeposit;
-    token.mint(who, needed);
+    uint256 needed = amt + _safeCfg.fixedDeposit + _safeCfg.initialDeposit;
+    _token.mint(who, needed);
 
     vm.startPrank(who);
-    token.approve(address(_safetyNet), type(uint256).max);
+    _token.approve(address(_safetyNet), type(uint256).max);
     _safetyNet.deposit(id, amt);
     vm.stopPrank();
   }

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -137,11 +137,17 @@ abstract contract SafetyNetFuzzBase is Test {
 
   /// @dev Convenience: mint + approve, then deposit `value` for `who` into fund `id`.
   function _depositAs(address who, uint256 id, uint256 value) internal {
-    uint256 needed = value + safeCfg.initialDeposit + safeCfg.fixedDeposit;
+    uint256 due = safetyNet.dueRemainingThisEpoch(id, who);
+    if (due == 0) return;
+
+    uint256 amt = value > due ? due : value;
+
+    uint256 needed = amt + safeCfg.fixedDeposit + safeCfg.initialDeposit;
     token.mint(who, needed);
+
     vm.startPrank(who);
     token.approve(address(safetyNet), type(uint256).max);
-    safetyNet.deposit(id, value);
+    safetyNet.deposit(id, amt);
     vm.stopPrank();
   }
 

--- a/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
@@ -13,7 +13,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
     uint256 successfulCreations;
 
     for (uint256 i = 0; i < safetyNetCount; i++) {
-      ISafetyNet.SafetyNet memory config = safeCfg;
+      ISafetyNet.SafetyNet memory config = _safeCfg;
       config.safetyNetStart = block.timestamp + 1;
       config.consensusThreshold = uint256((consensusBasePercentage + i) % 100);
       if (config.consensusThreshold < 1) config.consensusThreshold = 1;
@@ -29,7 +29,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
   }
 
   function test_Create_RevertsOnZeroAddressMember() public {
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.safetyNetStart = block.timestamp + 1;
     config.members = _threeMembers();
     config.members[0] = address(0);
@@ -39,7 +39,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
   }
 
   function test_Create_RevertsOnDisallowedToken_then_SucceedsWhenAllowed() public {
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.safetyNetStart = block.timestamp + 1;
 
     MockERC20 temporaryToken = new MockERC20('Tmp', 'TMP');

--- a/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
@@ -6,50 +6,50 @@ import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
 import {MockERC20} from 'test/mocks/MockERC20.sol';
 
 contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
-  function testFuzz_LotsOfSafetyNetCreations(uint8 nRaw, uint8 consensusBase) public {
-    uint256 n = bound(uint256(nRaw), 5, 50);
-    uint256 cBase = 30 + (uint256(consensusBase) % 40);
+  function testFuzz_LotsOfSafetyNetCreations(uint8 safetyNetCountRaw, uint8 consensusBase) public {
+    uint256 safetyNetCount = bound(uint256(safetyNetCountRaw), 5, 50);
+    uint256 consensusBasePercentage = 30 + (uint256(consensusBase) % 40);
 
-    uint256 success;
+    uint256 successfulCreations;
 
-    for (uint256 i = 0; i < n; i++) {
-      ISafetyNet.SafetyNet memory cfg = safeCfg;
-      cfg.safetyNetStart = block.timestamp + 1;
-      cfg.consensusThreshold = uint256((cBase + i) % 100);
-      if (cfg.consensusThreshold < 1) cfg.consensusThreshold = 1;
-      cfg.autoThreshold = SAFE_AUTO_THRESHOLD + i * 1e15;
-      cfg.members = _threeMembers();
+    for (uint256 i = 0; i < safetyNetCount; i++) {
+      ISafetyNet.SafetyNet memory config = safeCfg;
+      config.safetyNetStart = block.timestamp + 1;
+      config.consensusThreshold = uint256((consensusBasePercentage + i) % 100);
+      if (config.consensusThreshold < 1) config.consensusThreshold = 1;
+      config.autoThreshold = _SAFE_AUTO_THRESHOLD + i * 1e15;
+      config.members = _threeMembers();
 
-      uint256 id = safetyNet.create(cfg);
-      assertEq(id, success, 'id matches successes so far');
-      success++;
+      uint256 safetyNetId = _safetyNet.create(config);
+      assertEq(safetyNetId, successfulCreations, 'safetyNetId matches successes so far');
+      successfulCreations++;
     }
 
-    assertEq(safetyNet.nextId(), success, 'nextId equals the number of successful creations');
+    assertEq(_safetyNet.nextId(), successfulCreations, 'nextId equals the number of successful creations');
   }
 
   function test_Create_RevertsOnZeroAddressMember() public {
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.safetyNetStart = block.timestamp + 1;
-    cfg.members = _threeMembers();
-    cfg.members[0] = address(0);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.safetyNetStart = block.timestamp + 1;
+    config.members = _threeMembers();
+    config.members[0] = address(0);
 
     vm.expectRevert(ISafetyNet.InvalidMemberAddress.selector);
-    safetyNet.create(cfg);
+    _safetyNet.create(config);
   }
 
   function test_Create_RevertsOnDisallowedToken_then_SucceedsWhenAllowed() public {
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.safetyNetStart = block.timestamp + 1;
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.safetyNetStart = block.timestamp + 1;
 
-    MockERC20 tmp = new MockERC20('Tmp', 'TMP');
-    cfg.token = address(tmp);
+    MockERC20 temporaryToken = new MockERC20('Tmp', 'TMP');
+    config.token = address(temporaryToken);
 
     vm.expectRevert(ISafetyNet.TokenNotAllowed.selector);
-    safetyNet.create(cfg);
+    _safetyNet.create(config);
 
-    safetyNet.setTokenAllowed(address(tmp), true);
-    uint256 idAllowed = safetyNet.create(cfg);
-    assertEq(idAllowed, 0, 'first successful creation gets id 0');
+    _safetyNet.setTokenAllowed(address(temporaryToken), true);
+    uint256 allowedSafetyNetId = _safetyNet.create(config);
+    assertEq(allowedSafetyNetId, 0, 'first successful creation gets id 0');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
@@ -23,78 +23,90 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
     uint256 dep3Raw,
     uint8 skipEpochsRaw
   ) public {
-    uint256 dep1 = bound(dep1Raw, 1e17, 5e19);
-    uint256 dep2 = bound(dep2Raw, 1e17, 5e19);
-    uint256 dep3 = bound(dep3Raw, 1e17, 5e19);
+    uint256 depositAmountMember1 = bound(dep1Raw, 1e17, 5e19);
+    uint256 depositAmountMember2 = bound(dep2Raw, 1e17, 5e19);
+    uint256 depositAmountMember3 = bound(dep3Raw, 1e17, 5e19);
     uint256 skipEpochs = bound(uint256(skipEpochsRaw), 1, 4);
 
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.members = defaultMembers;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.safetyNetStart = block.timestamp;
+    config.members = defaultMembers;
+    config.ratio = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
     // Pre-fund with enough allowance for multiple deposits.
-    _mintApprove(member1, dep1 + dep1 + 2 * (cfg.initialDeposit + cfg.fixedDeposit), address(safetyNet));
-    _mintApprove(member2, dep2 + dep2 + 2 * (cfg.initialDeposit + cfg.fixedDeposit), address(safetyNet));
-    _mintApprove(member3, dep3 + dep3 + 2 * (cfg.initialDeposit + cfg.fixedDeposit), address(safetyNet));
+    _mintApprove(
+      member1,
+      depositAmountMember1 + depositAmountMember1 + 2 * (config.initialDeposit + config.fixedDeposit),
+      address(_safetyNet)
+    );
+    _mintApprove(
+      member2,
+      depositAmountMember2 + depositAmountMember2 + 2 * (config.initialDeposit + config.fixedDeposit),
+      address(_safetyNet)
+    );
+    _mintApprove(
+      member3,
+      depositAmountMember3 + depositAmountMember3 + 2 * (config.initialDeposit + config.fixedDeposit),
+      address(_safetyNet)
+    );
 
     // Initial deposits
-    _depositAs(member1, id, dep1);
-    _depositAs(member2, id, dep2);
-    _depositAs(member3, id, dep3);
+    _depositAs(member1, safetyNetId, depositAmountMember1);
+    _depositAs(member2, safetyNetId, depositAmountMember2);
+    _depositAs(member3, safetyNetId, depositAmountMember3);
 
     // Next epoch: member3 skips their payment
-    vm.warp(block.timestamp + cfg.epochDuration + 1);
-    _depositAs(member1, id, dep1);
-    _depositAs(member2, id, dep2);
+    vm.warp(block.timestamp + config.epochDuration + 1);
+    _depositAs(member1, safetyNetId, depositAmountMember1);
+    _depositAs(member2, safetyNetId, depositAmountMember2);
     // member3 intentionally skips
 
     // Advance further epochs → fund should now be decommissionable
-    vm.warp(block.timestamp + cfg.epochDuration * skipEpochs + 1);
-    assertTrue(safetyNet.isDecommissionable(id), 'decommissionable after a missed epoch');
+    vm.warp(block.timestamp + config.epochDuration * skipEpochs + 1);
+    assertTrue(_safetyNet.isDecommissionable(safetyNetId), 'decommissionable after a missed epoch');
 
     // Snapshot before decommission
-    uint256 cBalBefore = token.balanceOf(address(safetyNet));
-    uint256 w1 = safetyNet.memberWithdrawableBalance(id, member1);
-    uint256 w2 = safetyNet.memberWithdrawableBalance(id, member2);
-    uint256 w3 = safetyNet.memberWithdrawableBalance(id, member3);
-    uint256 sumW = w1 + w2 + w3;
+    uint256 cBalBefore = token.balanceOf(address(_safetyNet));
+    uint256 member1Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member1);
+    uint256 member2Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member2);
+    uint256 member3Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member3);
+    uint256 totalWithdrawables = member1Withdrawable + member2Withdrawable + member3Withdrawable;
 
-    assertGe(cBalBefore, sumW, 'contract covers withdrawables here');
+    assertGe(cBalBefore, totalWithdrawables, 'contract covers withdrawables here');
 
     // Split of remainder among 3 members (equal share)
-    uint256 remaining = cBalBefore - sumW;
+    uint256 remaining = cBalBefore - totalWithdrawables;
     uint256 split = remaining / 3;
     uint256 remainder = remaining % 3;
 
-    uint256 m1Before = token.balanceOf(member1);
-    uint256 m2Before = token.balanceOf(member2);
-    uint256 m3Before = token.balanceOf(member3);
+    uint256 member1BalanceBefore = token.balanceOf(member1);
+    uint256 member2BalanceBefore = token.balanceOf(member2);
+    uint256 member3BalanceBefore = token.balanceOf(member3);
 
     // Execute decommission
-    safetyNet.decommission(id);
+    _safetyNet.decommission(safetyNetId);
 
     // Fund should be marked as not commissioned anymore
     vm.expectRevert(ISafetyNet.NotCommissioned.selector);
-    safetyNet.getSafetyNet(id);
+    _safetyNet.getSafetyNet(safetyNetId);
 
     // All withdrawables zeroed out
-    assertEq(safetyNet.memberWithdrawableBalance(id, member1), 0);
-    assertEq(safetyNet.memberWithdrawableBalance(id, member2), 0);
-    assertEq(safetyNet.memberWithdrawableBalance(id, member3), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member1), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member2), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member3), 0);
 
     // Members receive withdrawables + fair share of the split
-    uint256 m1After = token.balanceOf(member1);
-    uint256 m2After = token.balanceOf(member2);
-    uint256 m3After = token.balanceOf(member3);
+    uint256 member1BalanceAfter = token.balanceOf(member1);
+    uint256 member2BalanceAfter = token.balanceOf(member2);
+    uint256 member3BalanceAfter = token.balanceOf(member3);
 
-    assertEq(m1After - m1Before, w1 + split);
-    assertEq(m2After - m2Before, w2 + split);
-    assertEq(m3After - m3Before, w3 + split);
+    assertEq(member1BalanceAfter - member1BalanceBefore, member1Withdrawable + split);
+    assertEq(member2BalanceAfter - member2BalanceBefore, member2Withdrawable + split);
+    assertEq(member3BalanceAfter - member3BalanceBefore, member3Withdrawable + split);
 
     // Dust remainder (if any) stays in the contract
-    uint256 cBalAfter = token.balanceOf(address(safetyNet));
+    uint256 cBalAfter = token.balanceOf(address(_safetyNet));
     assertEq(cBalAfter, remainder, 'dust remainder retained');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Decommission.t.sol
@@ -28,49 +28,49 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
     uint256 depositAmountMember3 = bound(dep3Raw, 1e17, 5e19);
     uint256 skipEpochs = bound(uint256(skipEpochsRaw), 1, 4);
 
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.safetyNetStart = block.timestamp;
-    config.members = defaultMembers;
+    config.members = _defaultMembers;
     config.ratio = 1;
     uint256 safetyNetId = _safetyNet.create(config);
 
     // Pre-fund with enough allowance for multiple deposits.
     _mintApprove(
-      member1,
+      _member1,
       depositAmountMember1 + depositAmountMember1 + 2 * (config.initialDeposit + config.fixedDeposit),
       address(_safetyNet)
     );
     _mintApprove(
-      member2,
+      _member2,
       depositAmountMember2 + depositAmountMember2 + 2 * (config.initialDeposit + config.fixedDeposit),
       address(_safetyNet)
     );
     _mintApprove(
-      member3,
+      _member3,
       depositAmountMember3 + depositAmountMember3 + 2 * (config.initialDeposit + config.fixedDeposit),
       address(_safetyNet)
     );
 
     // Initial deposits
-    _depositAs(member1, safetyNetId, depositAmountMember1);
-    _depositAs(member2, safetyNetId, depositAmountMember2);
-    _depositAs(member3, safetyNetId, depositAmountMember3);
+    _depositAs(_member1, safetyNetId, depositAmountMember1);
+    _depositAs(_member2, safetyNetId, depositAmountMember2);
+    _depositAs(_member3, safetyNetId, depositAmountMember3);
 
-    // Next epoch: member3 skips their payment
+    // Next epoch: _member3 skips their payment
     vm.warp(block.timestamp + config.epochDuration + 1);
-    _depositAs(member1, safetyNetId, depositAmountMember1);
-    _depositAs(member2, safetyNetId, depositAmountMember2);
-    // member3 intentionally skips
+    _depositAs(_member1, safetyNetId, depositAmountMember1);
+    _depositAs(_member2, safetyNetId, depositAmountMember2);
+    // _member3 intentionally skips
 
     // Advance further epochs → fund should now be decommissionable
     vm.warp(block.timestamp + config.epochDuration * skipEpochs + 1);
     assertTrue(_safetyNet.isDecommissionable(safetyNetId), 'decommissionable after a missed epoch');
 
     // Snapshot before decommission
-    uint256 cBalBefore = token.balanceOf(address(_safetyNet));
-    uint256 member1Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member1);
-    uint256 member2Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member2);
-    uint256 member3Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, member3);
+    uint256 cBalBefore = _token.balanceOf(address(_safetyNet));
+    uint256 member1Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, _member1);
+    uint256 member2Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, _member2);
+    uint256 member3Withdrawable = _safetyNet.memberWithdrawableBalance(safetyNetId, _member3);
     uint256 totalWithdrawables = member1Withdrawable + member2Withdrawable + member3Withdrawable;
 
     assertGe(cBalBefore, totalWithdrawables, 'contract covers withdrawables here');
@@ -80,9 +80,9 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
     uint256 split = remaining / 3;
     uint256 remainder = remaining % 3;
 
-    uint256 member1BalanceBefore = token.balanceOf(member1);
-    uint256 member2BalanceBefore = token.balanceOf(member2);
-    uint256 member3BalanceBefore = token.balanceOf(member3);
+    uint256 member1BalanceBefore = _token.balanceOf(_member1);
+    uint256 member2BalanceBefore = _token.balanceOf(_member2);
+    uint256 member3BalanceBefore = _token.balanceOf(_member3);
 
     // Execute decommission
     _safetyNet.decommission(safetyNetId);
@@ -92,21 +92,21 @@ contract SafetyNetFuzz_Decommission is SafetyNetFuzzBase {
     _safetyNet.getSafetyNet(safetyNetId);
 
     // All withdrawables zeroed out
-    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member1), 0);
-    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member2), 0);
-    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, member3), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, _member1), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, _member2), 0);
+    assertEq(_safetyNet.memberWithdrawableBalance(safetyNetId, _member3), 0);
 
     // Members receive withdrawables + fair share of the split
-    uint256 member1BalanceAfter = token.balanceOf(member1);
-    uint256 member2BalanceAfter = token.balanceOf(member2);
-    uint256 member3BalanceAfter = token.balanceOf(member3);
+    uint256 member1BalanceAfter = _token.balanceOf(_member1);
+    uint256 member2BalanceAfter = _token.balanceOf(_member2);
+    uint256 member3BalanceAfter = _token.balanceOf(_member3);
 
     assertEq(member1BalanceAfter - member1BalanceBefore, member1Withdrawable + split);
     assertEq(member2BalanceAfter - member2BalanceBefore, member2Withdrawable + split);
     assertEq(member3BalanceAfter - member3BalanceBefore, member3Withdrawable + split);
 
     // Dust remainder (if any) stays in the contract
-    uint256 cBalAfter = token.balanceOf(address(_safetyNet));
+    uint256 cBalAfter = _token.balanceOf(address(_safetyNet));
     assertEq(cBalAfter, remainder, 'dust remainder retained');
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -9,22 +9,22 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 epochs = bound(uint256(epochsRaw), 2, 12);
     uint256 ops = bound(uint256(opsRaw), 5, 40);
 
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.safetyNetStart = block.timestamp;
-    config.members = defaultMembers;
+    config.members = _defaultMembers;
     config.ratio = 1;
     uint256 id = _safetyNet.create(config);
 
-    _mintApprove(member1, 1e24, address(_safetyNet));
-    _mintApprove(member2, 1e24, address(_safetyNet));
-    _mintApprove(member3, 1e24, address(_safetyNet));
+    _mintApprove(_member1, 1e24, address(_safetyNet));
+    _mintApprove(_member2, 1e24, address(_safetyNet));
+    _mintApprove(_member3, 1e24, address(_safetyNet));
 
     uint256 seed = uint256(keccak256(abi.encodePacked(block.timestamp, epochs, ops, extraSeed)));
 
     for (uint256 e = 0; e < epochs; e++) {
       for (uint256 k = 0; k < ops; k++) {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
-        address actor = _pick(defaultMembers, seed);
+        address actor = _pick(_defaultMembers, seed);
 
         this.caseDeposit(id, actor, seed);
         this.caseSmallWithdraw(id, actor, seed, config);
@@ -90,7 +90,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 want = (contrib / 30) * daysReq;
 
     uint256 cntBefore = _safetyNet.smallWithdrawsCount(id, epochIndex, actor);
-    uint256 balBefore = token.balanceOf(actor);
+    uint256 balBefore = _token.balanceOf(actor);
     bool withinLimit = cntBefore < config.smallWithdrawsLimit;
     bool smallByAmt = (want <= config.autoThreshold);
     bool enoughBalance = (want <= beforeWithdrawable);
@@ -98,7 +98,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     vm.prank(actor);
     try _safetyNet.withdraw(id, daysReq) {
       uint256 nowW = _safetyNet.memberWithdrawableBalance(id, actor);
-      uint256 balNow = token.balanceOf(actor);
+      uint256 balNow = _token.balanceOf(actor);
       uint256 cntNow = _safetyNet.smallWithdrawsCount(id, epochIndex, actor);
 
       if (want == 0) {
@@ -169,8 +169,8 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
 
   /// Small-withdraw limit fuzzing
   function testFuzz_SmallWithdrawsRespectLimit(uint8 daysReqRaw, uint8 extraWithdrawsRaw) public {
-    ISafetyNet.SafetyNet memory config = safeCfg;
-    config.members = defaultMembers;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
+    config.members = _defaultMembers;
     config.ratio = 1;
     config.safetyNetStart = block.timestamp;
     uint256 id = _safetyNet.create(config);
@@ -204,40 +204,40 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 remaining = planned;
     while (remaining > 0) {
       // First ever deposit must be EXACTLY initialDeposit, independent of epoch dues.
-      if (_safetyNet.safetyNetMemberContribute(id, member1) == 0) {
-        _mintApprove(member1, config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-        vm.prank(member1);
+      if (_safetyNet.safetyNetMemberContribute(id, _member1) == 0) {
+        _mintApprove(_member1, config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+        vm.prank(_member1);
         _safetyNet.deposit(id, config.initialDeposit);
         continue;
       }
 
       // After onboarding, pay against this epoch’s remaining dues.
-      uint256 due = _safetyNet.duesRemainingThisEpoch(id, member1);
+      uint256 due = _safetyNet.duesRemainingThisEpoch(id, _member1);
       if (due == 0) {
         vm.warp(block.timestamp + config.epochDuration + 1);
         continue;
       }
       uint256 pay = remaining > due ? due : remaining;
-      _mintApprove(member1, pay + config.fixedDeposit, address(_safetyNet));
-      vm.prank(member1);
+      _mintApprove(_member1, pay + config.fixedDeposit, address(_safetyNet));
+      vm.prank(_member1);
       _safetyNet.deposit(id, pay);
       remaining -= pay;
     }
 
     for (uint256 i = 0; i < config.smallWithdrawsLimit; i++) {
-      vm.prank(member1);
+      vm.prank(_member1);
       _safetyNet.withdraw(id, daysRequested);
     }
 
     for (uint256 j = 0; j < extraWithdraws; j++) {
-      vm.prank(member1);
+      vm.prank(_member1);
       vm.expectRevert(ISafetyNet.ExceedsSmallWithdrawalLimit.selector);
       _safetyNet.withdraw(id, daysRequested);
     }
 
     // After advancing to new epoch, limit resets
     vm.warp(block.timestamp + config.epochDuration + 1);
-    vm.prank(member1);
+    vm.prank(_member1);
     _safetyNet.withdraw(id, daysRequested);
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -37,30 +37,46 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
 
   // ── Case 1: Deposits — 1 per member per epoch; flag set; balance increases
   function _caseDeposit(uint256 id, address actor, uint256 seed) external {
+    // need the config to read initialDeposit
+    ISafetyNet.SafetyNet memory sn = safetyNet.getSafetyNet(id);
+
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
     uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
     uint256 dueBefore = safetyNet.duesRemainingThisEpoch(id, actor);
 
     if (dueBefore == 0) {
+      // already fully paid this epoch → any extra should exceed cap
       vm.prank(actor);
       vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
       try safetyNet.deposit(id, 1) {} catch {}
       return;
     }
 
-    // Choose a positive amount within the remaining due
+    // draw a positive amount within remaining due (used for non-onboarding path)
     uint256 v = 1e18 + (seed % 1e18);
-    uint256 amt = v % (dueBefore + 1);
-    if (amt == 0) amt = dueBefore;
+    uint256 picked = v % (dueBefore + 1);
+    if (picked == 0) picked = dueBefore;
 
-    vm.prank(actor);
-    safetyNet.deposit(id, amt);
+    uint256 depositedAmt;
+
+    vm.startPrank(actor);
+    if (!safetyNet.hasMadeFirstDeposit(id, actor)) {
+      // epoch 0 – must pay exactly initialDeposit
+      safetyNet.deposit(id, sn.initialDeposit);
+      depositedAmt = sn.initialDeposit;
+    } else {
+      // subsequent epochs – partials allowed up to fixedDeposit
+      // (dueBefore > 0 here, so picked ∈ [1, dueBefore])
+      safetyNet.deposit(id, picked);
+      depositedAmt = picked;
+    }
+    vm.stopPrank();
 
     bool paidAfter = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
-    assertEq(paidAfter, amt == dueBefore, 'flag only when epoch fully paid');
+    assertEq(paidAfter, depositedAmt == dueBefore, 'flag only when epoch fully paid');
 
     uint256 afterW = safetyNet.memberWithdrawableBalance(id, actor);
-    assertEq(afterW, beforeW + amt, 'withdrawable += deposited amt');
+    assertEq(afterW, beforeW + depositedAmt, 'withdrawable += deposited amt');
   }
 
   // ── Case 2: Small withdrawals — within limit, ≤ autoThreshold, and ≤ balance

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -39,20 +39,28 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
   function _caseDeposit(uint256 id, address actor, uint256 seed) external {
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
     uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
-    uint256 v = 1e18 + (seed % 1e18);
-    bool already = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
+    uint256 dueBefore = safetyNet.dueRemainingThisEpoch(id, actor);
 
-    vm.prank(actor);
-    if (already) {
-      vm.expectRevert(ISafetyNet.AlreadyDeposited.selector);
-      try safetyNet.deposit(id, v) {} catch {}
+    if (dueBefore == 0) {
+      vm.prank(actor);
+      vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
+      try safetyNet.deposit(id, 1) {} catch {}
       return;
     }
 
-    safetyNet.deposit(id, v);
-    assertTrue(safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx), 'epoch flag set');
+    // Choose a positive amount within the remaining due
+    uint256 v = 1e18 + (seed % 1e18);
+    uint256 amt = v % (dueBefore + 1);
+    if (amt == 0) amt = dueBefore;
+
+    vm.prank(actor);
+    safetyNet.deposit(id, amt);
+
+    bool paidAfter = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
+    assertEq(paidAfter, amt == dueBefore, 'flag only when epoch fully paid');
+
     uint256 afterW = safetyNet.memberWithdrawableBalance(id, actor);
-    assertEq(afterW, beforeW + v, 'withdrawable += v');
+    assertEq(afterW, beforeW + amt, 'withdrawable += deposited amt');
   }
 
   // ── Case 2: Small withdrawals — within limit, ≤ autoThreshold, and ≤ balance
@@ -175,10 +183,20 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 planned = (cfg.smallWithdrawsLimit + extraWithdraws) * perWithdraw;
     if (dep < planned) dep = planned;
 
-    uint256 totalNeeded = dep + cfg.initialDeposit + cfg.fixedDeposit;
-    _mintApprove(member1, totalNeeded, address(safetyNet));
-    vm.prank(member1);
-    safetyNet.deposit(id, dep);
+    // Prefund up to `planned` while respecting per-epoch deposit caps
+    uint256 remaining = planned;
+    while (remaining > 0) {
+      uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+      if (due == 0) {
+        vm.warp(block.timestamp + cfg.epochDuration + 1);
+        continue;
+      }
+      uint256 pay = remaining > due ? due : remaining;
+      _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+      vm.prank(member1);
+      safetyNet.deposit(id, pay);
+      remaining -= pay;
+    }
 
     for (uint256 i = 0; i < cfg.smallWithdrawsLimit; i++) {
       vm.prank(member1);

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -37,8 +37,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
 
   // ── Case 1: Deposits — 1 per member per epoch; flag set; balance increases
   function _caseDeposit(uint256 id, address actor, uint256 seed) external {
-    // need the config to read initialDeposit
-    ISafetyNet.SafetyNet memory sn = safetyNet.getSafetyNet(id);
+    ISafetyNet.SafetyNet memory _safetyNet = safetyNet.getSafetyNet(id);
 
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
     uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
@@ -62,8 +61,8 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     vm.startPrank(actor);
     if (!safetyNet.hasMadeFirstDeposit(id, actor)) {
       // epoch 0 – must pay exactly initialDeposit
-      safetyNet.deposit(id, sn.initialDeposit);
-      depositedAmt = sn.initialDeposit;
+      safetyNet.deposit(id, _safetyNet.initialDeposit);
+      depositedAmt = _safetyNet.initialDeposit;
     } else {
       // subsequent epochs – partials allowed up to fixedDeposit
       // (dueBefore > 0 here, so picked ∈ [1, dueBefore])
@@ -72,8 +71,10 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     }
     vm.stopPrank();
 
+    // Re-check dues after the deposit and assert the flag reflects "fully paid"
+    uint256 dueAfter = safetyNet.duesRemainingThisEpoch(id, actor);
     bool paidAfter = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
-    assertEq(paidAfter, depositedAmt == dueBefore, 'flag only when epoch fully paid');
+    assertEq(paidAfter, dueAfter == 0, 'flag only when epoch fully paid');
 
     uint256 afterW = safetyNet.memberWithdrawableBalance(id, actor);
     assertEq(afterW, beforeW + depositedAmt, 'withdrawable += deposited amt');
@@ -199,16 +200,25 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 planned = (cfg.smallWithdrawsLimit + extraWithdraws) * perWithdraw;
     if (dep < planned) dep = planned;
 
-    // Prefund up to `planned` while respecting per-epoch deposit caps
+    // Prefund up to `planned` while respecting onboarding + per-epoch caps
     uint256 remaining = planned;
     while (remaining > 0) {
+      // First ever deposit must be EXACTLY initialDeposit, independent of epoch dues.
+      if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
+        _mintApprove(member1, cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+        vm.prank(member1);
+        safetyNet.deposit(id, cfg.initialDeposit);
+        continue;
+      }
+
+      // After onboarding, pay against this epoch’s remaining dues.
       uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
       if (due == 0) {
         vm.warp(block.timestamp + cfg.epochDuration + 1);
         continue;
       }
       uint256 pay = remaining > due ? due : remaining;
-      _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+      _mintApprove(member1, pay + cfg.fixedDeposit, address(safetyNet));
       vm.prank(member1);
       safetyNet.deposit(id, pay);
       remaining -= pay;

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -59,7 +59,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 depositedAmount;
 
     vm.startPrank(actor);
-    if (!_safetyNet.hasMadeFirstDeposit(id, actor)) {
+    if (_safetyNet.safetyNetMemberContribute(id, actor) == 0) {
       // epoch 0 – must pay exactly initialDeposit
       _safetyNet.deposit(id, safetyNetSnapshot.initialDeposit);
       depositedAmount = safetyNetSnapshot.initialDeposit;
@@ -204,7 +204,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 remaining = planned;
     while (remaining > 0) {
       // First ever deposit must be EXACTLY initialDeposit, independent of epoch dues.
-      if (!_safetyNet.hasMadeFirstDeposit(id, member1)) {
+      if (_safetyNet.safetyNetMemberContribute(id, member1) == 0) {
         _mintApprove(member1, config.initialDeposit + config.fixedDeposit, address(_safetyNet));
         vm.prank(member1);
         _safetyNet.deposit(id, config.initialDeposit);

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -9,15 +9,15 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     uint256 epochs = bound(uint256(epochsRaw), 2, 12);
     uint256 ops = bound(uint256(opsRaw), 5, 40);
 
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.members = defaultMembers;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.safetyNetStart = block.timestamp;
+    config.members = defaultMembers;
+    config.ratio = 1;
+    uint256 id = _safetyNet.create(config);
 
-    _mintApprove(member1, 1e24, address(safetyNet));
-    _mintApprove(member2, 1e24, address(safetyNet));
-    _mintApprove(member3, 1e24, address(safetyNet));
+    _mintApprove(member1, 1e24, address(_safetyNet));
+    _mintApprove(member2, 1e24, address(_safetyNet));
+    _mintApprove(member3, 1e24, address(_safetyNet));
 
     uint256 seed = uint256(keccak256(abi.encodePacked(block.timestamp, epochs, ops, extraSeed)));
 
@@ -26,92 +26,92 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
         address actor = _pick(defaultMembers, seed);
 
-        this._caseDeposit(id, actor, seed);
-        this._caseSmallWithdraw(id, actor, seed, cfg);
-        this._caseLargeWithdraw(id, actor, seed, cfg);
-        this._caseMaybeExecuteLatest(cfg, actor);
+        this.caseDeposit(id, actor, seed);
+        this.caseSmallWithdraw(id, actor, seed, config);
+        this.caseLargeWithdraw(id, actor, seed, config);
+        this.caseMaybeExecuteLatest(config, actor);
       }
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
     }
   }
 
   // ── Case 1: Deposits — 1 per member per epoch; flag set; balance increases
-  function _caseDeposit(uint256 id, address actor, uint256 seed) external {
-    ISafetyNet.SafetyNet memory _safetyNet = safetyNet.getSafetyNet(id);
+  function caseDeposit(uint256 id, address actor, uint256 seed) external {
+    ISafetyNet.SafetyNet memory safetyNetSnapshot = _safetyNet.getSafetyNet(id);
 
-    uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
-    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
-    uint256 dueBefore = safetyNet.duesRemainingThisEpoch(id, actor);
+    uint256 epochIndex = _safetyNet.getCurrentEpochIndex(id);
+    uint256 beforeWithdrawable = _safetyNet.memberWithdrawableBalance(id, actor);
+    uint256 duesRemainingBefore = _safetyNet.duesRemainingThisEpoch(id, actor);
 
-    if (dueBefore == 0) {
+    if (duesRemainingBefore == 0) {
       // already fully paid this epoch → any extra should exceed cap
       vm.prank(actor);
       vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
-      try safetyNet.deposit(id, 1) {} catch {}
+      try _safetyNet.deposit(id, 1) {} catch {}
       return;
     }
 
     // draw a positive amount within remaining due (used for non-onboarding path)
-    uint256 v = 1e18 + (seed % 1e18);
-    uint256 picked = v % (dueBefore + 1);
-    if (picked == 0) picked = dueBefore;
+    uint256 valueCandidate = 1e18 + (seed % 1e18);
+    uint256 pickedWithinDues = valueCandidate % (duesRemainingBefore + 1);
+    if (pickedWithinDues == 0) pickedWithinDues = duesRemainingBefore;
 
-    uint256 depositedAmt;
+    uint256 depositedAmount;
 
     vm.startPrank(actor);
-    if (!safetyNet.hasMadeFirstDeposit(id, actor)) {
+    if (!_safetyNet.hasMadeFirstDeposit(id, actor)) {
       // epoch 0 – must pay exactly initialDeposit
-      safetyNet.deposit(id, _safetyNet.initialDeposit);
-      depositedAmt = _safetyNet.initialDeposit;
+      _safetyNet.deposit(id, safetyNetSnapshot.initialDeposit);
+      depositedAmount = safetyNetSnapshot.initialDeposit;
     } else {
       // subsequent epochs – partials allowed up to fixedDeposit
-      // (dueBefore > 0 here, so picked ∈ [1, dueBefore])
-      safetyNet.deposit(id, picked);
-      depositedAmt = picked;
+      // (duesRemainingBefore > 0 here, so pickedWithinDues ∈ [1, duesRemainingBefore])
+      _safetyNet.deposit(id, pickedWithinDues);
+      depositedAmount = pickedWithinDues;
     }
     vm.stopPrank();
 
     // Re-check dues after the deposit and assert the flag reflects "fully paid"
-    uint256 dueAfter = safetyNet.duesRemainingThisEpoch(id, actor);
-    bool paidAfter = safetyNet.hasMemberDepositedInEpoch(id, actor, epochIdx);
-    assertEq(paidAfter, dueAfter == 0, 'flag only when epoch fully paid');
+    uint256 duesRemainingAfter = _safetyNet.duesRemainingThisEpoch(id, actor);
+    bool paidAfter = _safetyNet.hasMemberDepositedInEpoch(id, actor, epochIndex);
+    assertEq(paidAfter, duesRemainingAfter == 0, 'flag only when epoch fully paid');
 
-    uint256 afterW = safetyNet.memberWithdrawableBalance(id, actor);
-    assertEq(afterW, beforeW + depositedAmt, 'withdrawable += deposited amt');
+    uint256 afterWithdrawable = _safetyNet.memberWithdrawableBalance(id, actor);
+    assertEq(afterWithdrawable, beforeWithdrawable + depositedAmount, 'withdrawable += deposited amt');
   }
 
   // ── Case 2: Small withdrawals — within limit, ≤ autoThreshold, and ≤ balance
-  function _caseSmallWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
-    uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
-    uint256 contrib = safetyNet.safetyNetMemberContribute(id, actor);
-    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
+  function caseSmallWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory config) external {
+    uint256 epochIndex = _safetyNet.getCurrentEpochIndex(id);
+    uint256 contrib = _safetyNet.safetyNetMemberContribute(id, actor);
+    uint256 beforeWithdrawable = _safetyNet.memberWithdrawableBalance(id, actor);
 
     uint256 daysReq = 1 + (seed % 3);
     uint256 want = (contrib / 30) * daysReq;
 
-    uint256 cntBefore = safetyNet.smallWithdrawsCount(id, epochIdx, actor);
+    uint256 cntBefore = _safetyNet.smallWithdrawsCount(id, epochIndex, actor);
     uint256 balBefore = token.balanceOf(actor);
-    bool withinLimit = cntBefore < cfg.smallWithdrawsLimit;
-    bool smallByAmt = (want <= cfg.autoThreshold);
-    bool enoughBalance = (want <= beforeW);
+    bool withinLimit = cntBefore < config.smallWithdrawsLimit;
+    bool smallByAmt = (want <= config.autoThreshold);
+    bool enoughBalance = (want <= beforeWithdrawable);
 
     vm.prank(actor);
-    try safetyNet.withdraw(id, daysReq) {
-      uint256 nowW = safetyNet.memberWithdrawableBalance(id, actor);
+    try _safetyNet.withdraw(id, daysReq) {
+      uint256 nowW = _safetyNet.memberWithdrawableBalance(id, actor);
       uint256 balNow = token.balanceOf(actor);
-      uint256 cntNow = safetyNet.smallWithdrawsCount(id, epochIdx, actor);
+      uint256 cntNow = _safetyNet.smallWithdrawsCount(id, epochIndex, actor);
 
       if (want == 0) {
         // Intentional: zero-amount small withdraw still increments counter (balance unchanged)
-        assertEq(nowW, beforeW);
+        assertEq(nowW, beforeWithdrawable);
         assertEq(balNow, balBefore);
         assertEq(cntNow, cntBefore + 1);
-        _assertSmallCounterBound(id, epochIdx, actor, cfg.smallWithdrawsLimit);
+        _assertSmallCounterBound(id, epochIndex, actor, config.smallWithdrawsLimit);
       } else if (smallByAmt && withinLimit && enoughBalance) {
-        assertEq(beforeW - nowW, want);
+        assertEq(beforeWithdrawable - nowW, want);
         assertEq(balNow - balBefore, want);
         assertEq(cntNow, cntBefore + 1);
-        _assertSmallCounterBound(id, epochIdx, actor, cfg.smallWithdrawsLimit);
+        _assertSmallCounterBound(id, epochIndex, actor, config.smallWithdrawsLimit);
       } else {
         assertTrue(false, 'withdraw succeeded though conditions not met');
       }
@@ -119,67 +119,67 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
   }
 
   // ── Case 3: Large withdrawals — create a request; execution after contest window
-  function _caseLargeWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory cfg) external {
-    uint256 contrib = safetyNet.safetyNetMemberContribute(id, actor);
-    uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
+  function caseLargeWithdraw(uint256 id, address actor, uint256 seed, ISafetyNet.SafetyNet memory config) external {
+    uint256 contrib = _safetyNet.safetyNetMemberContribute(id, actor);
+    uint256 beforeWithdrawable = _safetyNet.memberWithdrawableBalance(id, actor);
     uint256 daysReq = 40 + (seed % 40);
     uint256 want = (contrib / 30) * daysReq;
 
-    uint256 reqsBefore = safetyNet.nextIdRequest();
+    uint256 reqsBefore = _safetyNet.nextIdRequest();
 
     vm.prank(actor);
-    try safetyNet.withdraw(id, daysReq) {
-      uint256 reqsAfter = safetyNet.nextIdRequest();
-      if (want > cfg.autoThreshold) {
-        if (want <= beforeW && want > 0) {
+    try _safetyNet.withdraw(id, daysReq) {
+      uint256 reqsAfter = _safetyNet.nextIdRequest();
+      if (want > config.autoThreshold) {
+        if (want <= beforeWithdrawable && want > 0) {
           assertEq(reqsAfter, reqsBefore + 1, 'large creates request');
           uint256 reqId = reqsAfter - 1;
-          (address owner,, uint256 ts, uint256 yesVotes, uint256 noVotes, uint256 amount) = safetyNet.requests(reqId);
+          (address owner,, uint256 ts, uint256 yesVotes, uint256 noVotes, uint256 amount) = _safetyNet.requests(reqId);
           assertEq(owner, actor);
           assertEq(amount, want);
           assertEq(yesVotes, 0);
           assertEq(noVotes, 0);
           assertGe(block.timestamp, ts);
-          assertFalse(safetyNet.isExecuted(reqId));
+          assertFalse(_safetyNet.isExecuted(reqId));
 
           if ((seed & 1) == 1) {
-            vm.warp(block.timestamp + cfg.contestWindow + 1);
+            vm.warp(block.timestamp + config.contestWindow + 1);
             vm.prank(actor);
-            try safetyNet.executeContestedWithdrawal(reqId) {
-              assertTrue(safetyNet.isExecuted(reqId));
+            try _safetyNet.executeContestedWithdrawal(reqId) {
+              assertTrue(_safetyNet.isExecuted(reqId));
             } catch {}
           }
         } else {
-          assertEq(safetyNet.nextIdRequest(), reqsBefore, 'no request if insufficient');
+          assertEq(_safetyNet.nextIdRequest(), reqsBefore, 'no request if insufficient');
         }
       }
     } catch {}
   }
 
   // ── Case 4: Request execution attempt — only possible after contest window
-  function _caseMaybeExecuteLatest(ISafetyNet.SafetyNet memory cfg, address actor) external {
-    uint256 nReq = safetyNet.nextIdRequest();
+  function caseMaybeExecuteLatest(ISafetyNet.SafetyNet memory config, address actor) external {
+    uint256 nReq = _safetyNet.nextIdRequest();
     if (nReq == 0) return;
 
     uint256 reqId = nReq - 1;
-    vm.warp(block.timestamp + cfg.contestWindow + 1);
+    vm.warp(block.timestamp + config.contestWindow + 1);
     vm.prank(actor);
-    try safetyNet.executeContestedWithdrawal(reqId) {} catch {}
+    try _safetyNet.executeContestedWithdrawal(reqId) {} catch {}
   }
 
   /// Small-withdraw limit fuzzing
   function testFuzz_SmallWithdrawsRespectLimit(uint8 daysReqRaw, uint8 extraWithdrawsRaw) public {
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = defaultMembers;
-    cfg.ratio = 1;
-    cfg.safetyNetStart = block.timestamp;
-    uint256 id = safetyNet.create(cfg);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = defaultMembers;
+    config.ratio = 1;
+    config.safetyNetStart = block.timestamp;
+    uint256 id = _safetyNet.create(config);
 
     uint256 daysRequested = bound(uint256(daysReqRaw), 1, 3);
     uint256 extraWithdraws = bound(uint256(extraWithdrawsRaw), 0, 2);
 
     // craft deposit size so each withdraw is under autoThreshold
-    uint256 perWithdrawCap = (cfg.autoThreshold - 1) / 4;
+    uint256 perWithdrawCap = (config.autoThreshold - 1) / 4;
     if (perWithdrawCap == 0) perWithdrawCap = 1;
 
     uint256 dep = (perWithdrawCap * 30) / daysRequested;
@@ -197,47 +197,47 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
       }
     }
 
-    uint256 planned = (cfg.smallWithdrawsLimit + extraWithdraws) * perWithdraw;
+    uint256 planned = (config.smallWithdrawsLimit + extraWithdraws) * perWithdraw;
     if (dep < planned) dep = planned;
 
     // Prefund up to `planned` while respecting onboarding + per-epoch caps
     uint256 remaining = planned;
     while (remaining > 0) {
       // First ever deposit must be EXACTLY initialDeposit, independent of epoch dues.
-      if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
-        _mintApprove(member1, cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+      if (!_safetyNet.hasMadeFirstDeposit(id, member1)) {
+        _mintApprove(member1, config.initialDeposit + config.fixedDeposit, address(_safetyNet));
         vm.prank(member1);
-        safetyNet.deposit(id, cfg.initialDeposit);
+        _safetyNet.deposit(id, config.initialDeposit);
         continue;
       }
 
       // After onboarding, pay against this epoch’s remaining dues.
-      uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
+      uint256 due = _safetyNet.duesRemainingThisEpoch(id, member1);
       if (due == 0) {
-        vm.warp(block.timestamp + cfg.epochDuration + 1);
+        vm.warp(block.timestamp + config.epochDuration + 1);
         continue;
       }
       uint256 pay = remaining > due ? due : remaining;
-      _mintApprove(member1, pay + cfg.fixedDeposit, address(safetyNet));
+      _mintApprove(member1, pay + config.fixedDeposit, address(_safetyNet));
       vm.prank(member1);
-      safetyNet.deposit(id, pay);
+      _safetyNet.deposit(id, pay);
       remaining -= pay;
     }
 
-    for (uint256 i = 0; i < cfg.smallWithdrawsLimit; i++) {
+    for (uint256 i = 0; i < config.smallWithdrawsLimit; i++) {
       vm.prank(member1);
-      safetyNet.withdraw(id, daysRequested);
+      _safetyNet.withdraw(id, daysRequested);
     }
 
     for (uint256 j = 0; j < extraWithdraws; j++) {
       vm.prank(member1);
       vm.expectRevert(ISafetyNet.ExceedsSmallWithdrawalLimit.selector);
-      safetyNet.withdraw(id, daysRequested);
+      _safetyNet.withdraw(id, daysRequested);
     }
 
     // After advancing to new epoch, limit resets
-    vm.warp(block.timestamp + cfg.epochDuration + 1);
+    vm.warp(block.timestamp + config.epochDuration + 1);
     vm.prank(member1);
-    safetyNet.withdraw(id, daysRequested);
+    _safetyNet.withdraw(id, daysRequested);
   }
 }

--- a/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_DepositWithdraw.t.sol
@@ -39,7 +39,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
   function _caseDeposit(uint256 id, address actor, uint256 seed) external {
     uint256 epochIdx = safetyNet.getCurrentEpochIndex(id);
     uint256 beforeW = safetyNet.memberWithdrawableBalance(id, actor);
-    uint256 dueBefore = safetyNet.dueRemainingThisEpoch(id, actor);
+    uint256 dueBefore = safetyNet.duesRemainingThisEpoch(id, actor);
 
     if (dueBefore == 0) {
       vm.prank(actor);
@@ -186,7 +186,7 @@ contract SafetyNetFuzz_DepositWithdraw is SafetyNetFuzzBase {
     // Prefund up to `planned` while respecting per-epoch deposit caps
     uint256 remaining = planned;
     while (remaining > 0) {
-      uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+      uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
       if (due == 0) {
         vm.warp(block.timestamp + cfg.epochDuration + 1);
         continue;

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -15,131 +15,131 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   function testFuzz_LargeWithdrawal_RequestAndAutoExecute(uint256 depositValueRaw, uint8 extraDaysRaw) public {
     uint256 depositValue = bound(depositValueRaw, 5e18, 1e22);
 
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = defaultMembers;
-    cfg.ratio = 1;
-    cfg.autoThreshold = 1;
-    cfg.safetyNetStart = block.timestamp;
-    uint256 id = safetyNet.create(cfg);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = defaultMembers;
+    config.ratio = 1;
+    config.autoThreshold = 1;
+    config.safetyNetStart = block.timestamp;
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
+    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
     if (due == 0) {
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due = safetyNet.duesRemainingThisEpoch(id, member1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
+      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
-    _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
+    _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, member1)) {
       vm.prank(member1);
-      safetyNet.deposit(id, cfg.initialDeposit);
+      _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
       vm.prank(member1);
-      safetyNet.deposit(id, pay);
+      _safetyNet.deposit(safetyNetId, pay);
     }
 
     // Choose a daysRequested that ensures "large" classification.
-    safetyNet.safetyNetMemberContribute(id, member1);
+    _safetyNet.safetyNetMemberContribute(safetyNetId, member1);
     uint256 daysRequested = 1 + (uint256(extraDaysRaw) % 5);
 
     vm.prank(member1);
-    safetyNet.withdraw(id, daysRequested);
-    uint256 n = safetyNet.nextIdRequest();
-    assertGt(n, 0, 'expected a request');
-    uint256 reqId = n - 1;
+    _safetyNet.withdraw(safetyNetId, daysRequested);
+    uint256 requestCount = _safetyNet.nextIdRequest();
+    assertGt(requestCount, 0, 'expected a request');
+    uint256 requestId = requestCount - 1;
 
-    vm.warp(block.timestamp + cfg.contestWindow + 1);
+    vm.warp(block.timestamp + config.contestWindow + 1);
 
-    uint256 balBefore = token.balanceOf(member1);
+    uint256 balanceBefore = token.balanceOf(member1);
     vm.prank(member2);
-    safetyNet.executeContestedWithdrawal(reqId);
-    uint256 balAfter = token.balanceOf(member1);
+    _safetyNet.executeContestedWithdrawal(requestId);
+    uint256 balanceAfter = token.balanceOf(member1);
 
-    assertGt(balAfter, balBefore);
-    assertTrue(safetyNet.isExecuted(reqId));
+    assertGt(balanceAfter, balanceBefore);
+    assertTrue(_safetyNet.isExecuted(requestId));
   }
 
   /// -------------------------------------------------------------------------
   /// Property-based: Voting threshold boundary.
-  /// For m members and threshold T%, exactly floor(m*T/100) YES must NOT execute;
+  /// For memberCount members and threshold T%, exactly floor(memberCount*T/100) YES must NOT execute;
   /// strictly more than that must execute.
   /// -------------------------------------------------------------------------
   function testFuzz_Voting_ThresholdBoundary(uint8 membersRaw, uint8 consensusPctRaw) public {
-    uint256 m = bound(uint256(membersRaw), 3, 20);
+    uint256 memberCount = bound(uint256(membersRaw), 3, 20);
     uint256 consensus = bound(uint256(consensusPctRaw), 1, 99);
 
-    address[] memory members = _makeMembers(m);
+    address[] memory members = _makeMembers(memberCount);
 
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.consensusThreshold = consensus;
-    cfg.autoThreshold = 1;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.votingWindow = 7 days;
-    cfg.contestWindow = 7 days;
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.consensusThreshold = consensus;
+    config.autoThreshold = 1;
+    config.safetyNetStart = block.timestamp;
+    config.votingWindow = 7 days;
+    config.contestWindow = 7 days;
 
-    uint256 id = safetyNet.create(cfg);
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    // Seed deposits for members[1..m-1]
+    // Seed deposits for members[1..memberCount-1]
     uint256 depEach = 2e18;
-    for (uint256 i = 1; i < m; i++) {
-      uint256 dueI = safetyNet.duesRemainingThisEpoch(id, members[i]);
+    for (uint256 i = 1; i < memberCount; i++) {
+      uint256 dueI = _safetyNet.duesRemainingThisEpoch(safetyNetId, members[i]);
       if (dueI > 0) {
         uint256 payI = depEach > dueI ? dueI : depEach;
-        _mintApprove(members[i], payI + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-        if (!safetyNet.hasMadeFirstDeposit(id, members[i])) {
+        _mintApprove(members[i], payI + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+        if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[i])) {
           vm.prank(members[i]);
-          safetyNet.deposit(id, cfg.initialDeposit);
+          _safetyNet.deposit(safetyNetId, config.initialDeposit);
         } else {
           vm.prank(members[i]);
-          safetyNet.deposit(id, payI);
+          _safetyNet.deposit(safetyNetId, payI);
         }
       }
     }
 
     // Single (larger) deposit for members[0] so we can make a large request
-    uint256 due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
+    uint256 due0 = _safetyNet.duesRemainingThisEpoch(safetyNetId, members[0]);
     if (due0 == 0) {
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
+      vm.warp(block.timestamp + config.epochDuration + 1);
+      due0 = _safetyNet.duesRemainingThisEpoch(safetyNetId, members[0]);
     }
 
     uint256 depositValue0 = 3e18;
     uint256 pay0 = depositValue0 > due0 ? due0 : depositValue0;
-    _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    if (!safetyNet.hasMadeFirstDeposit(id, members[0])) {
+    _mintApprove(members[0], pay0 + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[0])) {
       vm.prank(members[0]);
-      safetyNet.deposit(id, cfg.initialDeposit);
+      _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
       vm.prank(members[0]);
-      safetyNet.deposit(id, pay0);
+      _safetyNet.deposit(safetyNetId, pay0);
     }
 
     uint256 daysRequested = 1;
 
     vm.prank(members[0]);
-    safetyNet.withdraw(id, daysRequested);
-    uint256 n = safetyNet.nextIdRequest();
-    assertGt(n, 0, 'expected a request');
-    uint256 reqId = n - 1;
+    _safetyNet.withdraw(safetyNetId, daysRequested);
+    uint256 requestCount = _safetyNet.nextIdRequest();
+    assertGt(requestCount, 0, 'expected a request');
+    uint256 requestId = requestCount - 1;
 
     // Exactly threshold YES votes (floor).
-    uint256 needed = (m * consensus) / 100; // floor
-    for (uint256 i = 1; i <= needed && i < m; i++) {
+    uint256 needed = (memberCount * consensus) / 100; // floor
+    for (uint256 i = 1; i <= needed && i < memberCount; i++) {
       vm.prank(members[i]);
-      safetyNet.vote(reqId, true);
+      _safetyNet.vote(requestId, true);
     }
-    assertFalse(safetyNet.isExecuted(reqId), '== threshold must not execute');
+    assertFalse(_safetyNet.isExecuted(requestId), '== threshold must not execute');
 
     // One more YES crosses the threshold.
-    if (needed + 1 < m) {
-      uint256 balBefore = token.balanceOf(members[0]);
+    if (needed + 1 < memberCount) {
+      uint256 balanceBefore = token.balanceOf(members[0]);
       vm.prank(members[needed + 1]);
-      safetyNet.vote(reqId, true);
-      assertTrue(safetyNet.isExecuted(reqId), '> threshold executes');
-      uint256 balAfter = token.balanceOf(members[0]);
-      assertGt(balAfter, balBefore);
+      _safetyNet.vote(requestId, true);
+      assertTrue(_safetyNet.isExecuted(requestId), '> threshold executes');
+      uint256 balanceAfter = token.balanceOf(members[0]);
+      assertGt(balanceAfter, balanceBefore);
     }
   }
 
@@ -154,76 +154,76 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 votingWin = bound(uint256(votingSecsRaw), 1 hours, 3 days);
     uint256 contestWin = bound(uint256(contestSecsRaw), 1 hours, 3 days);
 
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = defaultMembers;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.votingWindow = votingWin;
-    cfg.contestWindow = contestWin;
-    cfg.ratio = 1;
-    cfg.autoThreshold = 1;
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = defaultMembers;
+    config.safetyNetStart = block.timestamp;
+    config.votingWindow = votingWin;
+    config.contestWindow = contestWin;
+    config.ratio = 1;
+    config.autoThreshold = 1;
 
-    uint256 id = safetyNet.create(cfg);
+    uint256 safetyNetId = _safetyNet.create(config);
 
     // Fund member1 and create a "large" request.
     uint256 depositValue = 2e18;
-    uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
+    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
     if (due == 0) {
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due = safetyNet.duesRemainingThisEpoch(id, member1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
+      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
-    _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
+    _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, member1)) {
       vm.prank(member1);
-      safetyNet.deposit(id, cfg.initialDeposit);
+      _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
       vm.prank(member1);
-      safetyNet.deposit(id, pay);
+      _safetyNet.deposit(safetyNetId, pay);
     }
 
     uint256 daysRequested = 1;
 
     vm.prank(member1);
-    safetyNet.withdraw(id, daysRequested);
-    uint256 n = safetyNet.nextIdRequest();
-    assertGt(n, 0, 'expected a request');
-    uint256 reqId = n - 1;
+    _safetyNet.withdraw(safetyNetId, daysRequested);
+    uint256 requestCount = _safetyNet.nextIdRequest();
+    assertGt(requestCount, 0, 'expected a request');
+    uint256 requestId = requestCount - 1;
 
     // Only members may vote.
     address outsider = address(0xDEAD);
     vm.prank(outsider);
     vm.expectRevert(ISafetyNet.NotMember.selector);
-    safetyNet.vote(reqId, true);
+    _safetyNet.vote(requestId, true);
 
     // No double voting.
     vm.prank(member2);
-    safetyNet.vote(reqId, true);
+    _safetyNet.vote(requestId, true);
     vm.prank(member2);
     vm.expectRevert(ISafetyNet.AlreadyVoted.selector);
-    safetyNet.vote(reqId, true);
+    _safetyNet.vote(requestId, true);
 
     // Voting must be within the window.
     vm.warp(block.timestamp + votingWin + 1);
     vm.prank(member3);
     vm.expectRevert(ISafetyNet.VotingWindowClosed.selector);
-    safetyNet.vote(reqId, true);
+    _safetyNet.vote(requestId, true);
 
     // New request that gets contested; verify it does not auto-execute after timeout.
     vm.prank(member1);
-    safetyNet.withdraw(id, daysRequested);
-    uint256 n2 = safetyNet.nextIdRequest();
+    _safetyNet.withdraw(safetyNetId, daysRequested);
+    uint256 n2 = _safetyNet.nextIdRequest();
     assertGt(n2, 0, 'expected a request');
     uint256 req2 = n2 - 1;
 
     vm.prank(member2);
-    safetyNet.contest(req2);
+    _safetyNet.contest(req2);
 
     vm.warp(block.timestamp + contestWin + 1);
 
     // Attempt execution; it should not mark executed for contested request.
     vm.prank(member3);
-    try safetyNet.executeContestedWithdrawal(req2) {} catch {}
-    assertFalse(safetyNet.isExecuted(req2), 'contested request must not auto-execute');
+    try _safetyNet.executeContestedWithdrawal(req2) {} catch {}
+    assertFalse(_safetyNet.isExecuted(req2), 'contested request must not auto-execute');
   }
 
   /// -------------------------------------------------------------------------
@@ -239,68 +239,68 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint8 yesBiasRaw,
     uint256 randSeed
   ) public {
-    uint256 m = bound(uint256(memberCountRaw), 3, 20);
+    uint256 memberCount = bound(uint256(memberCountRaw), 3, 20);
     uint256 consensus = bound(uint256(consensusPctRaw), 1, 99);
     uint256 yesBias = bound(uint256(yesBiasRaw), 0, 100);
 
-    address[] memory members = _makeMembers(m);
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.consensusThreshold = consensus;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.votingWindow = 1 days;
-    cfg.contestWindow = 1 days;
-    cfg.autoThreshold = 1;
-    uint256 id = safetyNet.create(cfg);
+    address[] memory members = _makeMembers(memberCount);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.consensusThreshold = consensus;
+    config.safetyNetStart = block.timestamp;
+    config.votingWindow = 1 days;
+    config.contestWindow = 1 days;
+    config.autoThreshold = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
     // Seed balances; ignore per-member deposit failure to keep exploring.
-    for (uint256 i = 0; i < m; i++) {
-      _mintApprove(members[i], 5e21, address(safetyNet));
+    for (uint256 i = 0; i < memberCount; i++) {
+      _mintApprove(members[i], 5e21, address(_safetyNet));
       vm.prank(members[i]);
-      try safetyNet.deposit(id, 5e18) {} catch {}
+      try _safetyNet.deposit(safetyNetId, 5e18) {} catch {}
     }
 
-    uint256 due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
+    uint256 due0 = _safetyNet.duesRemainingThisEpoch(safetyNetId, members[0]);
     if (due0 == 0) {
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
+      vm.warp(block.timestamp + config.epochDuration + 1);
+      due0 = _safetyNet.duesRemainingThisEpoch(safetyNetId, members[0]);
     }
     uint256 depositValue = 5e18;
     uint256 pay0 = depositValue > due0 ? due0 : depositValue;
-    _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    if (!safetyNet.hasMadeFirstDeposit(id, members[0])) {
+    _mintApprove(members[0], pay0 + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[0])) {
       vm.prank(members[0]);
-      safetyNet.deposit(id, cfg.initialDeposit);
+      _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
       vm.prank(members[0]);
-      safetyNet.deposit(id, pay0);
+      _safetyNet.deposit(safetyNetId, pay0);
     }
 
     // With tiny autoThreshold, any positive withdrawal amount will be "large"
     uint256 daysRequested = 1;
 
     vm.prank(members[0]);
-    safetyNet.withdraw(id, daysRequested);
-    uint256 n = safetyNet.nextIdRequest();
-    assertGt(n, 0, 'expected a request');
-    uint256 reqId = n - 1;
+    _safetyNet.withdraw(safetyNetId, daysRequested);
+    uint256 requestCount = _safetyNet.nextIdRequest();
+    assertGt(requestCount, 0, 'expected a request');
+    uint256 requestId = requestCount - 1;
 
     // Randomized voting pass
-    for (uint256 i = 0; i < m && !safetyNet.isExecuted(reqId); i++) {
+    for (uint256 i = 0; i < memberCount && !_safetyNet.isExecuted(requestId); i++) {
       address voter = members[i];
       randSeed = uint256(keccak256(abi.encodePacked(randSeed, i)));
       bool voteYes = (randSeed % 100) < yesBias;
       vm.prank(voter);
-      try safetyNet.vote(reqId, voteYes) {} catch {}
+      try _safetyNet.vote(requestId, voteYes) {} catch {}
     }
 
     // If not executed by consensus, try after contest window.
-    if (!safetyNet.isExecuted(reqId)) {
-      vm.warp(block.timestamp + cfg.contestWindow + 1);
-      vm.prank(members[m - 1]);
-      try safetyNet.executeContestedWithdrawal(reqId) {} catch {}
+    if (!_safetyNet.isExecuted(requestId)) {
+      vm.warp(block.timestamp + config.contestWindow + 1);
+      vm.prank(members[memberCount - 1]);
+      try _safetyNet.executeContestedWithdrawal(requestId) {} catch {}
     }
 
     assertTrue(true); // sanity: no catastrophic revert

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -33,7 +33,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     safetyNet.deposit(id, pay);
 
     // Choose a daysRequested that ensures "large" classification.
-    uint256 contrib = safetyNet.safetyNetMemberContribute(id, member1);
+    safetyNet.safetyNetMemberContribute(id, member1);
     uint256 daysRequested = 1 + (uint256(extraDaysRaw) % 5);
 
     vm.prank(member1);

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -15,33 +15,33 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
   function testFuzz_LargeWithdrawal_RequestAndAutoExecute(uint256 depositValueRaw, uint8 extraDaysRaw) public {
     uint256 depositValue = bound(depositValueRaw, 5e18, 1e22);
 
-    ISafetyNet.SafetyNet memory config = safeCfg;
-    config.members = defaultMembers;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
+    config.members = _defaultMembers;
     config.ratio = 1;
     config.autoThreshold = 1;
     config.safetyNetStart = block.timestamp;
     uint256 safetyNetId = _safetyNet.create(config);
 
-    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
+    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, _member1);
     if (due == 0) {
       vm.warp(block.timestamp + config.epochDuration + 1);
-      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
+      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, _member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
-    _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (_safetyNet.safetyNetMemberContribute(safetyNetId, member1) == 0) {
-      vm.prank(member1);
+    _mintApprove(_member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, _member1) == 0) {
+      vm.prank(_member1);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
-      vm.prank(member1);
+      vm.prank(_member1);
       _safetyNet.deposit(safetyNetId, pay);
     }
 
     // Choose a daysRequested that ensures "large" classification.
-    _safetyNet.safetyNetMemberContribute(safetyNetId, member1);
+    _safetyNet.safetyNetMemberContribute(safetyNetId, _member1);
     uint256 daysRequested = 1 + (uint256(extraDaysRaw) % 5);
 
-    vm.prank(member1);
+    vm.prank(_member1);
     _safetyNet.withdraw(safetyNetId, daysRequested);
     uint256 requestCount = _safetyNet.nextIdRequest();
     assertGt(requestCount, 0, 'expected a request');
@@ -49,10 +49,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     vm.warp(block.timestamp + config.contestWindow + 1);
 
-    uint256 balanceBefore = token.balanceOf(member1);
-    vm.prank(member2);
+    uint256 balanceBefore = _token.balanceOf(_member1);
+    vm.prank(_member2);
     _safetyNet.executeContestedWithdrawal(requestId);
-    uint256 balanceAfter = token.balanceOf(member1);
+    uint256 balanceAfter = _token.balanceOf(_member1);
 
     assertGt(balanceAfter, balanceBefore);
     assertTrue(_safetyNet.isExecuted(requestId));
@@ -69,7 +69,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     address[] memory members = _makeMembers(memberCount);
 
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;
@@ -134,11 +134,11 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     // One more YES crosses the threshold.
     if (needed + 1 < memberCount) {
-      uint256 balanceBefore = token.balanceOf(members[0]);
+      uint256 balanceBefore = _token.balanceOf(members[0]);
       vm.prank(members[needed + 1]);
       _safetyNet.vote(requestId, true);
       assertTrue(_safetyNet.isExecuted(requestId), '> threshold executes');
-      uint256 balanceAfter = token.balanceOf(members[0]);
+      uint256 balanceAfter = _token.balanceOf(members[0]);
       assertGt(balanceAfter, balanceBefore);
     }
   }
@@ -154,8 +154,8 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 votingWin = bound(uint256(votingSecsRaw), 1 hours, 3 days);
     uint256 contestWin = bound(uint256(contestSecsRaw), 1 hours, 3 days);
 
-    ISafetyNet.SafetyNet memory config = safeCfg;
-    config.members = defaultMembers;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
+    config.members = _defaultMembers;
     config.safetyNetStart = block.timestamp;
     config.votingWindow = votingWin;
     config.contestWindow = contestWin;
@@ -164,26 +164,26 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     uint256 safetyNetId = _safetyNet.create(config);
 
-    // Fund member1 and create a "large" request.
+    // Fund _member1 and create a "large" request.
     uint256 depositValue = 2e18;
-    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
+    uint256 due = _safetyNet.duesRemainingThisEpoch(safetyNetId, _member1);
     if (due == 0) {
       vm.warp(block.timestamp + config.epochDuration + 1);
-      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, member1);
+      due = _safetyNet.duesRemainingThisEpoch(safetyNetId, _member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
-    _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (_safetyNet.safetyNetMemberContribute(safetyNetId, member1) == 0) {
-      vm.prank(member1);
+    _mintApprove(_member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, _member1) == 0) {
+      vm.prank(_member1);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
-      vm.prank(member1);
+      vm.prank(_member1);
       _safetyNet.deposit(safetyNetId, pay);
     }
 
     uint256 daysRequested = 1;
 
-    vm.prank(member1);
+    vm.prank(_member1);
     _safetyNet.withdraw(safetyNetId, daysRequested);
     uint256 requestCount = _safetyNet.nextIdRequest();
     assertGt(requestCount, 0, 'expected a request');
@@ -196,32 +196,32 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     _safetyNet.vote(requestId, true);
 
     // No double voting.
-    vm.prank(member2);
+    vm.prank(_member2);
     _safetyNet.vote(requestId, true);
-    vm.prank(member2);
+    vm.prank(_member2);
     vm.expectRevert(ISafetyNet.AlreadyVoted.selector);
     _safetyNet.vote(requestId, true);
 
     // Voting must be within the window.
     vm.warp(block.timestamp + votingWin + 1);
-    vm.prank(member3);
+    vm.prank(_member3);
     vm.expectRevert(ISafetyNet.VotingWindowClosed.selector);
     _safetyNet.vote(requestId, true);
 
     // New request that gets contested; verify it does not auto-execute after timeout.
-    vm.prank(member1);
+    vm.prank(_member1);
     _safetyNet.withdraw(safetyNetId, daysRequested);
     uint256 n2 = _safetyNet.nextIdRequest();
     assertGt(n2, 0, 'expected a request');
     uint256 req2 = n2 - 1;
 
-    vm.prank(member2);
+    vm.prank(_member2);
     _safetyNet.contest(req2);
 
     vm.warp(block.timestamp + contestWin + 1);
 
     // Attempt execution; it should not mark executed for contested request.
-    vm.prank(member3);
+    vm.prank(_member3);
     try _safetyNet.executeContestedWithdrawal(req2) {} catch {}
     assertFalse(_safetyNet.isExecuted(req2), 'contested request must not auto-execute');
   }
@@ -244,7 +244,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 yesBias = bound(uint256(yesBiasRaw), 0, 100);
 
     address[] memory members = _makeMembers(memberCount);
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -29,8 +29,13 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    vm.prank(member1);
-    safetyNet.deposit(id, pay);
+    if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
+      vm.prank(member1);
+      safetyNet.deposit(id, cfg.initialDeposit);
+    } else {
+      vm.prank(member1);
+      safetyNet.deposit(id, pay);
+    }
 
     // Choose a daysRequested that ensures "large" classification.
     safetyNet.safetyNetMemberContribute(id, member1);
@@ -83,8 +88,13 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       if (dueI > 0) {
         uint256 payI = depEach > dueI ? dueI : depEach;
         _mintApprove(members[i], payI + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-        vm.prank(members[i]);
-        safetyNet.deposit(id, payI);
+        if (!safetyNet.hasMadeFirstDeposit(id, members[i])) {
+          vm.prank(members[i]);
+          safetyNet.deposit(id, cfg.initialDeposit);
+        } else {
+          vm.prank(members[i]);
+          safetyNet.deposit(id, payI);
+        }
       }
     }
 
@@ -98,8 +108,13 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 depositValue0 = 3e18;
     uint256 pay0 = depositValue0 > due0 ? due0 : depositValue0;
     _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    vm.prank(members[0]);
-    safetyNet.deposit(id, pay0);
+    if (!safetyNet.hasMadeFirstDeposit(id, members[0])) {
+      vm.prank(members[0]);
+      safetyNet.deposit(id, cfg.initialDeposit);
+    } else {
+      vm.prank(members[0]);
+      safetyNet.deposit(id, pay0);
+    }
 
     uint256 daysRequested = 1;
 
@@ -158,8 +173,13 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    vm.prank(member1);
-    safetyNet.deposit(id, pay);
+    if (!safetyNet.hasMadeFirstDeposit(id, member1)) {
+      vm.prank(member1);
+      safetyNet.deposit(id, cfg.initialDeposit);
+    } else {
+      vm.prank(member1);
+      safetyNet.deposit(id, pay);
+    }
 
     uint256 daysRequested = 1;
 
@@ -250,8 +270,13 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 depositValue = 5e18;
     uint256 pay0 = depositValue > due0 ? due0 : depositValue;
     _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    vm.prank(members[0]);
-    safetyNet.deposit(id, pay0);
+    if (!safetyNet.hasMadeFirstDeposit(id, members[0])) {
+      vm.prank(members[0]);
+      safetyNet.deposit(id, cfg.initialDeposit);
+    } else {
+      vm.prank(members[0]);
+      safetyNet.deposit(id, pay0);
+    }
 
     // With tiny autoThreshold, any positive withdrawal amount will be "large"
     uint256 daysRequested = 1;

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -29,7 +29,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, member1)) {
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, member1) == 0) {
       vm.prank(member1);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
@@ -88,7 +88,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       if (dueI > 0) {
         uint256 payI = depEach > dueI ? dueI : depEach;
         _mintApprove(members[i], payI + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-        if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[i])) {
+        if (_safetyNet.safetyNetMemberContribute(safetyNetId, members[i]) == 0) {
           vm.prank(members[i]);
           _safetyNet.deposit(safetyNetId, config.initialDeposit);
         } else {
@@ -108,7 +108,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 depositValue0 = 3e18;
     uint256 pay0 = depositValue0 > due0 ? due0 : depositValue0;
     _mintApprove(members[0], pay0 + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[0])) {
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, members[0]) == 0) {
       vm.prank(members[0]);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
@@ -173,7 +173,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, member1)) {
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, member1) == 0) {
       vm.prank(member1);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {
@@ -270,7 +270,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     uint256 depositValue = 5e18;
     uint256 pay0 = depositValue > due0 ? due0 : depositValue;
     _mintApprove(members[0], pay0 + config.initialDeposit + config.fixedDeposit, address(_safetyNet));
-    if (!_safetyNet.hasMadeFirstDeposit(safetyNetId, members[0])) {
+    if (_safetyNet.safetyNetMemberContribute(safetyNetId, members[0]) == 0) {
       vm.prank(members[0]);
       _safetyNet.deposit(safetyNetId, config.initialDeposit);
     } else {

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -22,10 +22,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     cfg.safetyNetStart = block.timestamp;
     uint256 id = safetyNet.create(cfg);
 
-    uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+    uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
     if (due == 0) {
       vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due = safetyNet.dueRemainingThisEpoch(id, member1);
+      due = safetyNet.duesRemainingThisEpoch(id, member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
@@ -79,7 +79,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     // Seed deposits for members[1..m-1]
     uint256 depEach = 2e18;
     for (uint256 i = 1; i < m; i++) {
-      uint256 dueI = safetyNet.dueRemainingThisEpoch(id, members[i]);
+      uint256 dueI = safetyNet.duesRemainingThisEpoch(id, members[i]);
       if (dueI > 0) {
         uint256 payI = depEach > dueI ? dueI : depEach;
         _mintApprove(members[i], payI + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
@@ -89,10 +89,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     }
 
     // Single (larger) deposit for members[0] so we can make a large request
-    uint256 due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    uint256 due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
     if (due0 == 0) {
       vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+      due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
     }
 
     uint256 depositValue0 = 3e18;
@@ -151,10 +151,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
 
     // Fund member1 and create a "large" request.
     uint256 depositValue = 2e18;
-    uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+    uint256 due = safetyNet.duesRemainingThisEpoch(id, member1);
     if (due == 0) {
       vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due = safetyNet.dueRemainingThisEpoch(id, member1);
+      due = safetyNet.duesRemainingThisEpoch(id, member1);
     }
     uint256 pay = depositValue > due ? due : depositValue;
     _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
@@ -242,10 +242,10 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       try safetyNet.deposit(id, 5e18) {} catch {}
     }
 
-    uint256 due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    uint256 due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
     if (due0 == 0) {
       vm.warp(block.timestamp + cfg.epochDuration + 1);
-      due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+      due0 = safetyNet.duesRemainingThisEpoch(id, members[0]);
     }
     uint256 depositValue = 5e18;
     uint256 pay0 = depositValue > due0 ? due0 : depositValue;

--- a/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_RequestsVoting.t.sol
@@ -18,23 +18,29 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     ISafetyNet.SafetyNet memory cfg = safeCfg;
     cfg.members = defaultMembers;
     cfg.ratio = 1;
+    cfg.autoThreshold = 1;
     cfg.safetyNetStart = block.timestamp;
     uint256 id = safetyNet.create(cfg);
 
-    uint256 totalNeeded = depositValue + cfg.initialDeposit + cfg.fixedDeposit;
-    _mintApprove(member1, totalNeeded, address(safetyNet));
+    uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+    if (due == 0) {
+      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      due = safetyNet.dueRemainingThisEpoch(id, member1);
+    }
+    uint256 pay = depositValue > due ? due : depositValue;
+    _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
     vm.prank(member1);
-    safetyNet.deposit(id, depositValue);
+    safetyNet.deposit(id, pay);
 
     // Choose a daysRequested that ensures "large" classification.
-    uint256 minDaysToBeLarge = (cfg.autoThreshold * 30) / depositValue + 1;
-    uint256 daysRequested = minDaysToBeLarge + (uint256(extraDaysRaw) % 10) + 1;
-    if (daysRequested > 30) daysRequested = 30;
-    if (minDaysToBeLarge > 30) daysRequested = 30;
+    uint256 contrib = safetyNet.safetyNetMemberContribute(id, member1);
+    uint256 daysRequested = 1 + (uint256(extraDaysRaw) % 5);
 
     vm.prank(member1);
     safetyNet.withdraw(id, daysRequested);
-    uint256 reqId = safetyNet.nextIdRequest() - 1;
+    uint256 n = safetyNet.nextIdRequest();
+    assertGt(n, 0, 'expected a request');
+    uint256 reqId = n - 1;
 
     vm.warp(block.timestamp + cfg.contestWindow + 1);
 
@@ -63,6 +69,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     cfg.minimumMembers = 2;
     cfg.maximumMembers = m;
     cfg.consensusThreshold = consensus;
+    cfg.autoThreshold = 1;
     cfg.safetyNetStart = block.timestamp;
     cfg.votingWindow = 7 days;
     cfg.contestWindow = 7 days;
@@ -72,25 +79,35 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     // Seed deposits for members[1..m-1]
     uint256 depEach = 2e18;
     for (uint256 i = 1; i < m; i++) {
-      _mintApprove(members[i], depEach + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-      vm.prank(members[i]);
-      safetyNet.deposit(id, depEach);
+      uint256 dueI = safetyNet.dueRemainingThisEpoch(id, members[i]);
+      if (dueI > 0) {
+        uint256 payI = depEach > dueI ? dueI : depEach;
+        _mintApprove(members[i], payI + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+        vm.prank(members[i]);
+        safetyNet.deposit(id, payI);
+      }
     }
 
     // Single (larger) deposit for members[0] so we can make a large request
-    uint256 depositValue = 5e18;
-    _mintApprove(members[0], depositValue + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
-    vm.prank(members[0]);
-    safetyNet.deposit(id, depositValue);
+    uint256 due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    if (due0 == 0) {
+      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    }
 
-    // Compute days to classify as "large" based on that one deposit
-    uint256 minDaysToBeLarge = (cfg.autoThreshold * 30) / depositValue + 1;
-    if (minDaysToBeLarge > 30) minDaysToBeLarge = 30;
-    uint256 daysRequested = minDaysToBeLarge == 0 ? 1 : minDaysToBeLarge;
+    uint256 depositValue0 = 3e18;
+    uint256 pay0 = depositValue0 > due0 ? due0 : depositValue0;
+    _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+    vm.prank(members[0]);
+    safetyNet.deposit(id, pay0);
+
+    uint256 daysRequested = 1;
 
     vm.prank(members[0]);
     safetyNet.withdraw(id, daysRequested);
-    uint256 reqId = safetyNet.nextIdRequest() - 1;
+    uint256 n = safetyNet.nextIdRequest();
+    assertGt(n, 0, 'expected a request');
+    uint256 reqId = n - 1;
 
     // Exactly threshold YES votes (floor).
     uint256 needed = (m * consensus) / 100; // floor
@@ -128,27 +145,29 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     cfg.votingWindow = votingWin;
     cfg.contestWindow = contestWin;
     cfg.ratio = 1;
+    cfg.autoThreshold = 1;
 
     uint256 id = safetyNet.create(cfg);
 
     // Fund member1 and create a "large" request.
     uint256 depositValue = 2e18;
-    _mintApprove(member1, depositValue + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
+    uint256 due = safetyNet.dueRemainingThisEpoch(id, member1);
+    if (due == 0) {
+      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      due = safetyNet.dueRemainingThisEpoch(id, member1);
+    }
+    uint256 pay = depositValue > due ? due : depositValue;
+    _mintApprove(member1, pay + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
     vm.prank(member1);
-    safetyNet.deposit(id, depositValue);
+    safetyNet.deposit(id, pay);
 
-    uint256 minDaysToBeLarge = (cfg.autoThreshold * 30) / depositValue + 1;
-    if (minDaysToBeLarge > 30) {
-      minDaysToBeLarge = 30;
-    }
-    uint256 daysRequested = minDaysToBeLarge;
-    if (daysRequested == 0) {
-      daysRequested = 1;
-    }
+    uint256 daysRequested = 1;
 
     vm.prank(member1);
     safetyNet.withdraw(id, daysRequested);
-    uint256 reqId = safetyNet.nextIdRequest() - 1;
+    uint256 n = safetyNet.nextIdRequest();
+    assertGt(n, 0, 'expected a request');
+    uint256 reqId = n - 1;
 
     // Only members may vote.
     address outsider = address(0xDEAD);
@@ -172,7 +191,9 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     // New request that gets contested; verify it does not auto-execute after timeout.
     vm.prank(member1);
     safetyNet.withdraw(id, daysRequested);
-    uint256 req2 = safetyNet.nextIdRequest() - 1;
+    uint256 n2 = safetyNet.nextIdRequest();
+    assertGt(n2, 0, 'expected a request');
+    uint256 req2 = n2 - 1;
 
     vm.prank(member2);
     safetyNet.contest(req2);
@@ -211,6 +232,7 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
     cfg.safetyNetStart = block.timestamp;
     cfg.votingWindow = 1 days;
     cfg.contestWindow = 1 days;
+    cfg.autoThreshold = 1;
     uint256 id = safetyNet.create(cfg);
 
     // Seed balances; ignore per-member deposit failure to keep exploring.
@@ -220,17 +242,25 @@ contract SafetyNetFuzz_RequestsVoting is SafetyNetFuzzBase {
       try safetyNet.deposit(id, 5e18) {} catch {}
     }
 
+    uint256 due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    if (due0 == 0) {
+      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      due0 = safetyNet.dueRemainingThisEpoch(id, members[0]);
+    }
     uint256 depositValue = 5e18;
-    uint256 totalNeeded = depositValue + cfg.initialDeposit + cfg.fixedDeposit;
-    _mintApprove(members[0], totalNeeded, address(safetyNet));
+    uint256 pay0 = depositValue > due0 ? due0 : depositValue;
+    _mintApprove(members[0], pay0 + cfg.initialDeposit + cfg.fixedDeposit, address(safetyNet));
     vm.prank(members[0]);
-    try safetyNet.deposit(id, depositValue) {} catch {}
-    uint256 minDaysToBeLarge = (cfg.autoThreshold * 30) / depositValue + 1;
-    uint256 daysRequested = minDaysToBeLarge + 3;
+    safetyNet.deposit(id, pay0);
+
+    // With tiny autoThreshold, any positive withdrawal amount will be "large"
+    uint256 daysRequested = 1;
 
     vm.prank(members[0]);
     safetyNet.withdraw(id, daysRequested);
-    uint256 reqId = safetyNet.nextIdRequest() - 1;
+    uint256 n = safetyNet.nextIdRequest();
+    assertGt(n, 0, 'expected a request');
+    uint256 reqId = n - 1;
 
     // Randomized voting pass
     for (uint256 i = 0; i < m && !safetyNet.isExecuted(reqId); i++) {

--- a/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
@@ -14,7 +14,7 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(memberCount);
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;
@@ -47,7 +47,7 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(memberCount);
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;
@@ -87,7 +87,7 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(memberCount);
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;
@@ -127,7 +127,7 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
     address[] memory members = _makeMembers(memberCount);
-    ISafetyNet.SafetyNet memory config = safeCfg;
+    ISafetyNet.SafetyNet memory config = _safeCfg;
     config.members = members;
     config.minimumMembers = 2;
     config.maximumMembers = memberCount;

--- a/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_VariableMembers.t.sol
@@ -9,32 +9,32 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// Fuzz: deposits across epochs for variable members.
   /// -------------------------------------------------------------------------
   function testFuzz_Deposits_AcrossEpochs(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
-    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 memberCount = bound(uint256(membersRaw), 3, 25);
     uint256 epochs = bound(uint256(epochsRaw), 2, 8);
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
-    address[] memory members = _makeMembers(m);
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    address[] memory members = _makeMembers(memberCount);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.safetyNetStart = block.timestamp;
+    config.ratio = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    for (uint256 i = 0; i < m; i++) {
-      _mintApprove(members[i], 1e24, address(safetyNet));
+    for (uint256 i = 0; i < memberCount; i++) {
+      _mintApprove(members[i], 1e24, address(_safetyNet));
     }
 
     for (uint256 e = 0; e < epochs; e++) {
       for (uint256 k = 0; k < ops; k++) {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
-        address actor = members[seed % m];
+        address actor = members[seed % memberCount];
         uint256 v = 1e18 + (seed % 1e18);
         vm.prank(actor);
-        try safetyNet.deposit(id, v) {} catch {}
+        try _safetyNet.deposit(safetyNetId, v) {} catch {}
       }
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
     }
   }
 
@@ -42,34 +42,34 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
   /// Fuzz: small withdrawals (1–3 days) across epochs.
   /// -------------------------------------------------------------------------
   function testFuzz_SmallWithdraws_AcrossEpochs(uint8 membersRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
-    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 memberCount = bound(uint256(membersRaw), 3, 25);
     uint256 epochs = bound(uint256(epochsRaw), 2, 8);
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
-    address[] memory members = _makeMembers(m);
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    address[] memory members = _makeMembers(memberCount);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.safetyNetStart = block.timestamp;
+    config.ratio = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    for (uint256 i = 0; i < m; i++) {
-      _mintApprove(members[i], 1e24, address(safetyNet));
+    for (uint256 i = 0; i < memberCount; i++) {
+      _mintApprove(members[i], 1e24, address(_safetyNet));
       vm.prank(members[i]);
-      try safetyNet.deposit(id, 5e18) {} catch {}
+      try _safetyNet.deposit(safetyNetId, 5e18) {} catch {}
     }
 
     for (uint256 e = 0; e < epochs; e++) {
       for (uint256 k = 0; k < ops; k++) {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
-        address actor = members[seed % m];
+        address actor = members[seed % memberCount];
         uint256 daysReq = 1 + (seed % 3);
         vm.prank(actor);
-        try safetyNet.withdraw(id, daysReq) {} catch {}
+        try _safetyNet.withdraw(safetyNetId, daysReq) {} catch {}
       }
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
     }
   }
 
@@ -82,34 +82,34 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint8 opsRaw,
     uint256 seed
   ) public {
-    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 memberCount = bound(uint256(membersRaw), 3, 25);
     uint256 epochs = bound(uint256(epochsRaw), 2, 8);
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
-    address[] memory members = _makeMembers(m);
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    address[] memory members = _makeMembers(memberCount);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.safetyNetStart = block.timestamp;
+    config.ratio = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    for (uint256 i = 0; i < m; i++) {
-      _mintApprove(members[i], 1e24, address(safetyNet));
+    for (uint256 i = 0; i < memberCount; i++) {
+      _mintApprove(members[i], 1e24, address(_safetyNet));
       vm.prank(members[i]);
-      try safetyNet.deposit(id, 1e19) {} catch {}
+      try _safetyNet.deposit(safetyNetId, 1e19) {} catch {}
     }
 
     for (uint256 e = 0; e < epochs; e++) {
       for (uint256 k = 0; k < ops; k++) {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
-        address actor = members[seed % m];
+        address actor = members[seed % memberCount];
         uint256 daysReq = 40 + (seed % 40);
         vm.prank(actor);
-        try safetyNet.withdraw(id, daysReq) {} catch {}
+        try _safetyNet.withdraw(safetyNetId, daysReq) {} catch {}
       }
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
     }
   }
 
@@ -122,44 +122,44 @@ contract SafetyNetFuzz_VariableMembers is SafetyNetFuzzBase {
     uint8 opsRaw,
     uint256 seed
   ) public {
-    uint256 m = bound(uint256(membersRaw), 3, 25);
+    uint256 memberCount = bound(uint256(membersRaw), 3, 25);
     uint256 epochs = bound(uint256(epochsRaw), 2, 8);
     uint256 ops = bound(uint256(opsRaw), 5, 30);
 
-    address[] memory members = _makeMembers(m);
-    ISafetyNet.SafetyNet memory cfg = safeCfg;
-    cfg.members = members;
-    cfg.minimumMembers = 2;
-    cfg.maximumMembers = m;
-    cfg.safetyNetStart = block.timestamp;
-    cfg.ratio = 1;
-    uint256 id = safetyNet.create(cfg);
+    address[] memory members = _makeMembers(memberCount);
+    ISafetyNet.SafetyNet memory config = safeCfg;
+    config.members = members;
+    config.minimumMembers = 2;
+    config.maximumMembers = memberCount;
+    config.safetyNetStart = block.timestamp;
+    config.ratio = 1;
+    uint256 safetyNetId = _safetyNet.create(config);
 
-    for (uint256 i = 0; i < m; i++) {
-      _mintApprove(members[i], 1e24, address(safetyNet));
+    for (uint256 i = 0; i < memberCount; i++) {
+      _mintApprove(members[i], 1e24, address(_safetyNet));
       vm.prank(members[i]);
-      try safetyNet.deposit(id, 1e19) {} catch {}
+      try _safetyNet.deposit(safetyNetId, 1e19) {} catch {}
     }
 
     for (uint256 e = 0; e < epochs; e++) {
       for (uint256 k = 0; k < ops; k++) {
         seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
-        address actor = members[seed % m];
+        address actor = members[seed % memberCount];
 
         // Create a large withdraw request occasionally.
         uint256 daysReq = 40 + (seed % 40);
         vm.prank(actor);
-        try safetyNet.withdraw(id, daysReq) {} catch {}
+        try _safetyNet.withdraw(safetyNetId, daysReq) {} catch {}
 
         // If a request exists, occasionally fast-forward past contest window and execute.
-        if (safetyNet.nextIdRequest() > 0 && (seed & 1) == 1) {
-          uint256 reqId = safetyNet.nextIdRequest() - 1;
-          vm.warp(block.timestamp + cfg.contestWindow + 1);
+        if (_safetyNet.nextIdRequest() > 0 && (seed & 1) == 1) {
+          uint256 reqId = _safetyNet.nextIdRequest() - 1;
+          vm.warp(block.timestamp + config.contestWindow + 1);
           vm.prank(actor);
-          try safetyNet.executeContestedWithdrawal(reqId) {} catch {}
+          try _safetyNet.executeContestedWithdrawal(reqId) {} catch {}
         }
       }
-      vm.warp(block.timestamp + cfg.epochDuration + 1);
+      vm.warp(block.timestamp + config.epochDuration + 1);
     }
   }
 }

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -62,11 +62,11 @@ contract SafetyNetUnit is Test {
   }
 
   // ---------- helpers ----------
-  function _defaultSafetyNet(address _tokenAddr) internal view returns (ISafetyNet.SafetyNet memory sn) {
+  function _defaultSafetyNet(address _tokenAddr) internal view returns (ISafetyNet.SafetyNet memory _safetyNet) {
     address[] memory members = new address[](2);
     members[0] = _alice;
     members[1] = _bob;
-    sn = ISafetyNet.SafetyNet({
+    _safetyNet = ISafetyNet.SafetyNet({
       id: 0,
       owner: _owner,
       minimumMembers: 2,
@@ -93,14 +93,14 @@ contract SafetyNetUnit is Test {
   }
 
   function _payInitial(uint256 id, address who) internal {
-    ISafetyNet.SafetyNet memory sn = _sn.getSafetyNet(id);
+    ISafetyNet.SafetyNet memory _safetyNet = _sn.getSafetyNet(id);
     vm.prank(who);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
   }
 
   function _nextEpoch(uint256 id) internal {
-    ISafetyNet.SafetyNet memory sn = _sn.getSafetyNet(id);
-    vm.warp(sn.safetyNetStart + sn.epochDuration);
+    ISafetyNet.SafetyNet memory _safetyNet = _sn.getSafetyNet(id);
+    vm.warp(_safetyNet.safetyNetStart + _safetyNet.epochDuration);
   }
 
   // ---------- initialize ----------
@@ -162,105 +162,105 @@ contract SafetyNetUnit is Test {
 
   // ---------- create ----------
   function test_CreateWhenTokenIsNotInAllowedTokensMapping() external {
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     vm.expectRevert(ISafetyNet.TokenNotAllowed.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenSafetyNetStartTimeIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.safetyNetStart = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.safetyNetStart = 0;
     vm.expectRevert(ISafetyNet.InvalidSafetyNetStartTime.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenOwnerIsZeroAddress() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.owner = address(0);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.owner = address(0);
     vm.expectRevert(ISafetyNet.InvalidOwner.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenInitialDepositIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.initialDeposit = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.initialDeposit = 0;
     vm.expectRevert(ISafetyNet.InvalidInitialDeposit.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenFixedDepositIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.fixedDeposit = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.fixedDeposit = 0;
     vm.expectRevert(ISafetyNet.InvalidFixedDeposit.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenAutoThresholdIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.autoThreshold = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.autoThreshold = 0;
     vm.expectRevert(ISafetyNet.InvalidThreshold.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenMinimumMembersIs0() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.minimumMembers = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.minimumMembers = 0;
     vm.expectRevert(ISafetyNet.InvalidMinimumMembers.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenMinimumMembersIs1() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.minimumMembers = 1;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.minimumMembers = 1;
     vm.expectRevert(ISafetyNet.InvalidMinimumMembers.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenMaximumMembersEqualsMinimumMembers() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.maximumMembers = sn.minimumMembers;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.maximumMembers = _safetyNet.minimumMembers;
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateWhenMaximumMembersIsLessThanMinimumMembers() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.maximumMembers = 1;
-    sn.minimumMembers = 2;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.maximumMembers = 1;
+    _safetyNet.minimumMembers = 2;
     vm.expectRevert(ISafetyNet.InvalidMaximumMembers.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenEpochDurationIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.epochDuration = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.epochDuration = 0;
     vm.expectRevert(ISafetyNet.InvalidEpochDuration.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenSmallWithdrawsLimitIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.smallWithdrawsLimit = 0;
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.smallWithdrawsLimit = 0;
     vm.expectRevert(ISafetyNet.InvalidSmallWithdrawsLimit.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenMembersArrayIsEmpty() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.members = new address[](0);
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.members = new address[](0);
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
     (address[] memory members,) = _sn.getMemberBalances(id);
     assertEq(members.length, 0);
@@ -268,74 +268,74 @@ contract SafetyNetUnit is Test {
 
   function test_CreateWhenAnyMemberAddressIsZeroAddress() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.members[1] = address(0);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.members[1] = address(0);
     vm.expectRevert(ISafetyNet.InvalidMemberAddress.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenMembersArrayContainsDuplicates() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
 
     // Duplicate
-    sn.members[1] = _alice;
+    _safetyNet.members[1] = _alice;
 
     vm.expectRevert(ISafetyNet.DuplicateMember.selector);
-    _sn.create(sn);
+    _sn.create(_safetyNet);
   }
 
   function test_CreateWhenConsensusThresholdIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.consensusThreshold = 0;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.consensusThreshold = 0;
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateWhenConsensusThresholdIsGreaterThan100() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.consensusThreshold = 150;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.consensusThreshold = 150;
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateWhenRatioIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.ratio = 0;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.ratio = 0;
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateWhenRatioIsGreaterThan100() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.ratio = 200;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.ratio = 200;
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateWhenAllParametersAreValid() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     vm.expectEmit(true, false, false, true);
     emit ISafetyNet.SafetyNetCreated(
       0,
-      sn.minimumMembers,
-      sn.maximumMembers,
-      sn.consensusThreshold,
-      sn.members,
-      sn.token,
-      sn.initialDeposit,
-      sn.fixedDeposit,
-      sn.ratio,
-      sn.autoThreshold,
-      sn.epochDuration,
-      sn.smallWithdrawsLimit
+      _safetyNet.minimumMembers,
+      _safetyNet.maximumMembers,
+      _safetyNet.consensusThreshold,
+      _safetyNet.members,
+      _safetyNet.token,
+      _safetyNet.initialDeposit,
+      _safetyNet.fixedDeposit,
+      _safetyNet.ratio,
+      _safetyNet.autoThreshold,
+      _safetyNet.epochDuration,
+      _safetyNet.smallWithdrawsLimit
     );
-    uint256 id = _sn.create(sn);
+    uint256 id = _sn.create(_safetyNet);
     assertEq(id, 0);
 
     // nextId increments
@@ -343,7 +343,7 @@ contract SafetyNetUnit is Test {
 
     // Stored struct
     ISafetyNet.SafetyNet memory stored = _sn.getSafetyNet(id);
-    assertEq(stored.owner, sn.owner);
+    assertEq(stored.owner, _safetyNet.owner);
 
     // Members mapping and reverse index
     assertTrue(_sn.isMember(id, _alice));
@@ -359,8 +359,8 @@ contract SafetyNetUnit is Test {
   // ---------- decommission ----------
   function test_DecommissionWhenSafetyNetIsNotDecommissionable() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     vm.expectRevert(ISafetyNet.NotDecommissionable.selector);
     _sn.decommission(id);
   }
@@ -368,20 +368,20 @@ contract SafetyNetUnit is Test {
   // Create balances and decommission after marking a missed deposit
   function test_DecommissionWhenSafetyNetIsDecommissionable() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
     // epoch 0: onboarding
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
     vm.prank(_bob);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     // epoch 1: deliberately miss deposits
-    vm.warp(sn.safetyNetStart + sn.epochDuration);
+    vm.warp(_safetyNet.safetyNetStart + _safetyNet.epochDuration);
 
     // Seed balances
-    vm.warp(sn.safetyNetStart + 2 * sn.epochDuration + 1);
+    vm.warp(_safetyNet.safetyNetStart + 2 * _safetyNet.epochDuration + 1);
     vm.prank(_alice);
     _sn.deposit(id, 5 ether);
     vm.prank(_bob);
@@ -417,8 +417,8 @@ contract SafetyNetUnit is Test {
 
   function test_DepositWhenCallerIsNotInIsMemberMapping() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     vm.expectRevert(ISafetyNet.NotMember.selector);
     vm.prank(_carol);
     _sn.deposit(id, 1 ether);
@@ -434,9 +434,9 @@ contract SafetyNetUnit is Test {
 
   function test_DepositWhenCurrentTimeIsBeforeSafetyNetStartTime() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.safetyNetStart = block.timestamp + 1 days;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.safetyNetStart = block.timestamp + 1 days;
+    uint256 id = _sn.create(_safetyNet);
     vm.expectRevert(ISafetyNet.DepositBeforeSafetyNetStart.selector);
     vm.prank(_alice);
     _sn.deposit(id, 1 ether);
@@ -444,14 +444,14 @@ contract SafetyNetUnit is Test {
 
   function test_DepositWhenCurrentTimeEqualsSafetyNetStartTime() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
-    vm.warp(sn.safetyNetStart);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
+    vm.warp(_safetyNet.safetyNetStart);
 
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
-    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit);
+    assertEq(_sn.safetyNetBalance(id), _safetyNet.initialDeposit);
   }
 
   function test_DepositWhenMemberAlreadyDepositedInCurrentEpoch() external {
@@ -479,31 +479,29 @@ contract SafetyNetUnit is Test {
 
   function test_DepositWhenTokenTransferFromFails() external {
     _allowToken(address(_failToken));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_failToken));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_failToken));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.expectRevert(SafetyNet.TransferFailed.selector);
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
   }
 
   function test_DepositWhenMakingFirstDeposit() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
-    uint256 expectedTotal = sn.initialDeposit;
+    uint256 expectedTotal = _safetyNet.initialDeposit;
     vm.expectEmit(true, true, false, true);
     emit ISafetyNet.FundsDeposited(id, _alice, expectedTotal);
 
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
-    assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
-
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), _safetyNet.fixedDeposit);
     assertEq(_sn.safetyNetBalance(id), expectedTotal);
-    assertEq(_sn.memberWithdrawableBalance(id, _alice), sn.initialDeposit * sn.ratio);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), _safetyNet.initialDeposit * _safetyNet.ratio);
 
     // epoch 0 is considered fully paid (>= fixedDeposit)
     uint256 epoch = _sn.getCurrentEpochIndex(id);
@@ -512,8 +510,8 @@ contract SafetyNetUnit is Test {
 
   function test_DepositWhenMakingSubsequentDeposits() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     _payInitial(id, _alice);
     _nextEpoch(id);
 
@@ -523,18 +521,18 @@ contract SafetyNetUnit is Test {
     vm.prank(_alice);
     _sn.deposit(id, value);
 
-    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit + value);
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
-    assertEq(_sn.memberWithdrawableBalance(id, _alice), (sn.initialDeposit + value) * sn.ratio);
+    assertEq(_sn.safetyNetBalance(id), _safetyNet.initialDeposit + value);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), _safetyNet.fixedDeposit);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), (_safetyNet.initialDeposit + value) * _safetyNet.ratio);
   }
 
   function test_DepositWhenRatioIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.ratio = 0;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.ratio = 0;
+    uint256 id = _sn.create(_safetyNet);
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
     assertEq(_sn.memberWithdrawableBalance(id, _alice), 0);
     assertGt(_sn.safetyNetBalance(id), 0);
   }
@@ -556,11 +554,11 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenSenderIsNotAMember() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     vm.prank(_carol);
-    _sn.depositFor(id, sn.initialDeposit, _alice);
-    assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
+    _sn.depositFor(id, _safetyNet.initialDeposit, _alice);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), _safetyNet.fixedDeposit);
   }
 
   function test_DepositForWhenDepositValueIsZero() external {
@@ -573,9 +571,9 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenCurrentTimeIsBeforeSafetyNetStartTime() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.safetyNetStart = block.timestamp + 1 days;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.safetyNetStart = block.timestamp + 1 days;
+    uint256 id = _sn.create(_safetyNet);
     vm.expectRevert(ISafetyNet.DepositBeforeSafetyNetStart.selector);
     vm.prank(_alice);
     _sn.depositFor(id, 1 ether, _alice);
@@ -583,13 +581,13 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenTargetMemberAlreadyDepositedInCurrentEpoch() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.prank(_alice);
-    _sn.depositFor(id, sn.initialDeposit, _alice);
+    _sn.depositFor(id, _safetyNet.initialDeposit, _alice);
 
-    vm.warp(sn.safetyNetStart + sn.epochDuration + 1);
+    vm.warp(_safetyNet.safetyNetStart + _safetyNet.epochDuration + 1);
 
     vm.prank(_alice);
     _sn.depositFor(id, 6 ether, _alice);
@@ -603,22 +601,21 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenTokenTransferFromFailsFromSender() external {
     _allowToken(address(_failToken));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_failToken));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_failToken));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.expectRevert(SafetyNet.TransferFailed.selector);
     vm.prank(_alice);
-    _sn.depositFor(id, sn.initialDeposit, _alice);
+    _sn.depositFor(id, _safetyNet.initialDeposit, _alice);
   }
 
   function test_DepositForWhenMakingFirstDepositForTargetMember() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     vm.prank(_bob);
-    _sn.depositFor(id, sn.initialDeposit, _alice);
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
-    assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
+    _sn.depositFor(id, _safetyNet.initialDeposit, _alice);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), _safetyNet.fixedDeposit);
   }
 
   // ---------- withdraw ----------
@@ -639,11 +636,11 @@ contract SafetyNetUnit is Test {
 
   function test_WithdrawWhenDaysRequestedIsZero() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     uint256 beforeBal = _token.balanceOf(_alice);
     vm.prank(_alice);
@@ -656,11 +653,11 @@ contract SafetyNetUnit is Test {
 
   function test_WithdrawWhenRequestedWithdrawalAmountExceedsMemberWithdrawableBalance() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
     vm.expectRevert(ISafetyNet.NotWithdrawable.selector);
     vm.prank(_alice);
 
@@ -670,29 +667,29 @@ contract SafetyNetUnit is Test {
 
   function test_WithdrawWhenWithdrawalAmountIsBelowThreshold() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
 
     // Small path
-    sn.autoThreshold = 100 ether;
-    uint256 id = _sn.create(sn);
+    _safetyNet.autoThreshold = 100 ether;
+    uint256 id = _sn.create(_safetyNet);
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     uint256 before = _token.balanceOf(_alice);
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertGt(_token.balanceOf(_alice), before);
-    assertLt(_sn.memberWithdrawableBalance(id, _alice), sn.initialDeposit * sn.ratio);
+    assertLt(_sn.memberWithdrawableBalance(id, _alice), _safetyNet.initialDeposit * _safetyNet.ratio);
   }
 
   function test_WithdrawWhenWithdrawalAmountIsAboveAutoThresholdCreatesRequest() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     // Any withdraw > 1 wei goes to request path
-    sn.autoThreshold = 1;
-    uint256 id = _sn.create(sn);
+    _safetyNet.autoThreshold = 1;
+    uint256 id = _sn.create(_safetyNet);
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     vm.prank(_alice);
     _sn.withdraw(id, 1);
@@ -705,13 +702,13 @@ contract SafetyNetUnit is Test {
   // ---------- createRequest / contest / execute / vote (happy paths) ----------
   function _createFundAndRequest() internal returns (uint256 id, uint256 reqId) {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
 
     // Ensure withdraw goes through request path
-    sn.autoThreshold = 1;
-    id = _sn.create(sn);
+    _safetyNet.autoThreshold = 1;
+    id = _sn.create(_safetyNet);
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     // Create request via withdraw above threshold
     vm.prank(_alice);
@@ -767,7 +764,7 @@ contract SafetyNetUnit is Test {
     members[0] = _alice;
     members[1] = _bob;
     members[2] = _carol;
-    ISafetyNet.SafetyNet memory sn = ISafetyNet.SafetyNet({
+    ISafetyNet.SafetyNet memory _safetyNet = ISafetyNet.SafetyNet({
       id: 0,
       owner: _owner,
       minimumMembers: 2,
@@ -787,11 +784,11 @@ contract SafetyNetUnit is Test {
       epochDuration: 30 days,
       smallWithdrawsLimit: 3
     });
-    uint256 id = _sn.create(sn);
+    uint256 id = _sn.create(_safetyNet);
 
     // Onboard
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
 
     // Creates request 0
     vm.prank(_alice);
@@ -836,10 +833,10 @@ contract SafetyNetUnit is Test {
 
   function test_GetSafetyNetWhenSafetyNetExistsAndIsCommissioned() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
     ISafetyNet.SafetyNet memory g = _sn.getSafetyNet(id);
-    assertEq(g.owner, sn.owner);
+    assertEq(g.owner, _safetyNet.owner);
   }
 
   function test_GetSafetyNetsWhenIdsArrayIsEmpty() external view {
@@ -890,11 +887,11 @@ contract SafetyNetUnit is Test {
 
   function test_HasMemberDepositedInEpochWhenEpochMemberDepositsIsTrue() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(_safetyNet);
 
     vm.prank(_alice);
-    _sn.deposit(id, sn.initialDeposit);
+    _sn.deposit(id, _safetyNet.initialDeposit);
     assertTrue(_sn.hasMemberDepositedInEpoch(id, _alice, _sn.getCurrentEpochIndex(id)));
   }
 
@@ -904,25 +901,25 @@ contract SafetyNetUnit is Test {
 
   function test_GetCurrentEpochIndexWhenCurrentTimeEdgeCases() external {
     _allowToken(address(_token));
-    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
-    sn.safetyNetStart = block.timestamp + 1 days;
-    uint256 id = _sn.create(sn);
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.safetyNetStart = block.timestamp + 1 days;
+    uint256 id = _sn.create(_safetyNet);
 
     // Before start
     assertEq(_sn.getCurrentEpochIndex(id), 0);
-    vm.warp(sn.safetyNetStart);
+    vm.warp(_safetyNet.safetyNetStart);
 
     // At start
     assertEq(_sn.getCurrentEpochIndex(id), 0);
-    vm.warp(sn.safetyNetStart + 1);
+    vm.warp(_safetyNet.safetyNetStart + 1);
 
     // Just after start
     assertEq(_sn.getCurrentEpochIndex(id), 0);
-    vm.warp(sn.safetyNetStart + sn.epochDuration);
+    vm.warp(_safetyNet.safetyNetStart + _safetyNet.epochDuration);
 
     // Exactly one epoch
     assertEq(_sn.getCurrentEpochIndex(id), 1);
-    vm.warp(sn.safetyNetStart + 5 * sn.epochDuration + 10);
+    vm.warp(_safetyNet.safetyNetStart + 5 * _safetyNet.epochDuration + 10);
     assertEq(_sn.getCurrentEpochIndex(id), 5);
   }
 

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -365,9 +365,9 @@ contract SafetyNetUnit is Test {
 
     // Seed balances
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.fixedDeposit);
     vm.prank(_bob);
-    _sn.deposit(id, 20 ether);
+    _sn.deposit(id, sn.fixedDeposit);
 
     uint256 preBalanceAlice = _token.balanceOf(_alice);
     uint256 preBalanceBob = _token.balanceOf(_bob);
@@ -431,17 +431,28 @@ contract SafetyNetUnit is Test {
     vm.warp(sn.safetyNetStart);
     vm.prank(_alice);
     _sn.deposit(id, 1 ether);
-    assertEq(_sn.safetyNetBalance(id), 1 ether + sn.fixedDeposit + sn.initialDeposit);
+    assertEq(_sn.safetyNetBalance(id), 1 ether + sn.initialDeposit);
   }
 
   function test_DepositWhenMemberAlreadyDepositedInCurrentEpoch() external {
     _allowToken(address(_token));
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+
+    // First partial deposit
     vm.prank(_alice);
     _sn.deposit(id, 1 ether);
-    vm.expectRevert(ISafetyNet.AlreadyDeposited.selector);
+
+    // Fill the rest of the epoch dues to exactly fixedDeposit (10 ether total)
+    vm.prank(_alice);
+    _sn.deposit(id, 9 ether);
+
+    // Now any extra exceeds the epoch cap
+    vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
     vm.prank(_alice);
     _sn.deposit(id, 1 ether);
+
+    // Fully paid flag (derived) is now true
+    assertTrue(_sn.hasMemberDepositedInEpoch(id, _alice, _sn.getCurrentEpochIndex(id)));
   }
 
   function test_DepositWhenTokenTransferFromFails() external {
@@ -458,17 +469,21 @@ contract SafetyNetUnit is Test {
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     uint256 id = _sn.create(sn);
     uint256 value = 5 ether;
-    uint256 expectedTotal = value + sn.fixedDeposit + sn.initialDeposit;
+    uint256 expectedTotal = value + sn.initialDeposit;
     vm.expectEmit(true, true, false, true);
     emit ISafetyNet.FundsDeposited(id, _alice, expectedTotal);
     vm.prank(_alice);
     _sn.deposit(id, value);
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), value);
+
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
     assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
+
     assertEq(_sn.safetyNetBalance(id), expectedTotal);
     assertEq(_sn.memberWithdrawableBalance(id, _alice), value * sn.ratio);
+
+    // Fully paid flag (derived) is still false
     uint256 epoch = _sn.getCurrentEpochIndex(id);
-    assertTrue(_sn.epochMemberDeposits(id, epoch, _alice));
+    assertFalse(_sn.hasMemberDepositedInEpoch(id, _alice, epoch));
   }
 
   function test_DepositWhenMakingSubsequentDeposits() external {
@@ -481,14 +496,14 @@ contract SafetyNetUnit is Test {
     // Move to next epoch to allow another deposit
     vm.warp(sn.safetyNetStart + sn.epochDuration);
     uint256 value = 3 ether;
-    uint256 expectedTotal = value + sn.fixedDeposit;
+    uint256 expectedTotal = value;
     vm.expectEmit(true, true, false, true);
     emit ISafetyNet.FundsDeposited(id, _alice, expectedTotal);
     vm.prank(_alice);
     _sn.deposit(id, value);
 
-    // Unchanged
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), 5 ether);
+    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit + 5 ether + value);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
     assertEq(_sn.memberWithdrawableBalance(id, _alice), (5 ether + value) * sn.ratio);
   }
 
@@ -548,8 +563,10 @@ contract SafetyNetUnit is Test {
     _allowToken(address(_token));
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
     vm.prank(_alice);
-    _sn.depositFor(id, 1 ether, _alice);
-    vm.expectRevert(ISafetyNet.AlreadyDeposited.selector);
+    _sn.depositFor(id, 6 ether, _alice);
+    vm.prank(_bob);
+    _sn.depositFor(id, 4 ether, _alice);
+    vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
     vm.prank(_bob);
     _sn.depositFor(id, 1 ether, _alice);
   }
@@ -567,7 +584,7 @@ contract SafetyNetUnit is Test {
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
     vm.prank(_bob);
     _sn.depositFor(id, 2 ether, _alice);
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), 2 ether);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), 10 ether);
     assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
   }
 
@@ -591,7 +608,7 @@ contract SafetyNetUnit is Test {
     _allowToken(address(_token));
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
     vm.prank(_alice);
-    _sn.deposit(id, 30 ether);
+    _sn.deposit(id, 10 ether);
     uint256 beforeBal = _token.balanceOf(_alice);
     vm.prank(_alice);
     _sn.withdraw(id, 0);
@@ -621,12 +638,12 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 100 ether;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 30 ether);
+    _sn.deposit(id, 10 ether);
     uint256 before = _token.balanceOf(_alice);
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertGt(_token.balanceOf(_alice), before);
-    assertLt(_sn.memberWithdrawableBalance(id, _alice), 30 ether * sn.ratio);
+    assertLt(_sn.memberWithdrawableBalance(id, _alice), 10 ether * sn.ratio);
   }
 
   function test_WithdrawWhenWithdrawalAmountIsAboveAutoThresholdCreatesRequest() external {
@@ -636,7 +653,7 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 1;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 30 ether);
+    _sn.deposit(id, 10 ether);
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertEq(_sn.nextIdRequest(), 1);
@@ -654,7 +671,7 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 1;
     id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 30 ether);
+    _sn.deposit(id, sn.fixedDeposit);
 
     // Create request via withdraw above threshold
     vm.prank(_alice);
@@ -732,7 +749,7 @@ contract SafetyNetUnit is Test {
     });
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 30 ether);
+    _sn.deposit(id, sn.fixedDeposit);
     vm.prank(_alice);
 
     // Creates request 0
@@ -833,7 +850,7 @@ contract SafetyNetUnit is Test {
     _allowToken(address(_token));
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
     vm.prank(_alice);
-    _sn.deposit(id, 1 ether);
+    _sn.deposit(id, 10 ether);
     assertTrue(_sn.hasMemberDepositedInEpoch(id, _alice, _sn.getCurrentEpochIndex(id)));
   }
 

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -92,6 +92,17 @@ contract SafetyNetUnit is Test {
     _sn.setTokenAllowed(tkn, true);
   }
 
+  function _payInitial(uint256 id, address who) internal {
+    ISafetyNet.SafetyNet memory sn = _sn.getSafetyNet(id);
+    vm.prank(who);
+    _sn.deposit(id, sn.initialDeposit);
+  }
+
+  function _nextEpoch(uint256 id) internal {
+    ISafetyNet.SafetyNet memory sn = _sn.getSafetyNet(id);
+    vm.warp(sn.safetyNetStart + sn.epochDuration);
+  }
+
   // ---------- initialize ----------
   function test_InitializeWhenAlreadyInitialized() external {
     vm.expectRevert(abi.encodeWithSignature('InvalidInitialization()'));
@@ -360,14 +371,21 @@ contract SafetyNetUnit is Test {
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     uint256 id = _sn.create(sn);
 
-    // Advance time one epoch so epoch 0 is past; leave a missed deposit => decommissionable
+    // epoch 0: onboarding
+    vm.prank(_alice);
+    _sn.deposit(id, sn.initialDeposit);
+    vm.prank(_bob);
+    _sn.deposit(id, sn.initialDeposit);
+
+    // epoch 1: deliberately miss deposits
     vm.warp(sn.safetyNetStart + sn.epochDuration);
 
     // Seed balances
+    vm.warp(sn.safetyNetStart + 2 * sn.epochDuration + 1);
     vm.prank(_alice);
-    _sn.deposit(id, sn.fixedDeposit);
+    _sn.deposit(id, 5 ether);
     vm.prank(_bob);
-    _sn.deposit(id, sn.fixedDeposit);
+    _sn.deposit(id, 5 ether);
 
     uint256 preBalanceAlice = _token.balanceOf(_alice);
     uint256 preBalanceBob = _token.balanceOf(_bob);
@@ -429,14 +447,18 @@ contract SafetyNetUnit is Test {
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     uint256 id = _sn.create(sn);
     vm.warp(sn.safetyNetStart);
+
     vm.prank(_alice);
-    _sn.deposit(id, 1 ether);
-    assertEq(_sn.safetyNetBalance(id), 1 ether + sn.initialDeposit);
+    _sn.deposit(id, sn.initialDeposit);
+
+    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit);
   }
 
   function test_DepositWhenMemberAlreadyDepositedInCurrentEpoch() external {
     _allowToken(address(_token));
     uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    _payInitial(id, _alice);
+    _nextEpoch(id);
 
     // First partial deposit
     vm.prank(_alice);
@@ -459,52 +481,51 @@ contract SafetyNetUnit is Test {
     _allowToken(address(_failToken));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_failToken));
     uint256 id = _sn.create(sn);
+
     vm.expectRevert(SafetyNet.TransferFailed.selector);
     vm.prank(_alice);
-    _sn.deposit(id, 1);
+    _sn.deposit(id, sn.initialDeposit);
   }
 
   function test_DepositWhenMakingFirstDeposit() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     uint256 id = _sn.create(sn);
-    uint256 value = 5 ether;
-    uint256 expectedTotal = value + sn.initialDeposit;
+
+    uint256 expectedTotal = sn.initialDeposit;
     vm.expectEmit(true, true, false, true);
     emit ISafetyNet.FundsDeposited(id, _alice, expectedTotal);
+
     vm.prank(_alice);
-    _sn.deposit(id, value);
+    _sn.deposit(id, sn.initialDeposit);
 
     assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
     assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
 
     assertEq(_sn.safetyNetBalance(id), expectedTotal);
-    assertEq(_sn.memberWithdrawableBalance(id, _alice), value * sn.ratio);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), sn.initialDeposit * sn.ratio);
 
-    // Fully paid flag (derived) is still false
+    // epoch 0 is considered fully paid (>= fixedDeposit)
     uint256 epoch = _sn.getCurrentEpochIndex(id);
-    assertFalse(_sn.hasMemberDepositedInEpoch(id, _alice, epoch));
+    assertTrue(_sn.hasMemberDepositedInEpoch(id, _alice, epoch));
   }
 
   function test_DepositWhenMakingSubsequentDeposits() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
     uint256 id = _sn.create(sn);
-    vm.prank(_alice);
-    _sn.deposit(id, 5 ether);
+    _payInitial(id, _alice);
+    _nextEpoch(id);
 
-    // Move to next epoch to allow another deposit
-    vm.warp(sn.safetyNetStart + sn.epochDuration);
     uint256 value = 3 ether;
-    uint256 expectedTotal = value;
     vm.expectEmit(true, true, false, true);
-    emit ISafetyNet.FundsDeposited(id, _alice, expectedTotal);
+    emit ISafetyNet.FundsDeposited(id, _alice, value);
     vm.prank(_alice);
     _sn.deposit(id, value);
 
-    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit + 5 ether + value);
+    assertEq(_sn.safetyNetBalance(id), sn.initialDeposit + value);
     assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
-    assertEq(_sn.memberWithdrawableBalance(id, _alice), (5 ether + value) * sn.ratio);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), (sn.initialDeposit + value) * sn.ratio);
   }
 
   function test_DepositWhenRatioIsZero() external {
@@ -513,7 +534,7 @@ contract SafetyNetUnit is Test {
     sn.ratio = 0;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.initialDeposit);
     assertEq(_sn.memberWithdrawableBalance(id, _alice), 0);
     assertGt(_sn.safetyNetBalance(id), 0);
   }
@@ -535,9 +556,10 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenSenderIsNotAMember() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
     vm.prank(_carol);
-    _sn.depositFor(id, 1 ether, _alice);
+    _sn.depositFor(id, sn.initialDeposit, _alice);
     assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
   }
 
@@ -561,11 +583,19 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenTargetMemberAlreadyDepositedInCurrentEpoch() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
+
+    vm.prank(_alice);
+    _sn.depositFor(id, sn.initialDeposit, _alice);
+
+    vm.warp(sn.safetyNetStart + sn.epochDuration + 1);
+
     vm.prank(_alice);
     _sn.depositFor(id, 6 ether, _alice);
     vm.prank(_bob);
     _sn.depositFor(id, 4 ether, _alice);
+
     vm.expectRevert(ISafetyNet.ExceedsDepositAmount.selector);
     vm.prank(_bob);
     _sn.depositFor(id, 1 ether, _alice);
@@ -573,18 +603,21 @@ contract SafetyNetUnit is Test {
 
   function test_DepositForWhenTokenTransferFromFailsFromSender() external {
     _allowToken(address(_failToken));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_failToken)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_failToken));
+    uint256 id = _sn.create(sn);
+
     vm.expectRevert(SafetyNet.TransferFailed.selector);
     vm.prank(_alice);
-    _sn.depositFor(id, 1 ether, _alice);
+    _sn.depositFor(id, sn.initialDeposit, _alice);
   }
 
   function test_DepositForWhenMakingFirstDepositForTargetMember() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
     vm.prank(_bob);
-    _sn.depositFor(id, 2 ether, _alice);
-    assertEq(_sn.safetyNetMemberContribute(id, _alice), 10 ether);
+    _sn.depositFor(id, sn.initialDeposit, _alice);
+    assertEq(_sn.safetyNetMemberContribute(id, _alice), sn.fixedDeposit);
     assertTrue(_sn.hasMadeFirstDeposit(id, _alice));
   }
 
@@ -606,9 +639,12 @@ contract SafetyNetUnit is Test {
 
   function test_WithdrawWhenDaysRequestedIsZero() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
+
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.initialDeposit);
+
     uint256 beforeBal = _token.balanceOf(_alice);
     vm.prank(_alice);
     _sn.withdraw(id, 0);
@@ -620,14 +656,16 @@ contract SafetyNetUnit is Test {
 
   function test_WithdrawWhenRequestedWithdrawalAmountExceedsMemberWithdrawableBalance() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
+
     vm.prank(_alice);
-    _sn.deposit(id, 1 ether);
+    _sn.deposit(id, sn.initialDeposit);
     vm.expectRevert(ISafetyNet.NotWithdrawable.selector);
     vm.prank(_alice);
 
     // Likely exceeds withdrawable
-    _sn.withdraw(id, 31);
+    _sn.withdraw(id, 301);
   }
 
   function test_WithdrawWhenWithdrawalAmountIsBelowThreshold() external {
@@ -638,12 +676,13 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 100 ether;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.initialDeposit);
+
     uint256 before = _token.balanceOf(_alice);
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertGt(_token.balanceOf(_alice), before);
-    assertLt(_sn.memberWithdrawableBalance(id, _alice), 10 ether * sn.ratio);
+    assertLt(_sn.memberWithdrawableBalance(id, _alice), sn.initialDeposit * sn.ratio);
   }
 
   function test_WithdrawWhenWithdrawalAmountIsAboveAutoThresholdCreatesRequest() external {
@@ -653,7 +692,8 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 1;
     uint256 id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.initialDeposit);
+
     vm.prank(_alice);
     _sn.withdraw(id, 1);
     assertEq(_sn.nextIdRequest(), 1);
@@ -671,7 +711,7 @@ contract SafetyNetUnit is Test {
     sn.autoThreshold = 1;
     id = _sn.create(sn);
     vm.prank(_alice);
-    _sn.deposit(id, sn.fixedDeposit);
+    _sn.deposit(id, sn.initialDeposit);
 
     // Create request via withdraw above threshold
     vm.prank(_alice);
@@ -748,11 +788,13 @@ contract SafetyNetUnit is Test {
       smallWithdrawsLimit: 3
     });
     uint256 id = _sn.create(sn);
+
+    // Onboard
     vm.prank(_alice);
-    _sn.deposit(id, sn.fixedDeposit);
-    vm.prank(_alice);
+    _sn.deposit(id, sn.initialDeposit);
 
     // Creates request 0
+    vm.prank(_alice);
     _sn.withdraw(id, 1);
     uint256 reqId = 0;
 
@@ -848,9 +890,11 @@ contract SafetyNetUnit is Test {
 
   function test_HasMemberDepositedInEpochWhenEpochMemberDepositsIsTrue() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    ISafetyNet.SafetyNet memory sn = _defaultSafetyNet(address(_token));
+    uint256 id = _sn.create(sn);
+
     vm.prank(_alice);
-    _sn.deposit(id, 10 ether);
+    _sn.deposit(id, sn.initialDeposit);
     assertTrue(_sn.hasMemberDepositedInEpoch(id, _alice, _sn.getCurrentEpochIndex(id)));
   }
 


### PR DESCRIPTION
* Enforces “exact dues” per epoch: partial deposits allowed until `fixedDeposit` is reached; `cumulative > fixedDeposit` reverts `ExceedsDepositAmount()`.
* `epochMemberDeposits[snId][epoch][member] == true` means dues paid in full for that epoch, not “any amount deposited”.
* `safetyNetMemberContribute` is set once on first deposit to `fixedDeposit` (used for monthly/daily allowance math).

### Notes

* Some unit tests currently assume “any deposit marks the epoch”. Those will be updated after we agree this semantics is correct.
* Naming might be improved in a later PR (`epochMemberDeposits` → `epochDuesPaid`) for clarity.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211699753875908
  - https://app.asana.com/0/0/1211699753875912
  - https://app.asana.com/0/0/1211699753875923