### PR TITLE
feat: add configurable governance parameter setters

### DIFF
--- a/docs/PROTOCOL_EXPLAINER.md
+++ b/docs/PROTOCOL_EXPLAINER.md
@@ -1,0 +1,315 @@
+# Safety Net Protocol Explainer
+
+A plain-language overview of how Safety Net works — what it is, how groups use it, and
+what the key mechanics mean in practice.
+
+---
+
+## What is Safety Net?
+
+Safety Net is an on-chain implementation of a Broodfond — a Dutch model of mutual-aid
+income protection popular among freelancers and the self-employed. A Broodfond is a group
+savings pool where members regularly contribute money, and any member who experiences an
+income disruption (illness, job loss, unexpected expense) can request a payout from the
+shared pool.
+
+Safety Net brings this model to EVM-compatible blockchains using ERC-20 tokens. Any group
+of people — a freelancers' collective, a community cooperative, a friend group — can create
+a Safety Net, invite members, and run the mutual-aid protocol entirely on-chain with no
+central custodian.
+
+Key properties:
+
+- Non-custodial. Funds sit in the smart contract, not with any individual or company.
+- Permissioned membership. The Safety Net owner controls who can join via signed invites.
+- Configurable rules. Each Safety Net has its own parameters for deposits, withdrawals,
+  voting thresholds, and time windows.
+- Transparent. All contributions, balances, votes, and withdrawals are publicly visible.
+
+---
+
+## Lifecycle: Create → Join → Deposit → Withdraw → Decommission
+
+### 1. Create
+
+The Safety Net owner calls `create()` with a configuration struct. This sets:
+
+- The ERC-20 token used for all deposits and withdrawals (must be whitelisted by the
+  contract administrator).
+- The initial deposit required when a member first joins.
+- The fixed deposit (dues) each member must contribute per epoch.
+- The redeem ratio, which amplifies each member's withdrawable balance relative to
+  what they deposited.
+- Time parameters: epoch duration, contest window, voting window, Safety Net start time.
+- Membership limits: minimum and maximum member count.
+- Governance thresholds: consensus threshold, auto-execution threshold, and small
+  withdrawals limit.
+
+A unique ID is assigned and the Safety Net is live once the `safetyNetStart` timestamp
+is reached.
+
+### 2. Join
+
+New members join by redeeming a signed invite from the Safety Net owner. The owner
+generates an EIP-712 signed message containing the Safety Net ID and a unique nonce.
+This signature is passed to `redeemInvite()`. The contract:
+
+- Verifies the signature was created by the Safety Net owner.
+- Ensures the nonce has not been used before (preventing replay attacks).
+- Checks the Safety Net has not reached its maximum member count.
+- Adds the caller as a member.
+
+This approach lets the owner control access off-chain (no gas cost to the owner) while
+the join transaction is paid by the new member.
+
+### 3. Deposit
+
+Members deposit by calling `deposit()` or `depositFor()` (which allows depositing on
+behalf of another member).
+
+On a member's first deposit (onboarding epoch), they must pay exactly the `initialDeposit`
+amount in a single transaction. This acts as a commitment fee and sets up their monthly
+contribution record.
+
+In subsequent epochs, members pay the `fixedDeposit` amount. Partial payments are allowed
+— a member can spread their epoch dues across multiple transactions — as long as the total
+paid in one epoch does not exceed the `fixedDeposit`. Each deposit increases the member's
+`withdrawableBalance` by `depositAmount * redeemRatio`.
+
+### 4. Withdraw
+
+There are two withdrawal paths depending on the amount:
+
+**Small withdrawals** (amount <= autoThreshold):
+The withdrawal executes immediately without any voting. There is a per-epoch limit on how
+many small withdrawals a member can make (`smallWithdrawsLimit`). Once that limit is
+reached, any further withdrawal — even a small one — is blocked until the next epoch.
+
+**Large withdrawals** (amount > autoThreshold):
+A withdrawal request is created and enters the contest/vote flow described below.
+
+The amount a member can withdraw is calculated from their contribution history and the
+redeem ratio. The daily withdrawable amount is:
+
+    dailyAmount = (memberFixedDeposit * redeemRatio) / 30
+
+A member specifies how many days of benefit they want when calling `withdraw()`.
+
+### 5. Decommission
+
+A Safety Net can be decommissioned if any member missed their full epoch dues in any
+past epoch. The `isDecommissionable()` function checks all past epochs for any member
+whose total deposits fell below `fixedDeposit`.
+
+When decommissioned, the contract distributes each member's `withdrawableBalance` back
+to them, then splits any remaining pool balance equally among all members. The Safety Net
+record is deleted.
+
+---
+
+## Epoch System and Dues
+
+Time is divided into fixed-length epochs, measured in seconds (e.g., 30 days = 2592000
+seconds). The epoch index is computed from the Safety Net start time:
+
+    epochIndex = (currentTimestamp - safetyNetStart) / epochDuration
+
+Epoch 0 is the first epoch. Each member must deposit exactly `fixedDeposit` tokens within
+each epoch to remain in good standing. Partial deposits are accumulated and tracked per
+epoch per member in `epochMemberDepositedAmount`.
+
+If any member fails to meet their dues by the end of an epoch, the Safety Net becomes
+decommissionable. This creates a strong social and financial incentive for all members
+to contribute on time.
+
+---
+
+## Small vs Large Withdrawals
+
+The `autoThreshold` parameter divides withdrawals into two categories:
+
+**Small withdrawal** — amount is at or below `autoThreshold`:
+- Executes immediately with no approval required.
+- Deducts from the member's `withdrawableBalance` and the pool's total balance.
+- Tracked by epoch to enforce the `smallWithdrawsLimit` per member per epoch.
+
+**Large withdrawal** — amount exceeds `autoThreshold`:
+- A `Request` is created with the requested amount and timestamp.
+- Enters a contest window. Any member can call `contest()` during this window to flag
+  the request for peer review.
+- If nobody contests it within the contest window, any address can call
+  `executeContestedWithdrawal()` after the contest window closes to auto-execute the payout.
+- If the request is contested, it moves to the voting phase.
+
+---
+
+## Contest and Voting Mechanism
+
+When a large withdrawal request is contested, the group votes on whether to approve it.
+
+**Contesting**: Any member can call `contest()` within `contestWindow` seconds of the
+request being created. Once contested, the request can only be resolved by a vote.
+
+**Voting**: Members call `vote()` with `true` (approve) or `false` (reject). Each member
+gets one vote. Voting is open for `votingWindow` seconds from the request timestamp.
+
+**Consensus check**: After each vote, the contract checks whether the yes-vote count
+exceeds the consensus threshold:
+
+    yesVotes > (memberCount * consensusThreshold) / 100
+
+If consensus is reached, the withdrawal executes immediately. The member receives their
+requested amount from the pool.
+
+**No consensus / vote expires**: If the voting window closes without consensus being
+reached, the request is neither auto-executed nor manually executable. Funds remain in
+the pool. (Members would need to create a new request if they still wish to withdraw.)
+
+---
+
+## RedeemRatio Explained
+
+The `redeemRatio` is the core economic lever of a Broodfond. When a member deposits
+tokens, their withdrawable balance grows by more than what they put in:
+
+    withdrawableBalance += depositAmount * redeemRatio
+
+For example, with redeemRatio = 3:
+- A member deposits 10 tokens.
+- Their withdrawable balance increases by 30 tokens.
+- The pool only received 10 real tokens, but the member can potentially withdraw 30.
+
+This is not magic — it works because the pool is collective. Many members contribute
+regularly, so the total tokens in the pool are much larger than any individual's deposits.
+In a healthy Safety Net, only a minority of members need payouts at any one time, so the
+pool can support payouts larger than individual deposits.
+
+The contract enforces:
+- MINIMUM_REDEEM_RATIO = 1 (no amplification; withdrawable = deposited)
+- MAXIMUM_REDEEM_RATIO = 22 (22x amplification)
+
+The redeem ratio is set at creation time and cannot be changed. This ensures members
+know the payout terms before joining and no party can retroactively change the deal.
+
+---
+
+## Governance Parameters and Configurability
+
+Each Safety Net has governance parameters that control how the group operates. Starting
+with this release (#41), the Safety Net owner (the address that called `create()`) can
+update five of these parameters after creation using dedicated setter functions.
+
+This is distinct from the contract-level owner (who manages the token whitelist). The
+Safety Net owner is a per-group role.
+
+### Configurable Parameters
+
+#### consensusThreshold (setConsensusThreshold)
+The percentage of members whose yes-votes are required to immediately approve a contested
+withdrawal.
+
+- Valid range: 1 to 100 (inclusive).
+- Example: 60 means more than 60% of members must vote yes.
+- Emits: ParameterUpdated(id, keccak256("consensusThreshold"), newValue)
+
+#### autoThreshold (setAutoThreshold)
+The maximum withdrawal amount that executes automatically without any voting or contest.
+Withdrawals above this threshold become requests and enter the contest/vote flow.
+
+- Valid range: > 0
+- Emits: ParameterUpdated(id, keccak256("autoThreshold"), newValue)
+
+#### smallWithdrawsLimit (setSmallWithdrawsLimit)
+The maximum number of small (auto-executed) withdrawals a member may make per epoch.
+Once this limit is reached, the member must wait for the next epoch before making
+another small withdrawal.
+
+- Valid range: > 0
+- Emits: ParameterUpdated(id, keccak256("smallWithdrawsLimit"), newValue)
+
+#### contestWindow (setContestWindow)
+The duration in seconds during which a member can contest a large withdrawal request.
+After this window closes without a contest, the request can be auto-executed.
+
+- Valid range: > 0 AND <= votingWindow
+- The constraint ensures the contest window never exceeds the voting window (a request
+  must have time to be voted on after it can be contested).
+- Emits: ParameterUpdated(id, keccak256("contestWindow"), newValue)
+
+#### votingWindow (setVotingWindow)
+The duration in seconds during which members may cast votes on a contested request.
+The timer starts when the request is created (not when it is contested).
+
+- Valid range: > 0 AND >= contestWindow
+- The constraint ensures there is always time to vote on a contested request.
+- Emits: ParameterUpdated(id, keccak256("votingWindow"), newValue)
+
+### Access Control
+
+All setter functions check that `msg.sender == safetyNets[id].owner`. Any other caller
+receives the `Unauthorized` error. This is intentional — governance of each Safety Net
+belongs to the group's creator, not the platform operator.
+
+### Parameter Interdependencies
+
+The contest window and voting window are co-constrained:
+
+    contestWindow <= votingWindow
+
+This means:
+- You cannot set the contest window to be longer than the voting window.
+- You cannot set the voting window to be shorter than the contest window.
+- When reducing the voting window, you may first need to reduce the contest window.
+- When increasing the contest window, you may first need to increase the voting window.
+
+Owners should be transparent with their group when changing parameters, since these
+settings directly affect members' ability to contest and vote on withdrawal requests.
+
+---
+
+## Summary of Key Roles
+
+| Role | Description |
+|------|-------------|
+| Contract owner | Deployed by the platform; manages the ERC-20 token whitelist. Set via `initialize()`. |
+| Safety Net owner | Group creator; configures and governs one Safety Net. Set per Safety Net in the `create()` call. |
+| Member | Deposits dues, makes withdrawals, contests requests, votes. Joins via signed invite. |
+
+---
+
+## Summary of Key Events
+
+| Event | Trigger |
+|-------|---------|
+| SafetyNetCreated | New Safety Net created |
+| InviteRedeemed | Member joins via invite |
+| FundsDeposited | Member deposits tokens |
+| FundsWithdrawn | Small withdrawal auto-executed |
+| RequestCreated | Large withdrawal request opened |
+| WithdrawalPending | Large withdrawal request opened (alias) |
+| WithdrawalContested | Request flagged for voting |
+| Voted | Member casts a vote |
+| WithdrawalApproved | Consensus reached; withdrawal executed |
+| WithdrawalAutoExecuted | Contest window closed with no contest; auto-executed |
+| RequestEnded | Voting concluded |
+| SafetyNetDecommissioned | Safety Net wound down |
+| ParameterUpdated | Owner changed a governance parameter |
+| TokenAllowed | Platform owner whitelisted or de-listed a token |
+
+---
+
+## Quick Reference: Validation Rules
+
+| Parameter | Rule |
+|-----------|------|
+| minimumMembers | >= 2 |
+| maximumMembers | >= minimumMembers |
+| initialDeposit | > 0 |
+| fixedDeposit | > 0 |
+| epochDuration | > 0 |
+| redeemRatio | 1 to 22 (inclusive) |
+| autoThreshold | > 0 |
+| smallWithdrawsLimit | > 0 |
+| consensusThreshold | 1 to 100 (settable post-create) |
+| contestWindow | > 0 and <= votingWindow (settable post-create) |
+| votingWindow | > 0 and >= contestWindow (settable post-create) |

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -17,10 +17,15 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Number of days in a month (used for calculating monthly withdrawals)
   uint256 public constant DAYS_IN_A_MONTH = 30;
 
-  /// @notice Minimum redeem ratio
+  /// @notice Minimum redeem ratio (inclusive lower bound for SafetyNet.redeemRatio).
+  ///         A ratio of 1 means each deposited token grants exactly 1 token of withdrawal capacity —
+  ///         members can withdraw up to the total amount they have deposited (no amplification).
   uint256 public constant MINIMUM_REDEEM_RATIO = 1;
 
-  /// @notice Maximum redeem ratio
+  /// @notice Maximum redeem ratio (inclusive upper bound for SafetyNet.redeemRatio).
+  ///         A ratio of 22 means each deposited token grants 22 tokens of withdrawal capacity,
+  ///         allowing members to withdraw up to 22x the value of their fixed deposits.
+  ///         This cap prevents extreme liquidity mismatches within the collective pool.
   uint256 public constant MAXIMUM_REDEEM_RATIO = 22;
 
   /// @notice Invite signing domain name used for EIP-712 signatures
@@ -316,7 +321,46 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     }
   }
   /// @inheritdoc ISafetyNet
