### PR TITLE
[TEST — do not merge] Verify deprecated main-branch alias + upgrade-safety

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cicd:
-    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@main
+    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@RonTuretzky/codebase-improvement-plan
     secrets: inherit
     with:
       package-manager: yarn

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -76,6 +76,10 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Maximum byte length of a withdrawal request reason (~200 words; the UI enforces the word cap)
   uint256 public constant MAX_REASON_BYTES = 2000;
 
+  /// @notice TEST-ONLY storage-layout violation to re-confirm upgrade-safety fires via the
+  /// @notice deprecated `main-branch` alias. Inserting a slot before existing storage bricks upgrades.
+  uint256 public injectedUpgradeViolation;
+
   /// @notice ID counter used to assign unique identifiers to each Safety Net
   uint256 public nextId;
 


### PR DESCRIPTION
Throwaway test for [etherform#52](https://github.com/BreadchainCoop/etherform/pull/52). Keeps the **deprecated `main-branch: dev`** input (unchanged from this repo's `dev`) while pointing `uses:` at the etherform overhaul branch, plus a deliberate storage-layout violation in `SafetyNet`.

Confirms three things at once:
1. `main-branch` still works against the new etherform (backward compatible) — Build & Test should pass.
2. A deprecation warning is emitted for `main-branch`.
3. Upgrade-safety still catches the violation — **Upgrade Safety should FAIL**.

Will be closed, not merged.