### PR TITLE
[TEST — do not merge] Evaluate etherform upgrade-safety on a storage-layout violation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,11 +12,11 @@ concurrency:
 
 jobs:
   cicd:
-    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@main
+    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@RonTuretzky/codebase-improvement-plan
     secrets: inherit
     with:
       package-manager: yarn
-      main-branch: dev
+      base-branch: dev
       deploy-on-pr: true
       deploy-script: 'script/Deploy.sol:Deploy'
       contract-paths: |

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -73,6 +73,11 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Base denominator used for percentage calculations
   uint256 public constant PERCENTAGE_BASE = 100;
 
+  /// @notice TEST-ONLY storage-layout violation inserted to evaluate etherform's upgrade-safety check.
+  /// @dev Placing a new slot BEFORE the existing storage variables shifts every subsequent slot,
+  ///      which would brick a live proxy upgrade. The upgrade-safety job must catch this and fail.
+  uint256 public injectedUpgradeViolation;
+
   /// @notice ID counter used to assign unique identifiers to each Safety Net
   uint256 public nextId;
 


### PR DESCRIPTION
## Purpose

Validation PR for the etherform overhaul in [BreadchainCoop/etherform#52](https://github.com/BreadchainCoop/etherform/pull/52). **Not for merge** — please close after reviewing the check results.

It does two things:

1. **Repoints CI/CD at the overhaul branch** — `_foundry-cicd.yml@RonTuretzky/codebase-improvement-plan` (HEAD `1bec5c4`) instead of `@main`. This exercises the cross-repo path that etherform's own CI can't test: a real consumer calling the refactored, nested reusable workflows, with the bash scripts pulled from the same commit via `job.workflow_sha`.
2. **Deliberately violates upgrade safety** — inserts `uint256 public injectedUpgradeViolation` *before* `nextId` in `SafetyNet`, shifting every subsequent storage slot. This would brick a live proxy upgrade.

It also migrates the renamed workflow input `main-branch:` → `base-branch:` (a breaking change introduced by the overhaul), so this doubles as a migration check.

## Expected result

- ✅ Detect Changes — runs (contract changed)
- ✅ Build & Test — passes (the contract still compiles; the extra slot is harmless to compilation)
- ❌ **Upgrade Safety — FAILS** ← the behavior under test: OZ upgrades-core must detect the storage-layout incompatibility against `dev`
- ⏭️ Deploy Testnet — skipped (gated on upgrade-safety succeeding, so no deployment to Gnosis happens)

A green Upgrade Safety check here would be the bug. A red one confirms the check works end-to-end from a real consumer repo.