+  function setConsensusThreshold(uint256 _id, uint256 _newThreshold) external override {
+    if (msg.sender != safetyNets[_id].owner) revert Unauthorized();
+    if (_newThreshold < 1 || _newThreshold > 100) revert InvalidConsensusThreshold();
+    safetyNets[_id].consensusThreshold = _newThreshold;
+    emit ParameterUpdated(_id, keccak256('consensusThreshold'), _newThreshold);
+  }
 
+  /// @inheritdoc ISafetyNet
+  function setAutoThreshold(uint256 _id, uint256 _newAutoThreshold) external override {
+    if (msg.sender != safetyNets[_id].owner) revert Unauthorized();
+    if (_newAutoThreshold == 0) revert InvalidThreshold();
+    safetyNets[_id].autoThreshold = _newAutoThreshold;
+    emit ParameterUpdated(_id, keccak256('autoThreshold'), _newAutoThreshold);
+  }
+
+  /// @inheritdoc ISafetyNet
+  function setSmallWithdrawsLimit(uint256 _id, uint256 _newLimit) external override {
+    if (msg.sender != safetyNets[_id].owner) revert Unauthorized();
+    if (_newLimit == 0) revert InvalidSmallWithdrawsLimit();
+    safetyNets[_id].smallWithdrawsLimit = _newLimit;
+    emit ParameterUpdated(_id, keccak256('smallWithdrawsLimit'), _newLimit);
+  }
+
+  /// @inheritdoc ISafetyNet
+  function setContestWindow(uint256 _id, uint256 _newWindow) external override {
+    if (msg.sender != safetyNets[_id].owner) revert Unauthorized();
+    if (_newWindow == 0 || _newWindow > safetyNets[_id].votingWindow) revert InvalidContestWindow();
+    safetyNets[_id].contestWindow = _newWindow;
+    emit ParameterUpdated(_id, keccak256('contestWindow'), _newWindow);
+  }
+
+  /// @inheritdoc ISafetyNet
+  function setVotingWindow(uint256 _id, uint256 _newWindow) external override {
+    if (msg.sender != safetyNets[_id].owner) revert Unauthorized();
+    if (_newWindow == 0 || _newWindow < safetyNets[_id].contestWindow) revert InvalidVotingWindow();
+    safetyNets[_id].votingWindow = _newWindow;
+    emit ParameterUpdated(_id, keccak256('votingWindow'), _newWindow);
+  }
+
+  /// @inheritdoc ISafetyNet
   function isTokenAllowed(address _token) external view override returns (bool) {
     return allowedTokens[_token];
   }
