### PR TITLE
feat: Get-BREAD funding, deposit reminders, first-run onboarding

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -128,6 +128,7 @@ src/
 ├── components/
 │   ├── ui/           # Card/StatCard/Badge, ActionButton, TxStatus, AmountField,
 │   │                 # ConnectGate, AddressDisplay (copy), TimeDisplay (relative+abs)
+│   ├── funding/      # GetBreadModal — mint BREAD 1:1 from xDAI (Privy onramp buys xDAI)
 │   ├── net/          # NetCard, NetOverview, MembersList, Deposit/Withdraw panels,
 │   │                 # RequestsList (contest/execute), InvitePanel, DecommissionPanel
 │   └── create/       # create form (react-hook-form + zod)

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -45,6 +45,7 @@ const SECTIONS: Section[] = [
       "Deposits open once the owner starts the net. Your very first deposit is the initial deposit, paid exactly and in one payment — it activates your membership and sets your recurring dues.",
       "After that, you owe the recurring deposit every epoch. You can pay it in parts, and you can also pay another member's dues for them (the tokens still come from their wallet — they only save the gas). Every deposit adds 1:1 to your withdrawable balance.",
       "You can also pay ahead: deposit more than this epoch's dues and the extra prepays future epochs — the current epoch's remaining dues fill first, then the next epoch, and so on, up to 12 epochs ahead. The app previews exactly how a deposit will be allocated before you send it.",
+      "Short on BREAD? Use the \"Get BREAD\" button in the nav (or the prompt on the deposit form) to mint BREAD 1:1 from xDAI — and, on embedded-wallet sign-ins, to buy xDAI first.",
     ],
   },
   {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { VerifyBanner } from "@/components/verify-banner";
 import { NotificationBanner } from "@/components/notification-banner";
 import { ConfigWarning } from "@/components/config-warning";
 import { SiteFooter } from "@/components/site-footer";
+import { OnboardingGate } from "@/components/onboarding/onboarding-gate";
 import { buildMetadata } from "@/lib/metadata";
 
 export const metadata: Metadata = buildMetadata();
@@ -29,6 +30,7 @@ export default function RootLayout({
           <NotificationBanner />
           <main className="section-container flex-1 py-8">{children}</main>
           <SiteFooter />
+          <OnboardingGate />
         </Providers>
       </body>
     </html>

--- a/web/src/components/funding/get-bread-modal.tsx
+++ b/web/src/components/funding/get-bread-modal.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { formatUnits } from "viem";
+import { Body, Button, Heading4 } from "@breadcoop/ui";
+import { AmountField } from "@/components/ui/amount-field";
+import { TxStatus } from "@/components/ui/tx-status";
+import { PRIVY_ENABLED } from "@/lib/config";
+import { formatAmount, parseAmount } from "@/lib/format";
+import { GAS_RESERVE_XDAI, useBreadFunding } from "@/hooks/use-bread-funding";
+
+/** Below this much xDAI we nudge the user toward the (Privy) onramp. */
+const LOW_XDAI = GAS_RESERVE_XDAI;
+
+/**
+ * "Get BREAD" funding modal. BREAD is the Safety Net savings token and mints
+ * 1:1 from xDAI via BREAD's payable `mint(receiver)` (app-stacks
+ * fund-wallet / use-auto-bake-bread pattern).
+ *
+ * Shows live BREAD + xDAI balances; when Privy is enabled and xDAI is low it
+ * offers a "Buy xDAI" onramp; and it mints N BREAD from N xDAI (reserving a
+ * little xDAI for gas on MAX). Works in both wagmi and Privy-sponsored modes —
+ * minting routes through the shared `useTx` path.
+ */
+export function GetBreadModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [amount, setAmount] = useState("");
+
+  const {
+    breadBalance,
+    xdaiBalance,
+    refetchBreadBalance,
+    refetchXdaiBalance,
+    mintBread,
+    tx,
+    openOnramp,
+  } = useBreadFunding();
+
+  // MAX mints all xDAI minus a gas reserve (app-stacks gas-reserve-on-MAX).
+  const mintableXdai = useMemo(() => {
+    if (xdaiBalance === undefined) return undefined;
+    return xdaiBalance > GAS_RESERVE_XDAI ? xdaiBalance - GAS_RESERVE_XDAI : 0n;
+  }, [xdaiBalance]);
+
+  const parsed = useMemo(() => parseAmount(amount, 18), [amount]);
+  const insufficientXdai =
+    parsed !== null &&
+    parsed > 0n &&
+    mintableXdai !== undefined &&
+    parsed > mintableXdai;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    dialogRef.current
+      ?.querySelector<HTMLElement>("input,button")
+      ?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Refresh balances (and clear the field) after a successful mint.
+  useEffect(() => {
+    if (!tx.isSuccess) return;
+    refetchBreadBalance();
+    refetchXdaiBalance();
+    setAmount("");
+  }, [tx.isSuccess, refetchBreadBalance, refetchXdaiBalance]);
+
+  if (!open) return null;
+
+  const showOnramp = PRIVY_ENABLED && Boolean(openOnramp);
+  const lowXdai = xdaiBalance !== undefined && xdaiBalance < LOW_XDAI;
+
+  const submit = () => {
+    if (parsed === null || parsed === 0n || insufficientXdai) return;
+    mintBread(parsed);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-100 flex items-center justify-center p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/40" aria-hidden />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+        className="border-paper-2 bg-paper-0 relative w-full max-w-md rounded-2xl border p-6 shadow-xl"
+      >
+        <div id={titleId}>
+          <Heading4 className="text-text-standard">Get BREAD</Heading4>
+        </div>
+        <Body className="text-surface-grey-2 mt-2 text-sm">
+          BREAD is the savings token your Safety Net holds. It mints 1:1 from
+          xDAI — 1 xDAI becomes 1 BREAD, redeemable back to xDAI anytime.
+        </Body>
+
+        <dl className="border-paper-2 bg-paper-main mt-4 grid grid-cols-2 gap-px overflow-hidden rounded-xl border">
+          <div className="bg-paper-0 p-3">
+            <dt className="text-surface-grey-2 text-xs font-medium">
+              Your BREAD
+            </dt>
+            <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
+              {breadBalance !== undefined
+                ? formatAmount(breadBalance, 18)
+                : "…"}
+            </dd>
+          </div>
+          <div className="bg-paper-0 p-3">
+            <dt className="text-surface-grey-2 text-xs font-medium">
+              Your xDAI
+            </dt>
+            <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
+              {xdaiBalance !== undefined ? formatAmount(xdaiBalance, 18) : "…"}
+            </dd>
+          </div>
+        </dl>
+
+        {showOnramp && lowXdai && (
+          <div className="mt-4">
+            <p className="text-surface-grey-2 text-xs font-medium">
+              You&apos;ll need xDAI to mint BREAD. Buy some with card or another
+              wallet:
+            </p>
+            <Button
+              app="net"
+              variant="secondary"
+              className="mt-2 w-full"
+              onClick={() => openOnramp?.()}
+            >
+              Buy xDAI
+            </Button>
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-col gap-3">
+          <AmountField
+            label="Mint from xDAI"
+            value={amount}
+            onChange={setAmount}
+            balance={mintableXdai}
+            balanceLabel="Available"
+            symbol="xDAI"
+            decimals={18}
+            error={insufficientXdai}
+            help="1 xDAI = 1 BREAD. A little xDAI is kept back for gas when you use MAX."
+          />
+
+          {insufficientXdai && (
+            <p className="text-system-red text-xs font-medium">
+              That&apos;s more xDAI than you have available
+              {mintableXdai !== undefined
+                ? ` (${formatAmount(mintableXdai, 18)} xDAI, keeping ${formatUnits(
+                    GAS_RESERVE_XDAI,
+                    18,
+                  )} for gas)`
+                : ""}
+              .
+            </p>
+          )}
+
+          <Button
+            app="net"
+            variant="primary"
+            className="w-full"
+            isLoading={tx.isBusy}
+            onClick={submit}
+            {...(parsed === null || parsed === 0n || insufficientXdai
+              ? { disabled: true }
+              : {})}
+          >
+            {parsed !== null && parsed > 0n
+              ? `Mint ${formatAmount(parsed, 18)} BREAD from xDAI`
+              : "Mint BREAD from xDAI"}
+          </Button>
+
+          <TxStatus
+            status={tx.status}
+            hash={tx.hash}
+            error={tx.error}
+            successLabel="Minted BREAD"
+          />
+
+          <Button
+            app="net"
+            variant="secondary"
+            className="w-full"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAccount } from "wagmi";
 import { Navbar as KitNavbar } from "@breadcoop/ui";
+import { GetBreadModal } from "@/components/funding/get-bread-modal";
 import { cn } from "@/lib/utils";
 
 const LINKS = [
@@ -49,11 +52,26 @@ function NavLinks() {
  * pass a second disconnect button via `actionItems`.
  */
 export function Navbar() {
+  const { isConnected } = useAccount();
+  const [getBreadOpen, setGetBreadOpen] = useState(false);
+
   return (
     <header className="border-paper-2 bg-paper-main/80 sticky top-0 z-50 border-b backdrop-blur">
       <KitNavbar app="net" Link={Link} className="section-container">
-        <NavLinks />
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+          <NavLinks />
+          {isConnected && (
+            <button
+              type="button"
+              onClick={() => setGetBreadOpen(true)}
+              className="border-primary-jade text-primary-jade hover:bg-primary-jade/10 rounded-lg border px-3 py-1.5 text-sm font-bold whitespace-nowrap transition-colors md:mr-4"
+            >
+              Get BREAD
+            </button>
+          )}
+        </div>
       </KitNavbar>
+      <GetBreadModal open={getBreadOpen} onClose={() => setGetBreadOpen(false)} />
     </header>
   );
 }

--- a/web/src/components/net/deposit-panel.tsx
+++ b/web/src/components/net/deposit-panel.tsx
@@ -8,6 +8,7 @@ import { ActionButton } from "@/components/ui/action-button";
 import { AmountField } from "@/components/ui/amount-field";
 import { TxStatus } from "@/components/ui/tx-status";
 import { Card } from "@/components/ui/ui";
+import { GetBreadModal } from "@/components/funding/get-bread-modal";
 import { useMemberDepositInfo } from "@/hooks/use-safety-net";
 import { useDeposit, useDepositFor } from "@/hooks/use-safety-net-writes";
 import {
@@ -16,7 +17,7 @@ import {
   useTokenBalance,
   useTokenInfo,
 } from "@/hooks/use-token";
-import { MAX_PREPAY_EPOCHS } from "@/lib/config";
+import { BREAD_ADDRESS, MAX_PREPAY_EPOCHS } from "@/lib/config";
 import { formatAmount, parseAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { SafetyNetDetails } from "@/lib/types";
@@ -82,6 +83,7 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
   const [mode, setMode] = useState<"self" | "other">("self");
   const [otherMember, setOtherMember] = useState("");
   const [amount, setAmount] = useState("");
+  const [getBreadOpen, setGetBreadOpen] = useState(false);
   // Approve unlimited once (reference default) vs the exact amount each time.
   // Remembered per browser in localStorage.
   const [approveUnlimited, setApproveUnlimited] = useState(true);
@@ -149,6 +151,12 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
     parsed !== null && parsed > 0n && (allowance ?? 0n) < parsed;
   const insufficientBalance =
     parsed !== null && balance !== undefined && balance < parsed;
+  // The user can only top themselves up. Offer "Get BREAD" when they're short
+  // on a BREAD-denominated net and depositing for themselves.
+  const isBreadNet =
+    net.token.toLowerCase() === BREAD_ADDRESS.toLowerCase();
+  const canGetBread =
+    mode === "self" && isBreadNet && insufficientBalance === true;
   // Upper bound on what the prepay window can absorb: this epoch's remaining
   // dues + MAX_PREPAY_EPOCHS full epochs. (Future-epoch fills can't be read
   // cheaply, so a deposit inside this bound can still revert with
@@ -321,6 +329,15 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
             {formatAmount(balance, decimals)}) doesn&apos;t cover this deposit.
           </p>
         )}
+        {canGetBread && (
+          <button
+            type="button"
+            onClick={() => setGetBreadOpen(true)}
+            className="border-primary-jade text-primary-jade hover:bg-primary-jade/10 self-start rounded-lg border px-3 py-1.5 text-xs font-bold transition-colors"
+          >
+            Not enough BREAD — Get BREAD
+          </button>
+        )}
         {exceedsCapacity && (
           <p className="text-system-red text-xs font-medium">
             That&apos;s more than this epoch&apos;s dues plus{" "}
@@ -369,6 +386,10 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
           }
         />
       </div>
+      <GetBreadModal
+        open={getBreadOpen}
+        onClose={() => setGetBreadOpen(false)}
+      />
     </Card>
   );
 }

--- a/web/src/components/net/deposit-reminder.tsx
+++ b/web/src/components/net/deposit-reminder.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useMemo } from "react";
+import { Caption } from "@breadcoop/ui";
+import { CalendarPlus, DownloadSimple } from "@phosphor-icons/react";
+import { Card } from "@/components/ui/ui";
+import {
+  describeCadence,
+  downloadICS,
+  googleCalendarUrl,
+  outlookCalendarUrl,
+  recurrenceFromEpochSeconds,
+  yahooCalendarUrl,
+  type CalendarEvent,
+} from "@/lib/calendar";
+import { formatAmount } from "@/lib/format";
+import type { SafetyNetDetails } from "@/lib/types";
+import { useTokenInfo } from "@/hooks/use-token";
+
+/**
+ * "Never miss a deposit" — recurring calendar reminders for a member's dues.
+ *
+ * Only meaningful for a STARTED net (safetyNetStart != 0): the reminder recurs
+ * on the epoch cadence, anchored to the next epoch boundary so the first event
+ * is in the future. Everything is built client-side (see @/lib/calendar).
+ */
+export function DepositReminder({ details }: { details: SafetyNetDetails }) {
+  const net = details.safetyNet;
+  const { symbol, decimals } = useTokenInfo(net.token);
+
+  const started = net.safetyNetStart !== 0n;
+  const epochSeconds = Number(net.epochDuration);
+
+  const event = useMemo<CalendarEvent | null>(() => {
+    if (!started || epochSeconds <= 0) return null;
+
+    const start = Number(net.safetyNetStart);
+    const nowSec = Math.floor(Date.now() / 1000);
+    // Anchor to the next epoch boundary at/after now so the first reminder is
+    // upcoming rather than in the past.
+    const elapsed = Math.max(0, nowSec - start);
+    const epochsPassed = Math.ceil(elapsed / epochSeconds);
+    const nextBoundarySec = start + epochsPassed * epochSeconds;
+
+    const cadence = describeCadence(epochSeconds);
+    const dues = `${formatAmount(net.fixedDeposit, decimals)} ${symbol}`;
+
+    return {
+      title: `Safety Net #${net.id.toString()} — deposit dues`,
+      description: `Deposit your ${dues} dues into Safety Net #${net.id.toString()} (recurs ${cadence}). Open your net: check the app to pay this epoch's dues.`,
+      startTime: new Date(nextBoundarySec * 1000),
+      recurrence: recurrenceFromEpochSeconds(epochSeconds),
+      fileName: `safety-net-${net.id.toString()}-deposit`,
+    };
+  }, [
+    started,
+    epochSeconds,
+    net.safetyNetStart,
+    net.fixedDeposit,
+    net.id,
+    decimals,
+    symbol,
+  ]);
+
+  if (!event) return null;
+
+  const linkClass =
+    "inline-flex items-center justify-center gap-1.5 rounded-xl border border-paper-2 bg-paper-main px-3 py-2 text-sm font-bold text-text-standard transition-colors hover:border-primary-jade focus-visible:border-primary-jade focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-jade";
+
+  const cadence = describeCadence(epochSeconds);
+
+  return (
+    <Card>
+      <Caption className="text-surface-grey-2">Never miss a deposit</Caption>
+      <p className="text-text-standard mt-2 text-sm">
+        Dues of{" "}
+        <span className="font-bold">
+          {formatAmount(net.fixedDeposit, decimals)} {symbol}
+        </span>{" "}
+        {cadence}. Add a recurring reminder to your calendar.
+      </p>
+
+      <div
+        role="group"
+        aria-label="Add deposit reminder to a calendar"
+        className="mt-4 grid grid-cols-2 gap-2"
+      >
+        <a
+          className={linkClass}
+          href={googleCalendarUrl(event)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Add recurring deposit reminder to Google Calendar"
+        >
+          <CalendarPlus size={16} aria-hidden />
+          Google
+        </a>
+        <a
+          className={linkClass}
+          href={outlookCalendarUrl(event)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Add deposit reminder to Outlook (set recurrence manually)"
+        >
+          <CalendarPlus size={16} aria-hidden />
+          Outlook
+        </a>
+        <button
+          type="button"
+          className={linkClass}
+          onClick={() => downloadICS(event)}
+          aria-label="Download an Apple Calendar (.ics) file with a recurring deposit reminder"
+        >
+          <DownloadSimple size={16} aria-hidden />
+          Apple (.ics)
+        </button>
+        <a
+          className={linkClass}
+          href={yahooCalendarUrl(event)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Add deposit reminder to Yahoo Calendar (set recurrence manually)"
+        >
+          <CalendarPlus size={16} aria-hidden />
+          Yahoo
+        </a>
+      </div>
+
+      <Caption className="text-surface-grey mt-3 block">
+        Outlook and Yahoo links create a single event — set the {cadence}{" "}
+        recurrence there manually.
+      </Caption>
+    </Card>
+  );
+}

--- a/web/src/components/net/net-page-content.tsx
+++ b/web/src/components/net/net-page-content.tsx
@@ -19,6 +19,7 @@ import { RequestsList } from "@/components/net/requests-list";
 import { InvitePanel } from "@/components/net/invite-panel";
 import { StartNetBanner } from "@/components/net/start-panel";
 import { DecommissionPanel } from "@/components/net/decommission-panel";
+import { DepositReminder } from "@/components/net/deposit-reminder";
 import { ActivityFeed } from "@/components/net/activity-feed";
 import { useSafetyNetDetails } from "@/hooks/use-safety-net";
 import { isContractConfigured } from "@/lib/config";
@@ -135,6 +136,7 @@ function NetDetail() {
             {details.isMember ? (
               <>
                 <DepositPanel details={details} />
+                <DepositReminder details={details} />
                 <WithdrawPanel details={details} />
               </>
             ) : (

--- a/web/src/components/onboarding/onboarding-gate.tsx
+++ b/web/src/components/onboarding/onboarding-gate.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Question } from "@phosphor-icons/react";
+import { useOnboarding } from "@/hooks/use-onboarding";
+import { OnboardingModal } from "@/components/onboarding/onboarding-modal";
+
+/**
+ * App-wide onboarding host. Auto-opens the tour once for first-time visitors
+ * (localStorage-tracked, SSR-safe via the hook's `mounted` gate) and exposes a
+ * subtle floating "How it works" button so anyone can reopen it later —
+ * SiteFooter uses the kit's <Footer>, which has no slot for a custom link.
+ */
+export function OnboardingGate() {
+  const { mounted, isOpen, open, close, dismiss } = useOnboarding();
+
+  // Nothing localStorage-dependent renders until mounted, so server and first
+  // client render match (no hydration mismatch).
+  if (!mounted) return null;
+
+  return (
+    <>
+      {isOpen && <OnboardingModal onClose={close} onDone={dismiss} />}
+
+      {!isOpen && (
+        <button
+          type="button"
+          onClick={open}
+          aria-label="How it works — reopen the intro tour"
+          className="border-paper-2 bg-paper-0 text-primary-jade hover:border-primary-jade focus-visible:outline-primary-jade fixed right-4 bottom-4 z-40 inline-flex items-center gap-1.5 rounded-full border px-3 py-2 text-sm font-bold shadow-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          <Question size={16} aria-hidden />
+          How it works
+        </button>
+      )}
+    </>
+  );
+}

--- a/web/src/components/onboarding/onboarding-modal.tsx
+++ b/web/src/components/onboarding/onboarding-modal.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ComponentType,
+} from "react";
+import { Body, Button, Heading3 } from "@breadcoop/ui";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Coins,
+  HandDeposit,
+  Lifebuoy,
+  Sparkle,
+  UsersThree,
+  type IconProps,
+} from "@phosphor-icons/react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface Slide {
+  Icon: ComponentType<IconProps>;
+  title: string;
+  body: string;
+}
+
+const SLIDES: Slide[] = [
+  {
+    Icon: Lifebuoy,
+    title: "What is a Safety Net?",
+    body: "A Safety Net is a mutual-aid savings circle. A small group pools recurring deposits so that any member can draw on the fund when they need it — a modern, on-chain take on a rotating savings club.",
+  },
+  {
+    Icon: UsersThree,
+    title: "How membership works",
+    body: "You create a net on your own, then invite people with a link. Everyone accepts and joins, and once the group is set the owner starts the net. From that point deposits, withdrawals, and requests are live.",
+  },
+  {
+    Icon: Coins,
+    title: "Depositing your dues",
+    body: "Each epoch every member deposits a fixed amount in BREAD. You can pay a little at a time or prepay several epochs ahead — even cover another member's dues if they're short.",
+  },
+  {
+    Icon: HandDeposit,
+    title: "Requesting a withdrawal",
+    body: "Small withdrawals are instant. Larger ones open a group review: you give a reason, and members have a window to contest it before it executes. It keeps the fund fair and transparent.",
+  },
+  {
+    Icon: Sparkle,
+    title: "Getting help",
+    body: "That's the tour! You can reopen it any time from the “How it works” button. For the full details on epochs, requests, and contesting, head to the docs.",
+  },
+];
+
+const LAST = SLIDES.length - 1;
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function OnboardingModal({
+  onClose,
+  onDone,
+}: {
+  /** Backdrop click / re-open close — leaves the "seen" flag alone. */
+  onClose: () => void;
+  /** Skip / Done / Escape — marks the tour permanently seen. */
+  onDone: () => void;
+}) {
+  const [current, setCurrent] = useState(0);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  const next = () => setCurrent((c) => (c >= LAST ? c : c + 1));
+  const prev = () => setCurrent((c) => (c <= 0 ? c : c - 1));
+
+  // Focus trap + Escape (Escape marks seen, same as Skip/Done).
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onDone();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const root = dialogRef.current;
+      if (!root) return;
+      const nodes = Array.from(
+        root.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement,
+      );
+      if (nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [onDone],
+  );
+
+  // Move focus into the dialog on open; lock body scroll; restore on unmount.
+  useEffect(() => {
+    const root = dialogRef.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    root?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = overflow;
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
+  const slide = SLIDES[current];
+  const Icon = slide.Icon;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        onKeyDown={onKeyDown}
+        className="border-paper-2 bg-paper-0 relative flex w-full max-w-lg flex-col rounded-2xl border p-6 text-center shadow-xl"
+      >
+        <div className="flex items-center justify-end">
+          <Button
+            app="net"
+            variant="light"
+            size="sm"
+            onClick={onDone}
+            className="text-surface-grey-2"
+          >
+            Skip
+          </Button>
+        </div>
+
+        <figure className="text-primary-jade mx-auto mt-2 mb-4">
+          <Icon size={48} aria-hidden />
+        </figure>
+
+        <span id={titleId}>
+          <Heading3 className="text-text-standard">{slide.title}</Heading3>
+        </span>
+        <span id={descId} className="mx-auto mt-3 block max-w-sm">
+          <Body className="text-surface-grey-2">{slide.body}</Body>
+        </span>
+
+        {current === LAST && (
+          <Link
+            href="/docs"
+            className="text-primary-jade mt-3 inline-block text-sm font-bold underline"
+            onClick={onDone}
+          >
+            Read the docs
+          </Link>
+        )}
+
+        <div
+          className="my-6 flex items-center justify-center gap-2"
+          role="tablist"
+          aria-label="Onboarding progress"
+        >
+          {SLIDES.map((s, i) => (
+            <button
+              key={s.title}
+              type="button"
+              role="tab"
+              aria-selected={i === current}
+              aria-label={`Go to slide ${i + 1}: ${s.title}`}
+              onClick={() => setCurrent(i)}
+              className={cn(
+                "h-2 rounded-full transition-all",
+                i === current
+                  ? "bg-primary-jade w-6"
+                  : "bg-paper-2 hover:bg-surface-grey w-2",
+              )}
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            app="net"
+            variant="secondary"
+            onClick={prev}
+            disabled={current === 0}
+            leftIcon={<ArrowLeft size={18} aria-hidden />}
+          >
+            Back
+          </Button>
+          {current === LAST ? (
+            <Button
+              app="net"
+              variant="primary"
+              onClick={onDone}
+              leftIcon={<Sparkle size={18} aria-hidden />}
+            >
+              Done
+            </Button>
+          ) : (
+            <Button
+              app="net"
+              variant="primary"
+              onClick={next}
+              rightIcon={<ArrowRight size={18} aria-hidden />}
+            >
+              Next
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-bread-funding.ts
+++ b/web/src/hooks/use-bread-funding.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback } from "react";
+import { useAccount, useBalance, useReadContract } from "wagmi";
+import { parseEther, zeroAddress, type Address } from "viem";
+import { BREAD_ADDRESS, CHAIN_ID, PRIVY_ENABLED } from "@/lib/config";
+import { breadAbi } from "@/lib/abi/bread";
+import { useTx } from "@/hooks/use-tx";
+import { useXdaiOnrampPrivy } from "@/hooks/use-xdai-onramp-privy";
+
+const REFETCH_MS = 12_000;
+
+/** Reserve a little native xDAI for gas when minting the MAX balance. */
+export const GAS_RESERVE_XDAI = parseEther("0.01");
+
+/**
+ * "Get BREAD" funding: read the connected wallet's BREAD + native xDAI
+ * balances and mint BREAD 1:1 from xDAI.
+ *
+ * `mintBread` sends native value to BREAD's payable `mint(receiver)` through
+ * the app's shared `useTx` path (`TxRequest.value` is carried by both the
+ * wagmi and Privy senders), so minting works identically in normal wagmi and
+ * Privy-sponsored modes. Mirrors app-stacks `use-auto-bake-bread.ts`.
+ *
+ * `openOnramp` (Privy only) buys xDAI via Privy's fiat onramp; when Privy is
+ * disabled it is `undefined` and minting still works from existing xDAI.
+ */
+export function useBreadFunding() {
+  const { address } = useAccount();
+
+  const breadBalanceQuery = useReadContract({
+    address: BREAD_ADDRESS,
+    abi: breadAbi,
+    chainId: CHAIN_ID,
+    functionName: "balanceOf",
+    args: [address ?? zeroAddress],
+    query: { enabled: Boolean(address), refetchInterval: REFETCH_MS },
+  });
+
+  const xdaiBalanceQuery = useBalance({
+    address,
+    chainId: CHAIN_ID,
+    query: { enabled: Boolean(address), refetchInterval: REFETCH_MS },
+  });
+
+  const tx = useTx();
+
+  const mintBread = useCallback(
+    (xdaiAmount: bigint) => {
+      if (!address || xdaiAmount <= 0n) return;
+      return tx.run({
+        address: BREAD_ADDRESS,
+        abi: breadAbi,
+        functionName: "mint",
+        args: [address as Address],
+        value: xdaiAmount,
+      });
+    },
+    [address, tx],
+  );
+
+  // `PRIVY_ENABLED` is a build-time constant, so exactly one branch is live per
+  // build — the conditional hook call is statically consistent (same pattern as
+  // use-tx-sender.ts). The privy module never loads on the general path.
+  let openOnramp: (() => Promise<void>) | undefined;
+  if (PRIVY_ENABLED) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    openOnramp = useXdaiOnrampPrivy();
+  }
+
+  return {
+    breadBalance: breadBalanceQuery.data as bigint | undefined,
+    refetchBreadBalance: breadBalanceQuery.refetch,
+    xdaiBalance: xdaiBalanceQuery.data?.value,
+    refetchXdaiBalance: xdaiBalanceQuery.refetch,
+    mintBread,
+    tx,
+    openOnramp,
+  };
+}

--- a/web/src/hooks/use-onboarding.ts
+++ b/web/src/hooks/use-onboarding.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * localStorage-backed "has seen the onboarding tour" flag plus open/close
+ * controls. First-run detection: if the flag is absent on first mount, we open
+ * the tour automatically and stamp it so it never auto-opens again.
+ *
+ * SSR-safe: `mounted` stays false until the effect runs, so nothing that
+ * depends on localStorage renders during hydration (no mismatch). The tour is
+ * still manually re-openable via `open()` at any time.
+ */
+const STORAGE_KEY = "safetynet.onboardingSeen";
+
+export function useOnboarding() {
+  const [mounted, setMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    let seen = true;
+    try {
+      seen = localStorage.getItem(STORAGE_KEY) === "1";
+    } catch {
+      // storage unavailable — treat as already seen so we don't nag on every load
+    }
+    if (!seen) setIsOpen(true);
+  }, []);
+
+  const markSeen = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // storage unavailable — the flag lasts for this session only
+    }
+  }, []);
+
+  // Manual re-open (e.g. from a "How it works" affordance).
+  const open = useCallback(() => setIsOpen(true), []);
+
+  // Close for now, but leave the flag so it can auto-open again if unseen.
+  const close = useCallback(() => setIsOpen(false), []);
+
+  // Close and permanently stop auto-opening (Skip / Done).
+  const dismiss = useCallback(() => {
+    setIsOpen(false);
+    markSeen();
+  }, [markSeen]);
+
+  return { mounted, isOpen, open, close, dismiss };
+}

--- a/web/src/hooks/use-xdai-onramp-privy.ts
+++ b/web/src/hooks/use-xdai-onramp-privy.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback } from "react";
+import { useFundWallet } from "@privy-io/react-auth";
+import { useConnectedUser } from "@breadcoop/ui";
+import { CHAIN_ID } from "@/lib/config";
+
+/**
+ * Privy fiat/onramp for topping up the embedded wallet with native xDAI
+ * (app-stacks `use-wallet-funding.ts`, xDAI branch). Once the wallet holds
+ * xDAI the user can mint BREAD 1:1 from it.
+ *
+ * This module is only imported from `use-bread-funding.ts` when `PRIVY_ENABLED`,
+ * so `@privy-io/react-auth`'s hook never mounts on the general (RainbowKit) path.
+ */
+export function useXdaiOnrampPrivy() {
+  const { fundWallet } = useFundWallet();
+  const { user } = useConnectedUser();
+  const address = user.status === "CONNECTED" ? user.address : undefined;
+
+  return useCallback(async () => {
+    if (!address) return;
+    await fundWallet({
+      address,
+      options: {
+        chain: { id: CHAIN_ID },
+        uiConfig: { receiveFundsTitle: "Receive xDAI" },
+      },
+    });
+  }, [fundWallet, address]);
+}

--- a/web/src/lib/abi/bread.ts
+++ b/web/src/lib/abi/bread.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal BREAD token ABI.
+ *
+ * BREAD (Breadchain) is minted 1:1 from xDAI by sending native value to the
+ * payable `mint(address receiver)` function — mirrors app-stacks'
+ * `src/lib/abis/bread-abi.ts` (used by use-auto-bake-bread / use-watch-funded-xdai):
+ *
+ *   { name: "mint", stateMutability: "payable",
+ *     inputs: [{ name: "receiver", type: "address" }], outputs: [] }
+ *
+ * We include `balanceOf` too so callers don't need a second ERC20 ABI import.
+ */
+export const breadAbi = [
+  {
+    type: "function",
+    name: "mint",
+    stateMutability: "payable",
+    inputs: [{ name: "receiver", type: "address" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;

--- a/web/src/lib/calendar.ts
+++ b/web/src/lib/calendar.ts
@@ -1,0 +1,215 @@
+/**
+ * Dependency-free calendar-link builders for recurring deposit reminders.
+ *
+ * Ported from the app-stacks reminder utils: every provider gets a plain URL
+ * (or, for Apple/ICS, a downloadable data blob) built entirely client-side —
+ * no credentials, no network calls. The recurrence is expressed as an iCal
+ * RRULE derived from the net's epoch length; Google and ICS honour it, while
+ * Outlook and Yahoo have no URL-level recurrence support (documented below).
+ */
+
+export type RecurrenceFrequency = "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+
+export interface RecurrenceRule {
+  frequency: RecurrenceFrequency;
+  /** e.g. 2 = every 2 weeks. Omitted/1 means every unit. */
+  interval?: number;
+}
+
+export interface CalendarEvent {
+  title: string;
+  description: string;
+  startTime: Date;
+  /** Optional — defaults to startTime + 1 hour. */
+  endTime?: Date;
+  location?: string;
+  recurrence?: RecurrenceRule;
+  /** File name (without extension) for the ICS download. */
+  fileName?: string;
+}
+
+export type CalendarProvider = "google" | "ics" | "outlook" | "yahoo";
+
+/** Providers whose URL schemes cannot carry recurrence. */
+export const RECURRENCE_UNSUPPORTED: CalendarProvider[] = ["outlook", "yahoo"];
+
+const SECONDS_PER_DAY = 86_400;
+const SECONDS_PER_WEEK = SECONDS_PER_DAY * 7;
+// Calendar "months" are irregular; treat ~30 days as a month for cadence
+// classification only (the RRULE still uses whole-month FREQ when it fits).
+const SECONDS_PER_MONTH = SECONDS_PER_DAY * 30;
+const SECONDS_PER_YEAR = SECONDS_PER_DAY * 365;
+
+/**
+ * Map an epoch length (in seconds) onto the closest sensible iCal recurrence.
+ *
+ * We snap to a whole FREQ when the interval is a near-exact multiple of a
+ * calendar unit (weekly / monthly / yearly), otherwise fall back to a generic
+ * DAILY rule with an INTERVAL in whole days so any cadence stays expressible.
+ */
+export function recurrenceFromEpochSeconds(
+  epochSeconds: number,
+): RecurrenceRule {
+  const secs = Math.max(1, Math.round(epochSeconds));
+
+  const nearMultiple = (unit: number): number | null => {
+    const ratio = secs / unit;
+    const rounded = Math.round(ratio);
+    if (rounded < 1) return null;
+    // within 5% of a whole multiple counts as "on the unit"
+    return Math.abs(ratio - rounded) <= 0.05 ? rounded : null;
+  };
+
+  const years = nearMultiple(SECONDS_PER_YEAR);
+  if (years) return { frequency: "YEARLY", interval: years };
+
+  const months = nearMultiple(SECONDS_PER_MONTH);
+  if (months) return { frequency: "MONTHLY", interval: months };
+
+  const weeks = nearMultiple(SECONDS_PER_WEEK);
+  if (weeks) return { frequency: "WEEKLY", interval: weeks };
+
+  // Generic fallback: whole-day interval (minimum 1 day).
+  const days = Math.max(1, Math.round(secs / SECONDS_PER_DAY));
+  return { frequency: "DAILY", interval: days };
+}
+
+/** Human-readable cadence label, e.g. "every 2 weeks" / "every 3 days". */
+export function describeCadence(epochSeconds: number): string {
+  const rule = recurrenceFromEpochSeconds(epochSeconds);
+  const n = rule.interval ?? 1;
+  const unit = {
+    DAILY: "day",
+    WEEKLY: "week",
+    MONTHLY: "month",
+    YEARLY: "year",
+  }[rule.frequency];
+  return n === 1 ? `every ${unit}` : `every ${n} ${unit}s`;
+}
+
+function resolveEndTime(event: CalendarEvent): Date {
+  if (event.endTime) return event.endTime;
+  const end = new Date(event.startTime);
+  end.setHours(end.getHours() + 1);
+  return end;
+}
+
+/** UTC "basic" format used by Google/ICS: 20260703T140500Z. */
+function formatDateCompact(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+}
+
+/** Build an RRULE line, e.g. "RRULE:FREQ=WEEKLY;INTERVAL=2". */
+export function buildRRule(rule: RecurrenceRule): string {
+  const parts: string[] = [`FREQ=${rule.frequency}`];
+  if (rule.interval && rule.interval > 1) {
+    parts.push(`INTERVAL=${rule.interval}`);
+  }
+  return `RRULE:${parts.join(";")}`;
+}
+
+// ── Google Calendar ─────────────────────────────────────────────
+// Recurrence carried via the `recur` param (full RRULE string).
+export function googleCalendarUrl(event: CalendarEvent): string {
+  const endTime = resolveEndTime(event);
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: event.title,
+    details: event.description,
+    location: event.location ?? "",
+    dates: `${formatDateCompact(event.startTime)}/${formatDateCompact(endTime)}`,
+  });
+  if (event.recurrence) params.set("recur", buildRRule(event.recurrence));
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+// ── Outlook (web deep-link) ─────────────────────────────────────
+// No recurrence support in the URL scheme.
+export function outlookCalendarUrl(event: CalendarEvent): string {
+  const endTime = resolveEndTime(event);
+  const params = new URLSearchParams({
+    path: "/calendar/action/compose",
+    rru: "addevent",
+    subject: event.title,
+    body: event.description || "",
+    startdt: event.startTime.toISOString(),
+    enddt: endTime.toISOString(),
+    location: event.location ?? "",
+  });
+  return `https://outlook.office.com/calendar/0/deeplink/compose?${params.toString()}`;
+}
+
+// ── Yahoo Calendar ──────────────────────────────────────────────
+// No recurrence support in the URL scheme.
+function yahooDuration(startTime: Date, endTime: Date): string {
+  const durationMs = endTime.getTime() - startTime.getTime();
+  const hours = Math.floor(durationMs / 3_600_000);
+  const mins = Math.floor((durationMs % 3_600_000) / 60_000);
+  return `${String(hours).padStart(2, "0")}${String(mins).padStart(2, "0")}`;
+}
+
+export function yahooCalendarUrl(event: CalendarEvent): string {
+  const endTime = resolveEndTime(event);
+  const params = new URLSearchParams({
+    v: "60",
+    title: event.title,
+    desc: event.description,
+    st: formatDateCompact(event.startTime),
+    dur: yahooDuration(event.startTime, endTime),
+    in_loc: event.location ?? "",
+  });
+  return `https://calendar.yahoo.com/?${params.toString()}`;
+}
+
+/** Escape a value for an iCal text field (commas, semicolons, newlines). */
+function escapeICS(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+/** Full ICS document string (with RRULE + a 30-minute reminder alarm). */
+export function buildICS(event: CalendarEvent): string {
+  const endTime = resolveEndTime(event);
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Breadchain//SafetyNet//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${Date.now()}@safetynet.breadchain`,
+    `DTSTAMP:${formatDateCompact(new Date())}`,
+    `DTSTART:${formatDateCompact(event.startTime)}`,
+    `DTEND:${formatDateCompact(endTime)}`,
+    `SUMMARY:${escapeICS(event.title)}`,
+    `DESCRIPTION:${escapeICS(event.description)}`,
+    `LOCATION:${escapeICS(event.location ?? "")}`,
+  ];
+  if (event.recurrence) lines.push(buildRRule(event.recurrence));
+  lines.push(
+    "BEGIN:VALARM",
+    "TRIGGER:-PT30M",
+    "ACTION:DISPLAY",
+    `DESCRIPTION:${escapeICS(event.title)}`,
+    "END:VALARM",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  );
+  return lines.join("\r\n");
+}
+
+/** Trigger a client-side download of the event as an .ics file. */
+export function downloadICS(event: CalendarEvent): void {
+  const blob = new Blob([buildICS(event)], {
+    type: "text/calendar;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${event.fileName || "safety-net-deposit"}.ics`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Fills the top backend-free feature gaps vs app-stacks (crowdstake.fun is a yield-distribution app — different domain, no gaps to chase).

**1. Get BREAD funding flow** (fixes the gap we created by restricting creation to BREAD): xDAI→BREAD 1:1 mint via BREAD's payable `mint(receiver)` (matches app-stacks), routed through the shared tx path so it works in both wagmi and Privy-sponsored modes; Privy fiat onramp for xDAI when Privy is enabled (code-split, dead-eliminated in the no-Privy build). Surfaced as a "Get BREAD" button in the nav and an inline "Not enough BREAD" prompt in the deposit panel. Gas-reserve on MAX.

**2. Deposit reminders**: dependency-free Google / Outlook / Yahoo / Apple(ICS) calendar links with an RRULE for the net's epoch cadence, on started nets — cuts missed dues.

**3. First-run onboarding**: a dismissible slide carousel introducing the mutual-aid model (create → invite → start → deposit → request), localStorage-tracked, mounted app-wide with a reopen entry.

Lint clean; standard, base-path, and Privy-enabled static-export builds all pass. No new deps except reusing @privy-io/react-auth's funding API.