### PR TITLE
feat: redesign Create page (BREAD/custom tokens, stacks-style two-panel + overview)

### DIFF
--- a/web/src/app/create/page.tsx
+++ b/web/src/app/create/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { PageHeader } from "@/components/ui/ui";
 import { CreateForm } from "@/components/create/create-form";
 import { buildMetadata } from "@/lib/metadata";
 
@@ -12,11 +11,7 @@ export const metadata: Metadata = buildMetadata({
 
 export default function CreatePage() {
   return (
-    <div className="mx-auto max-w-2xl">
-      <PageHeader
-        title="Create a Safety Net"
-        subtitle="Set the rules of your group fund — who's in, what everyone contributes, and how withdrawals are approved."
-      />
+    <div className="mx-auto max-w-4xl">
       <CreateForm />
     </div>
   );

--- a/web/src/components/create/create-form.tsx
+++ b/web/src/components/create/create-form.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { useId, useMemo, type ReactNode } from "react";
+import { useId, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
-import { useForm } from "react-hook-form";
+import {
+  FormProvider,
+  useForm,
+  useFormContext,
+  type UseFormReturn,
+} from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useAccount } from "wagmi";
 import { isAddress, parseEventLogs, type Address } from "viem";
-import { Body, Button, Caption, Heading4 } from "@breadcoop/ui";
-import { ArrowRight, CheckCircle } from "@phosphor-icons/react";
+import { Body, Button, Caption, Heading2, Heading4, Logo } from "@breadcoop/ui";
+import { ArrowLeft, ArrowRight, CaretDown, CheckCircle } from "@phosphor-icons/react";
 import { ActionButton } from "@/components/ui/action-button";
 import { TxStatus } from "@/components/ui/tx-status";
 import { Card } from "@/components/ui/ui";
@@ -15,7 +20,7 @@ import { useCreateSafetyNet } from "@/hooks/use-safety-net-writes";
 import { useIsTokenAllowed } from "@/hooks/use-safety-net";
 import { useTokenInfo } from "@/hooks/use-token";
 import { safetyNetAbi } from "@/lib/abi/safety-net";
-import { BREAD_ADDRESS, REDEEM_RATIO, WXDAI_ADDRESS } from "@/lib/config";
+import { BREAD_ADDRESS, REDEEM_RATIO } from "@/lib/config";
 import { parseAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { createNetSchema, type CreateNetValues } from "./schema";
@@ -23,6 +28,28 @@ import { SuccessInvites } from "./success-invites";
 
 const inputClass =
   "w-full rounded-xl border border-paper-2 bg-paper-main px-4 py-2.5 text-text-standard outline-none focus:border-primary-jade disabled:opacity-60";
+
+/**
+ * Sensible governance defaults so a user can create a working net without
+ * ever opening "Advanced settings":
+ *  - contestThreshold 50 (%)  → a large withdrawal is vetoed only if a
+ *    majority contests it.
+ *  - contestWindowDays 3      → three days to object before it executes.
+ *  - smallWithdrawsLimit 3    → three instant withdrawals per member per epoch.
+ *  - autoThreshold ""         → left blank; the Advanced section pre-fills a
+ *    suggestion (a quarter of the recurring deposit) the first time it opens.
+ *  - minimumMembers 2         → the contract minimum that gates start().
+ */
+const DEFAULTS = {
+  memberCount: 10,
+  contestThreshold: 50,
+  contestWindowDays: 3,
+  epochDurationDays: 30,
+  smallWithdrawsLimit: 3,
+  minimumMembers: 2,
+} as const;
+
+type NetForm = UseFormReturn<CreateNetValues>;
 
 function Field({
   id,
@@ -74,16 +101,386 @@ function fieldAria(id: string, error?: string, help?: string) {
   };
 }
 
-function SectionTitle({ children }: { children: ReactNode }) {
+/** BREAD square logo suffixed inside an amount input (or plain symbol text). */
+function AmountSuffix({ isBread, symbol }: { isBread: boolean; symbol: string }) {
   return (
-    <h3 className="font-breadDisplay text-text-standard mt-2 text-lg font-bold uppercase">
-      {children}
-    </h3>
+    <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
+      {isBread ? (
+        <Logo size={20} variant="square" color="jade" />
+      ) : (
+        <span className="text-surface-grey text-sm font-bold">{symbol}</span>
+      )}
+    </div>
   );
 }
 
 export function CreateForm() {
+  const form = useForm<CreateNetValues>({
+    resolver: zodResolver(createNetSchema),
+    defaultValues: {
+      memberCount: DEFAULTS.memberCount,
+      tokenChoice: "bread",
+      customToken: "",
+      initialDeposit: "",
+      fixedDeposit: "",
+      redeemRatio: REDEEM_RATIO,
+      autoThreshold: "",
+      contestThreshold: DEFAULTS.contestThreshold,
+      contestWindowDays: DEFAULTS.contestWindowDays,
+      epochDurationDays: DEFAULTS.epochDurationDays,
+      smallWithdrawsLimit: DEFAULTS.smallWithdrawsLimit,
+      minimumMembers: DEFAULTS.minimumMembers,
+    },
+  });
+
+  // Mobile step flow: fill the form → Continue → review the Overview → Create.
+  // On lg+ both panels are always visible (this flag is ignored there).
+  const [showOverview, setShowOverview] = useState(false);
+
+  return (
+    <FormProvider {...form}>
+      <form noValidate onSubmit={(e) => e.preventDefault()}>
+        <header className="mb-6">
+          <Heading2 className="text-primary-jade">New Safety Net</Heading2>
+          <Body className="text-surface-grey-2 mt-2">
+            Set the rules of your group fund — who&apos;s in, what everyone
+            contributes, and how withdrawals are approved.
+          </Body>
+        </header>
+
+        <div className="lg:flex lg:items-start lg:gap-6">
+          <div className={cn("flex-1", showOverview && "hidden lg:block")}>
+            <FormPanel onContinue={() => setShowOverview(true)} />
+          </div>
+          <div className={cn("mt-6 flex-1 lg:mt-0", !showOverview && "hidden lg:block")}>
+            <OverviewPanel onBack={() => setShowOverview(false)} />
+          </div>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}
+
+/** Left panel: essentials up front, finer governance behind "Advanced". */
+function FormPanel({ onContinue }: { onContinue: () => void }) {
+  const form = useFormContext<CreateNetValues>();
+  const {
+    register,
+    watch,
+    setValue,
+    getValues,
+    trigger,
+    formState: { errors },
+  } = form;
+  const fid = useId();
+  const id = (name: string) => `${fid}-${name}`;
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const advancedId = useId();
+
+  const tokenChoice = watch("tokenChoice");
+  const isBread = tokenChoice === "bread";
+  const symbol = useNetSymbol(form);
+
+  const continueToReview = async () => {
+    if (await trigger()) onContinue();
+  };
+
+  const openAdvanced = () => {
+    setAdvancedOpen((open) => {
+      // Pre-fill a suggested instant-withdrawal threshold (¼ of the recurring
+      // deposit) the first time Advanced opens, if the user left it blank.
+      if (!open && !getValues("autoThreshold")) {
+        const fixed = Number(getValues("fixedDeposit"));
+        if (Number.isFinite(fixed) && fixed > 0) {
+          setValue("autoThreshold", String(fixed / 4));
+        }
+      }
+      return !open;
+    });
+  };
+
+  return (
+    <Card className="flex flex-col gap-5">
+      <Field
+        label="Token"
+        help="The ERC20 everyone saves in. BREAD is the default; pick Custom for another allowed token."
+        error={errors.customToken?.message}
+      >
+        <div role="group" aria-label="Token" className="flex flex-wrap gap-2">
+          {(
+            [
+              ["bread", "BREAD"],
+              ["custom", "Custom"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={tokenChoice === value}
+              onClick={() =>
+                setValue("tokenChoice", value, { shouldValidate: true })
+              }
+              className={cn(
+                "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-bold transition-colors",
+                tokenChoice === value
+                  ? "border-primary-jade bg-primary-jade text-white"
+                  : "border-paper-2 text-surface-grey-2 hover:border-primary-jade/50",
+              )}
+            >
+              {value === "bread" && (
+                <Logo
+                  size={18}
+                  variant="square"
+                  color={tokenChoice === value ? "white" : "jade"}
+                />
+              )}
+              {label}
+            </button>
+          ))}
+        </div>
+        {tokenChoice === "custom" && (
+          <input
+            aria-label="Custom token address"
+            aria-invalid={errors.customToken ? true : undefined}
+            className={`${inputClass} mt-2`}
+            placeholder="0x… token address"
+            {...register("customToken")}
+          />
+        )}
+        <TokenAllowedWarning form={form} />
+      </Field>
+
+      <Field
+        id={id("member-count")}
+        label="Max members"
+        help="You'll be the first member. Everyone else joins through invite links before you start the net."
+        error={errors.memberCount?.message}
+      >
+        <input
+          {...fieldAria(id("member-count"), errors.memberCount?.message, "help")}
+          type="number"
+          min={2}
+          className={inputClass}
+          {...register("memberCount", { valueAsNumber: true })}
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field
+          id={id("initial-deposit")}
+          label="Initial (join) deposit"
+          help={
+            isBread
+              ? "One-off joining payment. 1 BREAD = 1 USD."
+              : "One-off joining payment — a member's first deposit must be exactly this."
+          }
+          error={errors.initialDeposit?.message}
+        >
+          <div className="relative">
+            <input
+              {...fieldAria(
+                id("initial-deposit"),
+                errors.initialDeposit?.message,
+                "help",
+              )}
+              inputMode="decimal"
+              placeholder="0.0"
+              className={`${inputClass} pr-14`}
+              {...register("initialDeposit")}
+            />
+            <AmountSuffix isBread={isBread} symbol={symbol} />
+          </div>
+        </Field>
+        <Field
+          id={id("fixed-deposit")}
+          label="Recurring deposit"
+          help={
+            isBread
+              ? "Dues each member owes every epoch. 1 BREAD = 1 USD."
+              : "Dues each member owes every epoch after joining."
+          }
+          error={errors.fixedDeposit?.message}
+        >
+          <div className="relative">
+            <input
+              {...fieldAria(
+                id("fixed-deposit"),
+                errors.fixedDeposit?.message,
+                "help",
+              )}
+              inputMode="decimal"
+              placeholder="0.0"
+              className={`${inputClass} pr-14`}
+              {...register("fixedDeposit")}
+            />
+            <AmountSuffix isBread={isBread} symbol={symbol} />
+          </div>
+        </Field>
+      </div>
+
+      <Field
+        id={id("epoch-days")}
+        label="Epoch length (days)"
+        help="How often the recurring deposit is due. 30 days ≈ monthly."
+        error={errors.epochDurationDays?.message}
+      >
+        <input
+          {...fieldAria(id("epoch-days"), errors.epochDurationDays?.message, "help")}
+          type="number"
+          min={1}
+          className={inputClass}
+          {...register("epochDurationDays", { valueAsNumber: true })}
+        />
+      </Field>
+
+      {/* Advanced settings — sensible defaults are pre-filled, so this stays
+          closed for a typical net. */}
+      <div className="border-paper-2 border-t pt-4">
+        <button
+          type="button"
+          aria-expanded={advancedOpen}
+          aria-controls={advancedId}
+          onClick={openAdvanced}
+          className="text-surface-grey-2 hover:text-primary-jade flex w-full items-center justify-between text-sm font-bold transition-colors"
+        >
+          Advanced settings
+          <CaretDown
+            size={18}
+            className={cn("transition-transform", advancedOpen && "rotate-180")}
+          />
+        </button>
+
+        {advancedOpen && (
+          <div id={advancedId} className="mt-4 flex flex-col gap-5">
+            <Field
+              id={id("min-members")}
+              label="Minimum members to start"
+              help="You can only start the net once this many members have joined (contract minimum: 2)."
+              error={errors.minimumMembers?.message}
+            >
+              <input
+                {...fieldAria(
+                  id("min-members"),
+                  errors.minimumMembers?.message,
+                  "help",
+                )}
+                type="number"
+                min={2}
+                className={inputClass}
+                {...register("minimumMembers", { valueAsNumber: true })}
+              />
+            </Field>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Field
+                id={id("auto-threshold")}
+                label="Instant-withdrawal threshold"
+                help="Withdrawals up to this amount are paid instantly; larger ones can be contested. Defaults to ¼ of the recurring deposit."
+                error={errors.autoThreshold?.message}
+              >
+                <div className="relative">
+                  <input
+                    {...fieldAria(
+                      id("auto-threshold"),
+                      errors.autoThreshold?.message,
+                      "help",
+                    )}
+                    inputMode="decimal"
+                    placeholder="0.0"
+                    className={`${inputClass} pr-14`}
+                    {...register("autoThreshold")}
+                  />
+                  <AmountSuffix isBread={isBread} symbol={symbol} />
+                </div>
+              </Field>
+              <Field
+                id={id("small-limit")}
+                label="Instant withdrawals per epoch"
+                help="How many instant (small) withdrawals each member may make per epoch."
+                error={errors.smallWithdrawsLimit?.message}
+              >
+                <input
+                  {...fieldAria(
+                    id("small-limit"),
+                    errors.smallWithdrawsLimit?.message,
+                    "help",
+                  )}
+                  type="number"
+                  min={1}
+                  className={inputClass}
+                  {...register("smallWithdrawsLimit", { valueAsNumber: true })}
+                />
+              </Field>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <Field
+                id={id("contest-threshold")}
+                label="Contest threshold (%)"
+                help="A large withdrawal is vetoed when MORE than this percentage of members contest it."
+                error={errors.contestThreshold?.message}
+              >
+                <input
+                  {...fieldAria(
+                    id("contest-threshold"),
+                    errors.contestThreshold?.message,
+                    "help",
+                  )}
+                  type="number"
+                  min={1}
+                  max={100}
+                  className={inputClass}
+                  {...register("contestThreshold", { valueAsNumber: true })}
+                />
+              </Field>
+              <Field
+                id={id("contest-window")}
+                label="Contest window (days)"
+                help="How long the group has to contest a large withdrawal before it becomes executable."
+                error={errors.contestWindowDays?.message}
+              >
+                <input
+                  {...fieldAria(
+                    id("contest-window"),
+                    errors.contestWindowDays?.message,
+                    "help",
+                  )}
+                  type="number"
+                  min={0}
+                  step="any"
+                  className={inputClass}
+                  {...register("contestWindowDays", { valueAsNumber: true })}
+                />
+              </Field>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Mobile-only: advance to the Overview/Create step. */}
+      <Button
+        app="net"
+        variant="secondary"
+        type="button"
+        className="w-full lg:hidden"
+        rightIcon={<ArrowRight />}
+        onClick={continueToReview}
+      >
+        Continue
+      </Button>
+    </Card>
+  );
+}
+
+/** Right panel: a live plain-language summary + the primary Create action. */
+function OverviewPanel({ onBack }: { onBack: () => void }) {
   const { address } = useAccount();
+  const form = useFormContext<CreateNetValues>();
+  const {
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = form;
   const {
     create,
     status,
@@ -92,47 +489,21 @@ export function CreateForm() {
     error: txError,
     isBusy,
   } = useCreateSafetyNet();
-  const fid = useId();
-  const id = (name: string) => `${fid}-${name}`;
 
-  const {
-    register,
-    handleSubmit,
-    watch,
-    setValue,
-    formState: { errors },
-  } = useForm<CreateNetValues>({
-    resolver: zodResolver(createNetSchema),
-    defaultValues: {
-      memberCount: 10,
-      tokenChoice: "wxdai",
-      customToken: "",
-      initialDeposit: "",
-      fixedDeposit: "",
-      redeemRatio: REDEEM_RATIO,
-      autoThreshold: "",
-      contestThreshold: 50,
-      contestWindowDays: 3,
-      epochDurationDays: 30,
-      smallWithdrawsLimit: 3,
-      minimumMembers: 2,
-    },
-  });
+  const token = useNetToken(form);
+  const { decimals } = useTokenInfo(token);
+  const symbol = useNetSymbol(form);
 
-  const tokenChoice = watch("tokenChoice");
-  const customToken = watch("customToken");
+  const members = watch("memberCount");
+  const initial = watch("initialDeposit");
+  const fixed = watch("fixedDeposit");
+  const epochDays = watch("epochDurationDays");
+  const autoThreshold = watch("autoThreshold");
 
-  const token: Address | undefined = useMemo(() => {
-    if (tokenChoice === "wxdai") return WXDAI_ADDRESS;
-    if (tokenChoice === "bread") return BREAD_ADDRESS;
-    return isAddress(customToken) ? customToken : undefined;
-  }, [tokenChoice, customToken]);
-
-  const { symbol, decimals } = useTokenInfo(token);
-  const { data: tokenAllowed } = useIsTokenAllowed(token);
+  const amt = (v: string) => (v && Number(v) > 0 ? `${v} ${symbol}` : "—");
 
   // The new net's id, decoded from the SafetyNetCreated event in the receipt,
-  // so success can link straight to the net page (gap 6).
+  // so success can link straight to the net page.
   const createdId = useMemo(() => {
     if (!receipt) return undefined;
     try {
@@ -151,11 +522,11 @@ export function CreateForm() {
     if (!address || !token) return;
     const initialDeposit = parseAmount(v.initialDeposit, decimals);
     const fixedDeposit = parseAmount(v.fixedDeposit, decimals);
-    const autoThreshold = parseAmount(v.autoThreshold, decimals);
+    const autoThresholdWei = parseAmount(v.autoThreshold, decimals);
     if (
       initialDeposit === null ||
       fixedDeposit === null ||
-      autoThreshold === null
+      autoThresholdWei === null
     )
       return;
 
@@ -174,311 +545,133 @@ export function CreateForm() {
       initialDeposit,
       fixedDeposit,
       redeemRatio: BigInt(REDEEM_RATIO), // locked to 1 onchain in v1
-      autoThreshold,
+      autoThreshold: autoThresholdWei,
       contestWindow: BigInt(Math.round(v.contestWindowDays * 86_400)),
       epochDuration: BigInt(Math.round(v.epochDurationDays * 86_400)),
       smallWithdrawsLimit: BigInt(v.smallWithdrawsLimit),
     });
   });
 
+  const created = status === "success";
+
   return (
-    <form onSubmit={onSubmit} noValidate>
-      <Card className="flex flex-col gap-5">
-        <SectionTitle>Members</SectionTitle>
-        <Field
-          id={id("member-count")}
-          label="How many members?"
-          help="You'll be the first member. Everyone else joins through invite links before you start the net."
-          error={errors.memberCount?.message}
-        >
-          <input
-            {...fieldAria(
-              id("member-count"),
-              errors.memberCount?.message,
-              "help",
-            )}
-            type="number"
-            min={2}
-            className={inputClass}
-            {...register("memberCount", { valueAsNumber: true })}
-          />
-        </Field>
+    <Card className="border-primary-jade/30 flex flex-col gap-5">
+      <Heading4 className="text-text-standard border-paper-2 border-b pb-3">
+        Overview
+      </Heading4>
 
-        <Field
-          id={id("min-members")}
-          label="Minimum members"
-          help="You can only start the net once this many members have joined (contract minimum: 2)."
-          error={errors.minimumMembers?.message}
-        >
-          <input
-            {...fieldAria(
-              id("min-members"),
-              errors.minimumMembers?.message,
-              "help",
-            )}
-            type="number"
-            min={2}
-            className={inputClass}
-            {...register("minimumMembers", { valueAsNumber: true })}
-          />
-        </Field>
+      <Body className="text-surface-grey-2 leading-relaxed">
+        A {symbol} saving circle of up to{" "}
+        <strong className="text-text-standard">{members || "—"}</strong> members.
+        Everyone pays{" "}
+        <strong className="text-text-standard">{amt(initial)}</strong> to join and{" "}
+        <strong className="text-text-standard">{amt(fixed)}</strong> each epoch
+        (~<strong className="text-text-standard">{epochDays || "—"}</strong> days).
+        Withdrawals over{" "}
+        <strong className="text-text-standard">{amt(autoThreshold)}</strong> go to
+        a group vote.
+      </Body>
 
-        <SectionTitle>Money</SectionTitle>
-        <Field
-          label="Token"
-          help="The ERC20 everyone saves in. It must be allowed by the protocol."
-          error={errors.customToken?.message}
-        >
+      <p className="text-surface-grey text-xs">
+        Deposits and withdrawal power are 1:1 (redeem ratio ×1) — every token you
+        put in unlocks exactly one token of withdrawable balance.
+      </p>
+
+      {Object.keys(errors).length > 0 && !created && (
+        <p className="text-system-red text-xs font-medium">
+          Some fields need attention — check the form.
+        </p>
+      )}
+
+      <div className="mt-1">
+        {created ? (
           <div
-            role="group"
-            aria-label="Token"
-            className="flex flex-wrap gap-2"
+            role="status"
+            aria-live="polite"
+            className="border-primary-jade/40 bg-primary-jade/5 rounded-xl border p-4"
           >
-            {(
-              [
-                ["wxdai", "WXDAI"],
-                ["bread", "BREAD"],
-                ["custom", "Custom"],
-              ] as const
-            ).map(([value, label]) => (
-              <button
-                key={value}
-                type="button"
-                aria-pressed={tokenChoice === value}
-                onClick={() =>
-                  setValue("tokenChoice", value, { shouldValidate: true })
-                }
-                className={cn(
-                  "rounded-xl border px-4 py-2 text-sm font-bold transition-colors",
-                  tokenChoice === value
-                    ? "border-primary-jade bg-primary-jade text-white"
-                    : "border-paper-2 text-surface-grey-2 hover:border-primary-jade/50",
-                )}
+            <Heading4 className="text-text-standard flex items-center gap-2">
+              <CheckCircle
+                size={22}
+                weight="fill"
+                className="text-system-green shrink-0"
+              />
+              Safety Net{" "}
+              {createdId !== undefined ? `#${createdId.toString()} ` : ""}
+              created
+            </Heading4>
+            <Body className="text-surface-grey-2 mt-1 text-sm">
+              {createdId !== undefined
+                ? "You're the first member. Share the single-use invite links below — everyone else joins through them, and you start the net from its page once enough have joined."
+                : "Next step: open your new net, share its invite links, and start it once enough members have joined."}
+            </Body>
+            {createdId !== undefined && <SuccessInvites id={createdId} />}
+            <div className="mt-3">
+              <Button
+                as={Link}
+                app="net"
+                variant="primary"
+                rightIcon={<ArrowRight />}
+                href={createdId !== undefined ? `/net/?id=${createdId}` : "/"}
               >
-                {label}
-              </button>
-            ))}
-          </div>
-          {tokenChoice === "custom" && (
-            <input
-              aria-label="Custom token address"
-              aria-invalid={errors.customToken ? true : undefined}
-              className={`${inputClass} mt-2`}
-              placeholder="0x… token address"
-              {...register("customToken")}
-            />
-          )}
-          {token && tokenAllowed === false && (
-            <p className="text-system-warning mt-1.5 text-xs font-medium">
-              This token is not currently allowed by the SafetyNet protocol —
-              creation will fail until the protocol owner allows it.
-            </p>
-          )}
-        </Field>
-
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field
-            id={id("initial-deposit")}
-            label={`Initial deposit (${symbol})`}
-            help="One-off joining payment. A new member's very first deposit must be exactly this amount, in a single payment."
-            error={errors.initialDeposit?.message}
-          >
-            <input
-              {...fieldAria(
-                id("initial-deposit"),
-                errors.initialDeposit?.message,
-                "help",
-              )}
-              inputMode="decimal"
-              placeholder="0.0"
-              className={inputClass}
-              {...register("initialDeposit")}
-            />
-          </Field>
-          <Field
-            id={id("fixed-deposit")}
-            label={`Recurring deposit (${symbol})`}
-            help="Dues each member owes every epoch after joining. Can be paid in parts, and extra pays future epochs forward."
-            error={errors.fixedDeposit?.message}
-          >
-            <input
-              {...fieldAria(
-                id("fixed-deposit"),
-                errors.fixedDeposit?.message,
-                "help",
-              )}
-              inputMode="decimal"
-              placeholder="0.0"
-              className={inputClass}
-              {...register("fixedDeposit")}
-            />
-          </Field>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <Field
-            label="Redeem ratio"
-            help="Fixed in v1: deposits and withdrawal power are 1:1 — every token deposited unlocks exactly one token of withdrawable balance (leverage disabled)."
-          >
-            <div
-              aria-label="Redeem ratio, fixed at 1"
-              className="border-paper-2 bg-paper-2/50 text-surface-grey-2 w-full rounded-xl border px-4 py-2.5 font-bold"
-            >
-              ×1
-            </div>
-          </Field>
-          <Field
-            id={id("epoch-days")}
-            label="Epoch length (days)"
-            help="How often the recurring deposit is due. 30 days ≈ monthly."
-            error={errors.epochDurationDays?.message}
-          >
-            <input
-              {...fieldAria(
-                id("epoch-days"),
-                errors.epochDurationDays?.message,
-                "help",
-              )}
-              type="number"
-              min={1}
-              className={inputClass}
-              {...register("epochDurationDays", { valueAsNumber: true })}
-            />
-          </Field>
-        </div>
-
-        <SectionTitle>Withdrawals</SectionTitle>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field
-            id={id("auto-threshold")}
-            label={`Instant-withdrawal threshold (${symbol})`}
-            help="Withdrawals up to this amount are paid out instantly. Anything larger becomes a request the group can contest."
-            error={errors.autoThreshold?.message}
-          >
-            <input
-              {...fieldAria(
-                id("auto-threshold"),
-                errors.autoThreshold?.message,
-                "help",
-              )}
-              inputMode="decimal"
-              placeholder="0.0"
-              className={inputClass}
-              {...register("autoThreshold")}
-            />
-          </Field>
-          <Field
-            id={id("small-limit")}
-            label="Instant withdrawals per epoch"
-            help="How many instant (small) withdrawals each member may make per epoch."
-            error={errors.smallWithdrawsLimit?.message}
-          >
-            <input
-              {...fieldAria(
-                id("small-limit"),
-                errors.smallWithdrawsLimit?.message,
-                "help",
-              )}
-              type="number"
-              min={1}
-              className={inputClass}
-              {...register("smallWithdrawsLimit", { valueAsNumber: true })}
-            />
-          </Field>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <Field
-            id={id("contest-threshold")}
-            label="Contest threshold (%)"
-            help="A large withdrawal is vetoed when MORE than this percentage of members contest it."
-            error={errors.contestThreshold?.message}
-          >
-            <input
-              {...fieldAria(
-                id("contest-threshold"),
-                errors.contestThreshold?.message,
-                "help",
-              )}
-              type="number"
-              min={1}
-              max={100}
-              className={inputClass}
-              {...register("contestThreshold", { valueAsNumber: true })}
-            />
-          </Field>
-          <Field
-            id={id("contest-window")}
-            label="Contest window (days)"
-            help="How long the group has to contest a large withdrawal before it becomes executable."
-            error={errors.contestWindowDays?.message}
-          >
-            <input
-              {...fieldAria(
-                id("contest-window"),
-                errors.contestWindowDays?.message,
-                "help",
-              )}
-              type="number"
-              min={0}
-              step="any"
-              className={inputClass}
-              {...register("contestWindowDays", { valueAsNumber: true })}
-            />
-          </Field>
-        </div>
-
-        <div className="mt-2">
-          <ActionButton
-            onClick={onSubmit}
-            isLoading={isBusy}
-            disabled={status === "success"}
-          >
-            Create Safety Net
-          </ActionButton>
-          {status === "success" ? (
-            <div
-              role="status"
-              aria-live="polite"
-              className="border-primary-jade/40 bg-primary-jade/5 mt-4 rounded-xl border p-4"
-            >
-              <Heading4 className="text-text-standard flex items-center gap-2">
-                <CheckCircle
-                  size={22}
-                  weight="fill"
-                  className="text-system-green shrink-0"
-                />
-                Safety Net{" "}
-                {createdId !== undefined ? `#${createdId.toString()} ` : ""}
-                created
-              </Heading4>
-              <Body className="text-surface-grey-2 mt-1 text-sm">
                 {createdId !== undefined
-                  ? "You're the first member. Share the single-use invite links below — everyone else joins through them, and you start the net from its page once enough have joined."
-                  : "Next step: open your new net, share its invite links, and start it once enough members have joined."}
-              </Body>
-              {createdId !== undefined && <SuccessInvites id={createdId} />}
-              <div className="mt-3">
-                <Button
-                  as={Link}
-                  app="net"
-                  variant="primary"
-                  rightIcon={<ArrowRight />}
-                  href={
-                    createdId !== undefined ? `/net/?id=${createdId}` : "/"
-                  }
-                >
-                  {createdId !== undefined
-                    ? `Open Safety Net #${createdId.toString()}`
-                    : "Go to your dashboard"}
-                </Button>
-              </div>
+                  ? `Open Safety Net #${createdId.toString()}`
+                  : "Go to your dashboard"}
+              </Button>
             </div>
-          ) : (
+          </div>
+        ) : (
+          <>
+            <ActionButton onClick={onSubmit} isLoading={isBusy}>
+              Create Safety Net
+            </ActionButton>
             <TxStatus status={status} hash={hash} error={txError} />
-          )}
-        </div>
-      </Card>
-    </form>
+          </>
+        )}
+      </div>
+
+      {!created && (
+        <Button
+          app="net"
+          variant="secondary"
+          type="button"
+          className="w-full lg:hidden"
+          leftIcon={<ArrowLeft />}
+          onClick={onBack}
+        >
+          Back
+        </Button>
+      )}
+    </Card>
+  );
+}
+
+/** The selected token address (or undefined for an incomplete custom entry). */
+function useNetToken(form: NetForm): Address | undefined {
+  const tokenChoice = form.watch("tokenChoice");
+  const customToken = form.watch("customToken");
+  return useMemo(() => {
+    if (tokenChoice === "bread") return BREAD_ADDRESS;
+    return isAddress(customToken) ? customToken : undefined;
+  }, [tokenChoice, customToken]);
+}
+
+/** Display symbol for the selected token ("BREAD" or the ERC20 symbol). */
+function useNetSymbol(form: NetForm): string {
+  const token = useNetToken(form);
+  const { symbol } = useTokenInfo(token);
+  return form.watch("tokenChoice") === "bread" ? "BREAD" : symbol;
+}
+
+/** Protocol-allowance warning for the selected token. */
+function TokenAllowedWarning({ form }: { form: NetForm }) {
+  const token = useNetToken(form);
+  const { data: tokenAllowed } = useIsTokenAllowed(token);
+  if (!token || tokenAllowed !== false) return null;
+  return (
+    <p className="text-system-warning mt-1.5 text-xs font-medium">
+      This token is not currently allowed by the SafetyNet protocol — creation
+      will fail until the protocol owner allows it.
+    </p>
   );
 }

--- a/web/src/components/create/schema.ts
+++ b/web/src/components/create/schema.ts
@@ -19,7 +19,7 @@ export const createNetSchema = z
       .number({ error: "Enter a whole number" })
       .int("Whole numbers only")
       .min(2, "At least 2 members are required"),
-    tokenChoice: z.enum(["wxdai", "bread", "custom"]),
+    tokenChoice: z.enum(["bread", "custom"]),
     customToken: z.string().trim(),
     initialDeposit: amountString,
     fixedDeposit: amountString,

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -134,12 +134,11 @@ export const BREAD_ADDRESS: Address =
   "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3";
 
 export const KNOWN_TOKENS: { label: string; address: Address }[] = [
-  { label: "WXDAI", address: WXDAI_ADDRESS },
   { label: "BREAD", address: BREAD_ADDRESS },
 ];
 
 /** Default token for new Safety Nets. */
-export const DEFAULT_TOKEN = WXDAI_ADDRESS;
+export const DEFAULT_TOKEN = BREAD_ADDRESS;
 
 export const BLOCK_EXPLORER = "https://gnosisscan.io";
 export const txUrl = (hash: string) => `${BLOCK_EXPLORER}/tx/${hash}`;


### PR DESCRIPTION
Token picker now offers **BREAD (default) or Custom only** — WXDAI removed from creation (the constant stays for reading existing nets).

Create page redesigned learning from app-stacks' New Stack UX:
- Big jade heading + **two-panel desktop layout**: form left, a **live Overview** summary in plain language right ("A BREAD saving circle of up to N members. Everyone pays X to join and Y each epoch…").
- **Mobile step flow**: fill → Continue (validates) → review Overview → Create, with Back.
- **BREAD-branded amount inputs** (kit Logo suffix + "1 BREAD = 1 USD").
- **Progressive disclosure**: essentials up front (token, max members, initial + recurring deposit, epoch); governance controls (min members, instant-withdrawal threshold + per-epoch limit, contest threshold %, contest window) tucked into a collapsible **Advanced settings** with sensible defaults so a net is creatable without opening it.
- a11y preserved (labels, aria-invalid/describedby, aria-live, aria-expanded); post-create auto-invite flow unchanged; contract call unchanged.

Lint clean; standard + base-path static-export builds pass.