### PR TITLE
fix: bump OpenZeppelin to 5.5+ and fix remappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.1.0",
-    "@openzeppelin/contracts-upgradeable": "^5.1.0"
+    "@openzeppelin/contracts": "^5.5.0",
+    "@openzeppelin/contracts-upgradeable": "^5.5.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.3.0",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,8 +1,8 @@
 forge-std/=node_modules/forge-std/src/
 halmos-cheatcodes=node_modules/halmos-cheatcodes
 
-@openzeppelin/=node_modules/@openzeppelin/contracts/
-@openzeppelin-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
+@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 
 contracts/=src/contracts
 interfaces/=src/interfaces

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
-import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {Script} from 'forge-std/Script.sol';
 
 import {SafetyNet} from '../src/contracts/SafetyNet.sol';

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {OwnableUpgradeable} from '@openzeppelin-upgradeable/access/OwnableUpgradeable.sol';
-import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
-import {ReentrancyGuard} from '@openzeppelin/utils/ReentrancyGuard.sol';
-import {ECDSA} from '@openzeppelin/utils/cryptography/ECDSA.sol';
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {ReentrancyGuard} from '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
+import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 
 import {ISafetyNet} from '../interfaces/ISafetyNet.sol';
 

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.28;
 
 // ───────────────────────────── Imports ─────────────────────────────
 
-import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
-import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {Test} from 'forge-std/Test.sol';
 import {SafetyNet} from 'src/contracts/SafetyNet.sol';
 import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {ERC20} from '@openzeppelin/token/ERC20/ERC20.sol';
+import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 contract MockERC20 is ERC20 {
   constructor(string memory name, string memory symbol) ERC20(name, symbol) {}

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
-import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {stdError} from 'forge-std/StdError.sol';
 import {Test} from 'forge-std/Test.sol';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,15 +202,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openzeppelin/contracts-upgradeable@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.1.0.tgz#4d37648b7402929c53e2ff6e45749ecff91eb2b6"
-  integrity sha512-AIElwP5Ck+cslNE+Hkemf5SxjJoF4wBvvjxc27Rp+9jaPs/CLIaUBMYe1FNzhdiN0cYuwGRmYaRHmmntuiju4Q==
+"@openzeppelin/contracts-upgradeable@^5.5.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.6.1.tgz#7c1a0543bb73f5389e5f6cad268bf0715b7650e6"
+  integrity sha512-n4a/vfRs114lXyUdYg7pyY8LvFKWvCDF5lEcRRAVxap8g6ZEdLqm+9tmt2zTtRHcNMxTYp9y5t6KBof4tHp7Og==
 
-"@openzeppelin/contracts@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.1.0.tgz#4e61162f2a2bf414c4e10c45eca98ce5f1aadbd4"
-  integrity sha512-p1ULhl7BXzjjbha5aqst+QMLY+4/LCWADXOCsmLHRM77AqiPjnd9vvUN9sosUfhL9JGKpZ0TjEGxgvnizmWGSA==
+"@openzeppelin/contracts@^5.5.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.6.1.tgz#90c1cd427b3c1007ada4f42378ce84cc2a2145a5"
+  integrity sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==
 
 "@solidity-parser/parser@^0.16.0":
   version "0.16.2"


### PR DESCRIPTION
## Summary

- Bumps `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable` from 5.1.0 to ^5.5.0 (resolved to 5.6.1)
- Fixes Foundry remappings and updates all Solidity import paths to use standard OZ prefixes

## Why the remappings changed

The old remappings used a **shorthand convention**:

```
@openzeppelin/=node_modules/@openzeppelin/contracts/
@openzeppelin-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
```

This let project code write shorter imports like `@openzeppelin/token/ERC20/IERC20.sol` instead of `@openzeppelin/contracts/token/ERC20/IERC20.sol`.

This broke after the OZ upgrade because **`contracts-upgradeable` internally imports from `@openzeppelin/contracts/...`** (the standard npm path). With the shorthand remapping, Foundry resolved:

```
@openzeppelin/contracts/proxy/utils/Initializable.sol
→ node_modules/@openzeppelin/contracts/contracts/proxy/utils/Initializable.sol
                                       ^^^^^^^^^^
                                       doubled!
```

The `contracts/` segment in the import path was treated as a subdirectory under the already-remapped `node_modules/@openzeppelin/contracts/`, producing a **double `contracts/contracts/`** path that doesn't exist.

Foundry's longest-prefix-match rule means we can't have both `@openzeppelin/contracts/` (for OZ internals) and `@openzeppelin/` (for our shorthand) — the shorter one gets silently dropped. The fix is to use the **standard OZ remappings** and update all project imports to match:

```
@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
```

## Test plan

- [x] `forge test` — all 97 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)