@@ -498,12 +542,29 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /**
-   * @dev Make a withdrawal
-   * @param _id The ID of the Safety Net
-   * @param _member The address of the member making the withdrawal
-   * @param _daysRequested The number of days for which the member is requesting a withdrawal
-   * @notice If the requested amount is small, it is transferred directly to the member
-   *         If the requested amount is large, a request is created for approval
+   * @dev Execute a withdrawal for a Safety Net member.
+   *
+   * Withdrawal amount is computed in two steps using the redeemRatio multiplier:
+   *
+   *   Step 1 — Daily entitlement:
+   *       dailyWithdrawableAmount = (memberContribute * redeemRatio) / DAYS_IN_A_MONTH
+   *     where `memberContribute` is the member's fixed deposit (`safetyNetMemberContribute[_id][_member]`),
+   *     `redeemRatio` is the Safety Net's configured multiplier, and `DAYS_IN_A_MONTH` is 30.
+   *
+   *   Step 2 — Requested amount:
+   *       withdrawAmount = dailyWithdrawableAmount * daysRequested
+   *
+   *   Step 3 — Routing:
+   *     - If withdrawAmount <= autoThreshold  =>  small withdrawal: tokens are transferred directly to the member.
+   *     - If withdrawAmount >  autoThreshold  =>  large withdrawal: a Request is created and must be approved by peers.
+   *
+   * Worked example (redeemRatio = 5, fixedDeposit = 10e18, DAYS_IN_A_MONTH = 30):
+   *   dailyWithdrawableAmount = (10e18 * 5) / 30 = 1_666_666_666_666_666_666  (~1.667 tokens/day)
+   *   For 3 days requested: withdrawAmount = 1_666_666_666_666_666_666 * 3 = 4_999_999_999_999_999_998  (~5 tokens)
+   *
+   * @param _id              The ID of the Safety Net
+   * @param _member          The address of the member making the withdrawal
+   * @param _daysRequested   The number of days for which the member is requesting a withdrawal
    */
   function _withdraw(uint256 _id, address _member, uint256 _daysRequested) internal {
     SafetyNet memory _safetyNet = safetyNets[_id];
@@ -536,7 +597,24 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     }
   }
 
