### PR TITLE
chore: wire live Privy app id and deployed subgraph into the hosted build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,6 +43,11 @@ jobs:
           NEXT_PUBLIC_BASE_PATH: /safety-net
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
           NEXT_PUBLIC_SAFETYNET_ADDRESS: ${{ vars.NEXT_PUBLIC_SAFETYNET_ADDRESS }}
+          # Privy embedded wallets go live when this repo variable is set. Leave
+          # it UNSET to keep the RainbowKit path; the app is byte-identical then.
+          NEXT_PUBLIC_PRIVY_APP_ID: ${{ vars.NEXT_PUBLIC_PRIVY_APP_ID }}
+          # Activity feed reads the subgraph when set, else falls back to logs.
+          NEXT_PUBLIC_SUBGRAPH_URL: ${{ vars.NEXT_PUBLIC_SUBGRAPH_URL }}
         run: pnpm build
 
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -42,7 +42,7 @@ jobs:
     # Pinned to a commit SHA per subgraphform's README recommendation.
     uses: BreadchainCoop/subgraphform/.github/workflows/_subgraph-cicd.yml@b9c8ff3510380fad98b610bd8c0f855d1b9f331c
     with:
-      subgraph-name: safety-net-gnosis
+      subgraph-name: safety-net
       working-directory: subgraph
       deploy-on-main: true
       deploy-on-pr: false

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -7,7 +7,7 @@ plus members / deposits / withdrawals / requests / contests for the web app.
 - **Proxy (source):** `0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE`
 - **Network:** `gnosis`
 - **Start block:** `47000324`
-- **Studio slug:** `safety-net-gnosis`
+- **Studio slug:** `safety-net`
 
 Built on Breadchain's [subgraphform](https://github.com/BreadchainCoop/subgraphform)
 reusable CI/CD workflow (standard graph-cli layout, deploys to The Graph Studio).
@@ -60,7 +60,7 @@ the `main` branch once the deploy key exists. To deploy manually or set up CI:
 
 1. **Create the Studio subgraph.** Sign in at
    https://thegraph.com/studio with the deployer wallet and create a subgraph
-   with the slug **`safety-net-gnosis`** on network **Gnosis**.
+   with the slug **`safety-net`** on network **Gnosis**.
 2. **Get the deploy key.** Copy the "Deploy Key" shown in Studio.
 3. **CI:** add it as a repo secret named **`GRAPH_DEPLOY_KEY`** (Settings →
    Secrets and variables → Actions). CI deploys on push to `main`.
@@ -68,7 +68,7 @@ the `main` branch once the deploy key exists. To deploy manually or set up CI:
    ```bash
    yarn graph auth <DEPLOY_KEY>
    yarn codegen && yarn build
-   yarn graph deploy --version-label v0.0.1 safety-net-gnosis
+   yarn graph deploy --version-label v0.0.1 safety-net
    ```
 
 ### Deploy branch note
@@ -83,7 +83,7 @@ branch. See the comments in `.github/workflows/subgraph.yml`.
 Once deployed, the free Studio dev query endpoint (no API key, rate-limited) is:
 
 ```
-https://api.studio.thegraph.com/query/<studio-id>/safety-net-gnosis/<version>
+https://api.studio.thegraph.com/query/<studio-id>/safety-net/<version>
 ```
 
 The web app reads this from the env var **`NEXT_PUBLIC_SUBGRAPH_URL`**. Set it

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ safety-net-gnosis",
-    "create-local": "graph create --node http://localhost:8020/ safety-net-gnosis",
-    "remove-local": "graph remove --node http://localhost:8020/ safety-net-gnosis",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 safety-net-gnosis",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ safety-net",
+    "create-local": "graph create --node http://localhost:8020/ safety-net",
+    "remove-local": "graph remove --node http://localhost:8020/ safety-net",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 safety-net",
     "test": "graph test"
   },
   "dependencies": {


### PR DESCRIPTION
Sets the hosted build env for the two credentials just provisioned:
- `NEXT_PUBLIC_PRIVY_APP_ID` (repo variable) → live site uses Privy embedded wallets + sponsored txs. Remove the variable to revert to RainbowKit.
- `NEXT_PUBLIC_SUBGRAPH_URL` (repo variable) → activity feed reads the deployed subgraph (`safety-net` slug, Studio id 1756070), falling back to event logs on error.
- Subgraph slug renamed `safety-net-gnosis` → `safety-net` to match the created Studio subgraph.

The subgraph is already deployed and synced (no indexing errors). `GRAPH_DEPLOY_KEY` secret set for CI.