### PR TITLE
ci: rename etherform input main-branch → base-branch (merge after etherform#52)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     with:
       package-manager: yarn
-      main-branch: dev
+      base-branch: dev
       deploy-on-pr: true
       deploy-script: 'script/Deploy.sol:Deploy'
       contract-paths: |


### PR DESCRIPTION
## Why

[BreadchainCoop/etherform#52](https://github.com/BreadchainCoop/etherform/pull/52) overhauls the reusable workflows and **renames the input `main-branch` → `base-branch`** (for consistency with `_upgrade-safety.yml`). This repo passes `main-branch: dev`, so the moment #52 lands on etherform `main`, this repo's `cicd` job would fail with an *"unexpected input 'main-branch'"* error and every PR check here would go red.

This one-line PR migrates the input ahead of time.

## ⚠️ Merge ordering

Kept as a **draft** on purpose. Merge order matters:

1. First merge **etherform#52** to etherform `main`.
2. Then mark this ready and merge.

Until #52 is on `main`, the `cicd` check on **this** PR is *expected to be red* (the current etherform `main` doesn't know `base-branch` yet). After #52 lands, re-run the checks and they'll pass.

## Evidence it works

The exact rename was validated end-to-end against this repo in etherform's cross-repo test (safety-net#84, now closed): with `base-branch: dev` pointed at the #52 branch, Build & Test / Detect Changes passed and upgrade-safety behaved correctly. No other input names changed.

## Note for reviewers

Nothing else here changes. After merge, PR check *names* will differ slightly (etherform now nests its jobs, e.g. `cicd / CI / Build & Test`); `dev` has no branch protection, so no required-check config needs updating — but if you add branch protection later, use the new names.