-  /// @dev Calculates the daily withdrawal for a member in a Safety Net
+  /// @dev Calculates the daily withdrawal entitlement for a member in a Safety Net.
+  ///
+  /// Formula (step by step):
+  ///   1. Retrieve `memberContribute` = safetyNetMemberContribute[_id][_member]
+  ///      This is the member's fixed deposit amount set after their onboarding deposit.
+  ///   2. Compute monthly entitlement:
+  ///          monthlyWithdrawalAmount = memberContribute * redeemRatio
+  ///   3. Divide by DAYS_IN_A_MONTH (30) to obtain the per-day amount:
+  ///          dailyWithdrawableAmount = monthlyWithdrawalAmount / DAYS_IN_A_MONTH
+  ///
+  /// Example (memberContribute = 10e18, redeemRatio = 5):
+  ///   monthlyWithdrawalAmount = 10e18 * 5 = 50e18
+  ///   dailyWithdrawableAmount = 50e18 / 30  = 1_666_666_666_666_666_666  (~1.667 tokens/day)
+  ///
+  /// @param _id           The Safety Net ID
+  /// @param _member       The member address
+  /// @param _redeemRatio  The ratio multiplier from the SafetyNet config
+  /// @return              The amount the member may withdraw per day (in token wei)
   function _getDailyWithdrawableAmount(uint256 _id, address _member, uint256 _redeemRatio) internal view returns (uint256) {
     uint256 _memberContribute = safetyNetMemberContribute[_id][_member];
     uint256 _monthlyWithdrawalAmount = _memberContribute * _redeemRatio;

--- a/src/interfaces/ISafetyNet.sol
+++ b/src/interfaces/ISafetyNet.sol
@@ -23,7 +23,13 @@ interface ISafetyNet {
   /// @param members List of member addresses
   /// @param initialDeposit Initial deposit required to join
   /// @param fixedDeposit Fixed deposit fee amount
-  /// @param redeemRatio Ratio of deposit to withdrawal
+  /// @param redeemRatio Multiplier applied to each deposit to determine a member's withdrawal entitlement.
+  ///        Valid range: MINIMUM_REDEEM_RATIO (1) to MAXIMUM_REDEEM_RATIO (22).
+  ///        When a member deposits `V` tokens, their `memberWithdrawableBalance` increases by `V * redeemRatio`.
+  ///        The daily withdrawal entitlement is computed as:
+  ///            dailyWithdrawableAmount = (fixedDeposit * redeemRatio) / DAYS_IN_A_MONTH
+  ///        A ratio of 1 means members can withdraw exactly what they deposit (no multiplier).
+  ///        A ratio of 5 means each token deposited entitles the member to 5 tokens of withdrawal capacity.
   /// @param contestWindow Duration of the contest period for requests
   /// @param votingWindow Duration of the voting period for requests
   /// @param epochDuration Duration of each epoch in seconds
@@ -126,6 +132,9 @@ interface ISafetyNet {
 
   /// @notice Emitted when an invite is successfully redeemed
   event InviteRedeemed(uint256 indexed safetyNetId, address indexed redeemer);
+
+  /// @notice Emitted when a governance parameter is updated by the Safety Net owner
+  event ParameterUpdated(uint256 indexed id, bytes32 indexed parameter, uint256 newValue);
 
   /*///////////////////////////////////////////////////////////////
                             ERRORS
@@ -252,6 +261,18 @@ interface ISafetyNet {
   /// @notice Thrown when attempting to add members beyond the maximum allowed
   error SafetyNetFull();
 
+  /// @notice Thrown when consensus threshold is out of valid range (must be 1-100)
+  error InvalidConsensusThreshold();
+
+  /// @notice Thrown when contest window is invalid (must be > 0 and <= votingWindow)
+  error InvalidContestWindow();
+
+  /// @notice Thrown when voting window is invalid (must be > 0 and >= contestWindow)
+  error InvalidVotingWindow();
+
+  /// @notice Thrown when caller is not the Safety Net owner
+  error Unauthorized();
+
   /*///////////////////////////////////////////////////////////////
                             EXTERNAL
   //////////////////////////////////////////////////////////////*/
@@ -312,6 +333,31 @@ interface ISafetyNet {
   /// @param requestId The ID of the request
   /// @param voteValue True for yes, false for no
   function vote(uint256 requestId, bool voteValue) external;
+
+  /// @notice Updates the consensus threshold for a Safety Net
+  /// @param id The Safety Net ID
+  /// @param newThreshold New threshold percentage (1-100)
+  function setConsensusThreshold(uint256 id, uint256 newThreshold) external;
+
+  /// @notice Updates the auto-execution threshold for a Safety Net
+  /// @param id The Safety Net ID
+  /// @param newAutoThreshold New auto threshold amount (must be > 0)
+  function setAutoThreshold(uint256 id, uint256 newAutoThreshold) external;
+
+  /// @notice Updates the small withdrawals limit for a Safety Net
+  /// @param id The Safety Net ID
+  /// @param newLimit New small withdrawals limit per epoch (must be > 0)
+  function setSmallWithdrawsLimit(uint256 id, uint256 newLimit) external;
+
+  /// @notice Updates the contest window for a Safety Net
+  /// @param id The Safety Net ID
+  /// @param newWindow New contest window duration in seconds (must be > 0 and <= votingWindow)
+  function setContestWindow(uint256 id, uint256 newWindow) external;
+
+  /// @notice Updates the voting window for a Safety Net
+  /// @param id The Safety Net ID
+  /// @param newWindow New voting window duration in seconds (must be > 0 and >= contestWindow)
+  function setVotingWindow(uint256 id, uint256 newWindow) external;
 
   /*///////////////////////////////////////////////////////////////
                             VIEW

--- a/test/unit/SafetyNetConfigurable.t.sol
+++ b/test/unit/SafetyNetConfigurable.t.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {Test} from 'forge-std/Test.sol';
+
+import {SafetyNet} from 'src/contracts/SafetyNet.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+/// @title SafetyNetConfigurable
+/// @notice Unit tests for owner-controlled governance parameter setters (#41)
+contract SafetyNetConfigurable is Test {
+  SafetyNet internal _sn;
+  MockERC20 internal _token;
+
+  address internal _owner;
+  uint256 internal _ownerKey;
+  address internal _nonOwner = makeAddr('nonOwner');
+  address internal _alice = makeAddr('alice');
+  address internal _bob = makeAddr('bob');
+
+  uint256 internal _snId;
+
+  function setUp() public {
+    (_owner, _ownerKey) = makeAddrAndKey('owner');
+
+    // Deploy upgradeable proxy
+    address impl = address(new SafetyNet());
+    address admin = address(new ProxyAdmin(_owner));
+    address proxy = address(
+      new TransparentUpgradeableProxy(impl, admin, abi.encodeWithSelector(SafetyNet.initialize.selector, _owner))
+    );
+    _sn = SafetyNet(proxy);
+
+    _token = new MockERC20('Mock', 'MOCK');
+
+    // Whitelist token (contract-level owner)
+    vm.prank(_owner);
+    _sn.setTokenAllowed(address(_token), true);
+
+    // Mint and approve for members
+    _token.mint(_alice, 1_000_000 ether);
+    _token.mint(_bob, 1_000_000 ether);
+    vm.prank(_alice);
+    _token.approve(address(_sn), type(uint256).max);
+    vm.prank(_bob);
+    _token.approve(address(_sn), type(uint256).max);
+
+    // Create a default Safety Net owned by _owner
+    address[] memory members = new address[](2);
+    members[0] = _alice;
+    members[1] = _bob;
+
+    ISafetyNet.SafetyNet memory sn = ISafetyNet.SafetyNet({
+      id: 0,
+      owner: _owner,
+      minimumMembers: 2,
+      maximumMembers: 5,
+      consensusThreshold: 60,
+      safetyNetStart: block.timestamp,
+      token: address(_token),
+      members: members,
+      initialDeposit: 100 ether,
+      fixedDeposit: 10 ether,
+      redeemRatio: 1,
+      autoThreshold: 50 ether,
+      contestWindow: 3 days,
+      votingWindow: 7 days,
+      epochDuration: 30 days,
+      smallWithdrawsLimit: 3
+    });
+
+    vm.prank(_owner);
+    _snId = _sn.create(sn);
+  }
+
+  // -----------------------------------------------------------------------
+  // setConsensusThreshold
+  // -----------------------------------------------------------------------
+
+  function test_setConsensusThreshold_ownerSuccess() public {
+    vm.prank(_owner);
+    _sn.setConsensusThreshold(_snId, 75);
+    assertEq(_sn.getSafetyNet(_snId).consensusThreshold, 75);
+  }
+
+  function test_setConsensusThreshold_nonOwnerReverts() public {
+    vm.prank(_nonOwner);
+    vm.expectRevert(ISafetyNet.Unauthorized.selector);
+    _sn.setConsensusThreshold(_snId, 75);
+  }
+
+  function test_setConsensusThreshold_zeroReverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidConsensusThreshold.selector);
+    _sn.setConsensusThreshold(_snId, 0);
+  }
+
+  function test_setConsensusThreshold_101Reverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidConsensusThreshold.selector);
+    _sn.setConsensusThreshold(_snId, 101);
+  }
+
+  function test_setConsensusThreshold_boundary1Succeeds() public {
+    vm.prank(_owner);
+    _sn.setConsensusThreshold(_snId, 1);
+    assertEq(_sn.getSafetyNet(_snId).consensusThreshold, 1);
+  }
+
+  function test_setConsensusThreshold_boundary100Succeeds() public {
+    vm.prank(_owner);
+    _sn.setConsensusThreshold(_snId, 100);
+    assertEq(_sn.getSafetyNet(_snId).consensusThreshold, 100);
+  }
+
+  function test_setConsensusThreshold_emitsParameterUpdated() public {
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.ParameterUpdated(_snId, keccak256('consensusThreshold'), 80);
+    vm.prank(_owner);
+    _sn.setConsensusThreshold(_snId, 80);
+  }
+
+  // -----------------------------------------------------------------------
+  // setAutoThreshold
+  // -----------------------------------------------------------------------
+
+  function test_setAutoThreshold_ownerSuccess() public {
+    vm.prank(_owner);
+    _sn.setAutoThreshold(_snId, 100 ether);
+    assertEq(_sn.getSafetyNet(_snId).autoThreshold, 100 ether);
+  }
+
+  function test_setAutoThreshold_nonOwnerReverts() public {
+    vm.prank(_nonOwner);
+    vm.expectRevert(ISafetyNet.Unauthorized.selector);
+    _sn.setAutoThreshold(_snId, 100 ether);
+  }
+
+  function test_setAutoThreshold_zeroReverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidThreshold.selector);
+    _sn.setAutoThreshold(_snId, 0);
+  }
+
+  function test_setAutoThreshold_emitsParameterUpdated() public {
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.ParameterUpdated(_snId, keccak256('autoThreshold'), 200 ether);
+    vm.prank(_owner);
+    _sn.setAutoThreshold(_snId, 200 ether);
+  }
+
+  // -----------------------------------------------------------------------
+  // setSmallWithdrawsLimit
+  // -----------------------------------------------------------------------
+
+  function test_setSmallWithdrawsLimit_ownerSuccess() public {
+    vm.prank(_owner);
+    _sn.setSmallWithdrawsLimit(_snId, 5);
+    assertEq(_sn.getSafetyNet(_snId).smallWithdrawsLimit, 5);
+  }
+
+  function test_setSmallWithdrawsLimit_nonOwnerReverts() public {
+    vm.prank(_nonOwner);
+    vm.expectRevert(ISafetyNet.Unauthorized.selector);
+    _sn.setSmallWithdrawsLimit(_snId, 5);
+  }
+
+  function test_setSmallWithdrawsLimit_zeroReverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidSmallWithdrawsLimit.selector);
+    _sn.setSmallWithdrawsLimit(_snId, 0);
+  }
+
+  function test_setSmallWithdrawsLimit_emitsParameterUpdated() public {
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.ParameterUpdated(_snId, keccak256('smallWithdrawsLimit'), 10);
+    vm.prank(_owner);
+    _sn.setSmallWithdrawsLimit(_snId, 10);
+  }
+
+  // -----------------------------------------------------------------------
+  // setContestWindow
+  // -----------------------------------------------------------------------
+
+  function test_setContestWindow_ownerSuccess() public {
+    // contestWindow must be <= votingWindow (7 days); use 2 days
+    vm.prank(_owner);
+    _sn.setContestWindow(_snId, 2 days);
+    assertEq(_sn.getSafetyNet(_snId).contestWindow, 2 days);
+  }
+
+  function test_setContestWindow_nonOwnerReverts() public {
+    vm.prank(_nonOwner);
+    vm.expectRevert(ISafetyNet.Unauthorized.selector);
+    _sn.setContestWindow(_snId, 2 days);
+  }
+
+  function test_setContestWindow_zeroReverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidContestWindow.selector);
+    _sn.setContestWindow(_snId, 0);
+  }
+
+  function test_setContestWindow_exceedsVotingWindowReverts() public {
+    // votingWindow is 7 days; setting contestWindow to 8 days should revert
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidContestWindow.selector);
+    _sn.setContestWindow(_snId, 8 days);
+  }
+
+  function test_setContestWindow_equalToVotingWindowSucceeds() public {
+    // contestWindow == votingWindow is valid (<=)
+    vm.prank(_owner);
+    _sn.setContestWindow(_snId, 7 days);
+    assertEq(_sn.getSafetyNet(_snId).contestWindow, 7 days);
+  }
+
+  function test_setContestWindow_emitsParameterUpdated() public {
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.ParameterUpdated(_snId, keccak256('contestWindow'), 2 days);
+    vm.prank(_owner);
+    _sn.setContestWindow(_snId, 2 days);
+  }
+
+  // -----------------------------------------------------------------------
+  // setVotingWindow
+  // -----------------------------------------------------------------------
+
+  function test_setVotingWindow_ownerSuccess() public {
+    // votingWindow must be >= contestWindow (3 days); use 10 days
+    vm.prank(_owner);
+    _sn.setVotingWindow(_snId, 10 days);
+    assertEq(_sn.getSafetyNet(_snId).votingWindow, 10 days);
+  }
+
+  function test_setVotingWindow_nonOwnerReverts() public {
+    vm.prank(_nonOwner);
+    vm.expectRevert(ISafetyNet.Unauthorized.selector);
+    _sn.setVotingWindow(_snId, 10 days);
+  }
+
+  function test_setVotingWindow_zeroReverts() public {
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidVotingWindow.selector);
+    _sn.setVotingWindow(_snId, 0);
+  }
+
+  function test_setVotingWindow_belowContestWindowReverts() public {
+    // contestWindow is 3 days; setting votingWindow to 2 days should revert
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidVotingWindow.selector);
+    _sn.setVotingWindow(_snId, 2 days);
+  }
+
+  function test_setVotingWindow_equalToContestWindowSucceeds() public {
+    // votingWindow == contestWindow is valid (>=)
+    vm.prank(_owner);
+    _sn.setVotingWindow(_snId, 3 days);
+    assertEq(_sn.getSafetyNet(_snId).votingWindow, 3 days);
+  }
+
+  function test_setVotingWindow_emitsParameterUpdated() public {
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.ParameterUpdated(_snId, keccak256('votingWindow'), 14 days);
+    vm.prank(_owner);
+    _sn.setVotingWindow(_snId, 14 days);
+  }
+
+  // -----------------------------------------------------------------------
+  // Cross-parameter constraint tests
+  // -----------------------------------------------------------------------
+
+  function test_reduceVotingWindow_thenContestWindowBecomesTooLarge() public {
+    // Reduce votingWindow to 4 days first (still >= contestWindow of 3 days)
+    vm.prank(_owner);
+    _sn.setVotingWindow(_snId, 4 days);
+
+    // Now try to set contestWindow to 5 days — exceeds new votingWindow
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidContestWindow.selector);
+    _sn.setContestWindow(_snId, 5 days);
+  }
+
+  function test_increaseContestWindow_thenVotingWindowMustIncreaseToo() public {
+    // Increase contestWindow to 7 days (equal to current votingWindow — valid)
+    vm.prank(_owner);
+    _sn.setContestWindow(_snId, 7 days);
+
+    // Now reduce votingWindow below contestWindow — should revert
+    vm.prank(_owner);
+    vm.expectRevert(ISafetyNet.InvalidVotingWindow.selector);
+    _sn.setVotingWindow(_snId, 5 days);
+  }
+}


### PR DESCRIPTION
## Summary
Adds owner-controlled setter functions for governance parameters, allowing Safety Net creators to tune their group's rules after creation.

### New Setters
- `setConsensusThreshold(id, newThreshold)` — range: 1-100
- `setAutoThreshold(id, newAutoThreshold)` — must be > 0
- `setSmallWithdrawsLimit(id, newLimit)` — must be > 0
- `setContestWindow(id, newWindow)` — must be > 0 and ≤ votingWindow
- `setVotingWindow(id, newWindow)` — must be > 0 and ≥ contestWindow

### Changes
- **ISafetyNet.sol**: New event `ParameterUpdated`, 4 new errors, 5 function signatures
- **SafetyNet.sol**: 5 setter implementations with owner check + validation + event emission
- **docs/PROTOCOL_EXPLAINER.md**: ~300 line plain-language protocol overview

### Testing
29 new tests: happy paths, unauthorized caller reverts, boundary validation (0/101 fail, 1/100 pass), cross-parameter constraints, event emission. All 126 tests pass.

Closes #41