### PR TITLE
feat: named safety nets + full wallet funding hub (LiFi)

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -9,6 +9,7 @@ with deadlines, aggregated frontend views.
 | Contract | Address |
 |----------|---------|
 | SafetyNet (proxy — use this address) | [`0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE`](https://gnosis.blockscout.com/address/0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE) |
+| SafetyNet (implementation v4 — named nets) | [`0xa1A489D6070d191079E30D912bfA76174A658408`](https://gnosis.blockscout.com/address/0xa1A489D6070d191079E30D912bfA76174A658408) |
 | SafetyNet (implementation v3 — onchain request reasons) | [`0x0b5E8239c113713d2f6429cAbC3Cf83D53E0B1AD`](https://gnosis.blockscout.com/address/0x0b5E8239c113713d2f6429cAbC3Cf83D53E0B1AD) |
 | SafetyNet (implementation v2 — saving-circles membership model) | [`0x515D1cFec5B21a2648a504bc1B4A9e1977f14743`](https://gnosis.blockscout.com/address/0x515D1cFec5B21a2648a504bc1B4A9e1977f14743) |
 | SafetyNet (implementation v1) | [`0x32A0C6BeCceBe89E852faBEF29cC6016CFa380Ed`](https://gnosis.blockscout.com/address/0x32A0C6BeCceBe89E852faBEF29cC6016CFa380Ed) |

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -76,6 +76,9 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Maximum byte length of a withdrawal request reason (~200 words; the UI enforces the word cap)
   uint256 public constant MAX_REASON_BYTES = 2000;
 
+  /// @notice Maximum byte length of a Safety Net name
+  uint256 public constant MAX_NAME_BYTES = 128;
+
   /// @notice ID counter used to assign unique identifiers to each Safety Net
   uint256 public nextId;
 
@@ -134,6 +137,11 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Requester-supplied reason attached to each withdrawal request; empty string when none was provided
   mapping(uint256 requestId => string reason) public requestReasons;
 
+  /// @inheritdoc ISafetyNet
+  /// @dev Appended at the end of the storage layout to preserve the upgradeable proxy's byte layout.
+  ///      Stored only when a non-empty name is provided at creation; empty string otherwise
+  mapping(uint256 id => string name) public safetyNetNames;
+
   /// @dev Require that msg.sender is a member of the given Safety Net
   modifier onlyMemberOf(uint256 _safetyNetId) {
     _onlyMemberOf(_safetyNetId);
@@ -162,7 +170,9 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /// @inheritdoc ISafetyNet
-  function create(SafetyNet memory _safetyNet) external override nonReentrant returns (uint256 _id) {
+  function create(string calldata _name, SafetyNet memory _safetyNet) external override nonReentrant returns (uint256 _id) {
+    if (bytes(_name).length > MAX_NAME_BYTES) revert NameTooLong();
+
     _id = nextId++;
 
     if (safetyNets[_id].owner != address(0)) revert AlreadyExists();
@@ -191,6 +201,11 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     _safetyNet.id = _id;
     safetyNets[_id] = _safetyNet;
 
+    // Store the name only when non-empty to save gas; the getter returns "" otherwise
+    if (bytes(_name).length > 0) {
+      safetyNetNames[_id] = _name;
+    }
+
     emit SafetyNetCreated(
       _id,
       _safetyNet.owner,
@@ -204,7 +219,8 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
       _safetyNet.redeemRatio,
       _safetyNet.autoThreshold,
       _safetyNet.epochDuration,
-      _safetyNet.smallWithdrawsLimit
+      _safetyNet.smallWithdrawsLimit,
+      _name
     );
     return _id;
   }

--- a/src/interfaces/ISafetyNet.sol
+++ b/src/interfaces/ISafetyNet.sol
@@ -128,6 +128,7 @@ interface ISafetyNet {
   /// @param autoThreshold Maximum amount auto-executed without a request
   /// @param epochDuration Duration of each epoch in seconds
   /// @param smallWithdrawsLimit Maximum number of small withdrawals per epoch
+  /// @param name Optional human-readable name for the Safety Net; empty string when none was provided
   event SafetyNetCreated(
     uint256 indexed id,
     address indexed owner,
@@ -141,7 +142,8 @@ interface ISafetyNet {
     uint256 redeemRatio,
     uint256 autoThreshold,
     uint256 epochDuration,
-    uint256 smallWithdrawsLimit
+    uint256 smallWithdrawsLimit,
+    string name
   );
 
   /// @notice Emitted when a Safety Net is started by its owner
@@ -357,6 +359,9 @@ interface ISafetyNet {
   /// @notice Thrown when a withdrawal request reason exceeds `MAX_REASON_BYTES` bytes
   error ReasonTooLong();
 
+  /// @notice Thrown when a Safety Net name exceeds `MAX_NAME_BYTES` bytes
+  error NameTooLong();
+
   /*///////////////////////////////////////////////////////////////
                             EXTERNAL
   //////////////////////////////////////////////////////////////*/
@@ -374,9 +379,12 @@ interface ISafetyNet {
   /// @dev `members` must be empty and `safetyNetStart` must be 0; further members join via
   ///      {redeemInvite} and the start time is stamped by {start}. `owner` is taken from the
   ///      struct and is not required to equal msg.sender (relayed creation is allowed)
+  /// @param name Optional human-readable name for the Safety Net; must be at most `MAX_NAME_BYTES`
+  ///      bytes. Empty string is allowed (the UI falls back to "Safety Net #N"). Stored only when
+  ///      non-empty and read back via {safetyNetNames}
   /// @param safetyNet The Safety Net configuration
   /// @return id The unique ID of the newly created Safety Net
-  function create(SafetyNet memory safetyNet) external returns (uint256);
+  function create(string calldata name, SafetyNet memory safetyNet) external returns (uint256);
 
   /// @notice Starts a Safety Net, stamping its activation timestamp and opening the deposit/withdraw lifecycle
   /// @dev Only the Safety Net owner may call; requires at least `minimumMembers` joined members.
@@ -462,6 +470,14 @@ interface ISafetyNet {
   /*///////////////////////////////////////////////////////////////
                             VIEW
   //////////////////////////////////////////////////////////////*/
+
+  /// @notice Returns the optional human-readable name of a Safety Net
+  /// @dev This is the read path for names. Returns the empty string when no name was provided at
+  ///      creation (the UI then falls back to "Safety Net #N"). The name lives in an appended
+  ///      mapping and is not part of the {SafetyNet} struct
+  /// @param id The Safety Net ID
+  /// @return name The Safety Net's name, or the empty string if none was set
+  function safetyNetNames(uint256 id) external view returns (string memory name);
 
   /// @notice Retrieves a single Safety Net by ID
   /// @param id The Safety Net ID

--- a/subgraph/abis/SafetyNet.json
+++ b/subgraph/abis/SafetyNet.json
@@ -32,6 +32,19 @@
   },
   {
     "type": "function",
+    "name": "MAX_NAME_BYTES",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "MAX_PREPAY_EPOCHS",
     "inputs": [],
     "outputs": [
@@ -136,6 +149,11 @@
     "type": "function",
     "name": "create",
     "inputs": [
+      {
+        "name": "_name",
+        "type": "string",
+        "internalType": "string"
+      },
       {
         "name": "_safetyNet",
         "type": "tuple",
@@ -1681,6 +1699,25 @@
   },
   {
     "type": "function",
+    "name": "safetyNetNames",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "safetyNets",
     "inputs": [
       {
@@ -2162,6 +2199,12 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false
@@ -2522,6 +2565,11 @@
   {
     "type": "error",
     "name": "InviteAlreadyUsed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NameTooLong",
     "inputs": []
   },
   {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,6 +22,7 @@ enum RequestStatus {
 
 type SafetyNet @entity(immutable: false) {
   id: ID! # net id
+  name: String # human-readable name (may be empty/null)
   owner: Bytes!
   token: Bytes!
   minimumMembers: BigInt!

--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -90,6 +90,7 @@ function ensureMember(
 export function handleSafetyNetCreated(event: SafetyNetCreatedEvent): void {
   let netId = event.params.id.toString()
   let net = new SafetyNet(netId)
+  net.name = event.params.name
   net.owner = event.params.owner
   net.token = event.params.token
   net.minimumMembers = event.params.minimumMembers

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -40,7 +40,7 @@ dataSources:
       # are not indexed. We index from startBlock 47000324 (current proxy) with
       # the current signatures only; pre-upgrade test events are skipped.
       eventHandlers:
-        - event: SafetyNetCreated(indexed uint256,indexed address,uint256,uint256,uint256,address[],address,uint256,uint256,uint256,uint256,uint256,uint256)
+        - event: SafetyNetCreated(indexed uint256,indexed address,uint256,uint256,uint256,address[],address,uint256,uint256,uint256,uint256,uint256,uint256,string)
           handler: handleSafetyNetCreated
         - event: SafetyNetStarted(indexed uint256,uint256)
           handler: handleSafetyNetStarted

--- a/subgraph/tests/safety-net.test.ts
+++ b/subgraph/tests/safety-net.test.ts
@@ -47,7 +47,7 @@ function nextLog(e: ethereum.Event): void {
   e.logIndex = bi(LOG_INDEX++)
 }
 
-function createSafetyNetCreatedEvent(id: i32): SafetyNetCreated {
+function createSafetyNetCreatedEvent(id: i32, name: string = ""): SafetyNetCreated {
   let e = changetype<SafetyNetCreated>(newMockEvent())
   e.parameters = new Array()
   e.parameters.push(
@@ -97,6 +97,9 @@ function createSafetyNetCreatedEvent(id: i32): SafetyNetCreated {
   )
   e.parameters.push(
     new ethereum.EventParam("smallWithdrawsLimit", ethereum.Value.fromUnsignedBigInt(bi(10)))
+  )
+  e.parameters.push(
+    new ethereum.EventParam("name", ethereum.Value.fromString(name))
   )
   nextLog(e)
   return e
@@ -277,8 +280,9 @@ describe("SafetyNet subgraph", () => {
   })
 
   test("created then started lifecycle", () => {
-    handleSafetyNetCreated(createSafetyNetCreatedEvent(1))
+    handleSafetyNetCreated(createSafetyNetCreatedEvent(1, "Carla's Art Collective"))
     assert.entityCount("SafetyNet", 1)
+    assert.fieldEquals("SafetyNet", "1", "name", "Carla's Art Collective")
     assert.fieldEquals("SafetyNet", "1", "decommissioned", "false")
     assert.fieldEquals("SafetyNet", "1", "memberCount", "1")
     assert.fieldEquals("SafetyNet", "1", "owner", OWNER)

--- a/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzzBase.t.sol
@@ -145,7 +145,7 @@ abstract contract SafetyNetFuzzBase is Test {
     cfg.owner = _member1;
     cfg.members = new address[](0);
     cfg.safetyNetStart = 0;
-    _id = _safetyNet.create(cfg);
+    _id = _safetyNet.create('', cfg);
 
     for (uint256 i = 0; i < allMembers.length; i++) {
       if (allMembers[i] == _member1) continue;

--- a/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Create.t.sol
@@ -18,7 +18,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
       if (config.contestThreshold < 1) config.contestThreshold = 1;
       config.autoThreshold = _SAFE_AUTO_THRESHOLD + i * 1e15;
 
-      uint256 safetyNetId = _safetyNet.create(config);
+      uint256 safetyNetId = _safetyNet.create('', config);
       assertEq(safetyNetId, successfulCreations, 'safetyNetId matches successes so far');
 
       // The owner is registered as the sole founding member of every new net
@@ -37,7 +37,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
     config.members = _threeMembers();
 
     vm.expectRevert(ISafetyNet.InvalidMembers.selector);
-    _safetyNet.create(config);
+    _safetyNet.create('', config);
   }
 
   function test_Create_RevertsOnNonZeroStartTime() public {
@@ -46,7 +46,7 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
     config.safetyNetStart = block.timestamp + 1;
 
     vm.expectRevert(ISafetyNet.InvalidSafetyNetStartTime.selector);
-    _safetyNet.create(config);
+    _safetyNet.create('', config);
   }
 
   function test_Create_RevertsOnDisallowedToken_then_SucceedsWhenAllowed() public {
@@ -56,10 +56,10 @@ contract SafetyNetFuzz_Create is SafetyNetFuzzBase {
     config.token = address(temporaryToken);
 
     vm.expectRevert(ISafetyNet.TokenNotAllowed.selector);
-    _safetyNet.create(config);
+    _safetyNet.create('', config);
 
     _safetyNet.setTokenAllowed(address(temporaryToken), true);
-    uint256 allowedSafetyNetId = _safetyNet.create(config);
+    uint256 allowedSafetyNetId = _safetyNet.create('', config);
     assertEq(allowedSafetyNetId, 0, 'first successful creation gets id 0');
   }
 }

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -130,7 +130,7 @@ abstract contract SafetyNetUnitBase is Test {
 
   /// @dev create → invite each joiner (owner-signed) → start(); `cfg.owner` must be `_alice`
   function _createStartedWith(ISafetyNet.SafetyNet memory cfg, address[] memory joiners) internal returns (uint256 id) {
-    id = _sn.create(cfg);
+    id = _sn.create('', cfg);
     for (uint256 i = 0; i < joiners.length; i++) {
       _redeemInviteAs(id, joiners[i], _aliceKey);
     }
@@ -286,7 +286,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   function test_CreateWhenTokenIsNotInAllowedTokensMapping() external {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     vm.expectRevert(ISafetyNet.TokenNotAllowed.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenSafetyNetStartTimeIsNonzero() external {
@@ -296,7 +296,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     // The start time is stamped by start(); passing one at creation is invalid
     _safetyNet.safetyNetStart = block.timestamp;
     vm.expectRevert(ISafetyNet.InvalidSafetyNetStartTime.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenMembersArrayIsNonEmpty() external {
@@ -309,14 +309,14 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     members[1] = _bob;
     _safetyNet.members = members;
     vm.expectRevert(ISafetyNet.InvalidMembers.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
 
     // Even a single (or zero-address) entry is rejected
     address[] memory single = new address[](1);
     single[0] = address(0);
     _safetyNet.members = single;
     vm.expectRevert(ISafetyNet.InvalidMembers.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenOwnerIsZeroAddress() external {
@@ -324,7 +324,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.owner = address(0);
     vm.expectRevert(ISafetyNet.InvalidOwner.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenInitialDepositIsZero() external {
@@ -332,7 +332,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.initialDeposit = 0;
     vm.expectRevert(ISafetyNet.InvalidInitialDeposit.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenFixedDepositIsZero() external {
@@ -340,7 +340,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.fixedDeposit = 0;
     vm.expectRevert(ISafetyNet.InvalidFixedDeposit.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenAutoThresholdIsZero() external {
@@ -348,7 +348,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.autoThreshold = 0;
     vm.expectRevert(ISafetyNet.InvalidThreshold.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenMinimumMembersIs0() external {
@@ -356,7 +356,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.minimumMembers = 0;
     vm.expectRevert(ISafetyNet.InvalidMinimumMembers.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenMinimumMembersIs1() external {
@@ -364,14 +364,14 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.minimumMembers = 1;
     vm.expectRevert(ISafetyNet.InvalidMinimumMembers.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenMaximumMembersEqualsMinimumMembers() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.maximumMembers = _safetyNet.minimumMembers;
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     assertEq(id, 0);
   }
 
@@ -381,7 +381,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _safetyNet.maximumMembers = 1;
     _safetyNet.minimumMembers = 2;
     vm.expectRevert(ISafetyNet.InvalidMaximumMembers.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenEpochDurationIsZero() external {
@@ -389,7 +389,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.epochDuration = 0;
     vm.expectRevert(ISafetyNet.InvalidEpochDuration.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenSmallWithdrawsLimitIsZero() external {
@@ -397,7 +397,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.smallWithdrawsLimit = 0;
     vm.expectRevert(ISafetyNet.InvalidSmallWithdrawsLimit.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenRedeemRatioIsZero() external {
@@ -405,7 +405,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.redeemRatio = 0;
     vm.expectRevert(ISafetyNet.InvalidRatio.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenRedeemRatioIsGreaterThanOne() external {
@@ -415,14 +415,14 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     // Leverage is disabled in v1: the redeem ratio must be exactly 1
     _safetyNet.redeemRatio = 2;
     vm.expectRevert(ISafetyNet.InvalidRatio.selector);
-    _sn.create(_safetyNet);
+    _sn.create('', _safetyNet);
   }
 
   function test_CreateWhenRedeemRatioIsOne() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.redeemRatio = 1;
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     assertEq(_sn.getSafetyNet(id).redeemRatio, 1);
   }
 
@@ -430,7 +430,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.contestThreshold = 0;
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     assertEq(id, 0);
   }
 
@@ -438,13 +438,13 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     _safetyNet.contestThreshold = 150;
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     assertEq(id, 0);
   }
 
   function test_CreateRegistersOwnerAsSoleMember() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
 
     address[] memory members = _sn.getMembers(id);
     assertEq(members.length, 1);
@@ -481,9 +481,10 @@ contract SafetyNetUnit is SafetyNetUnitBase {
       _safetyNet.redeemRatio,
       _safetyNet.autoThreshold,
       _safetyNet.epochDuration,
-      _safetyNet.smallWithdrawsLimit
+      _safetyNet.smallWithdrawsLimit,
+      ''
     );
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     assertEq(id, 0);
 
     // nextId increments
@@ -505,6 +506,94 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     assertEq(_sn.getMemberSafetyNets(_bob).length, 0);
   }
 
+  // ---------- create: names ----------
+  function test_CreateStoresAndReturnsName() external {
+    _allowToken(address(_token));
+    string memory name = 'My Rainy Day Fund';
+    uint256 id = _sn.create(name, _defaultSafetyNet(address(_token)));
+    assertEq(_sn.safetyNetNames(id), name);
+  }
+
+  function test_CreateWithEmptyNameStoresNothing() external {
+    _allowToken(address(_token));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
+    assertEq(bytes(_sn.safetyNetNames(id)).length, 0);
+    assertEq(_sn.safetyNetNames(id), '');
+  }
+
+  function test_CreateWithMaxLengthNamePasses() external {
+    _allowToken(address(_token));
+    bytes memory buf = new bytes(_sn.MAX_NAME_BYTES());
+    for (uint256 i = 0; i < buf.length; i++) {
+      buf[i] = 'a';
+    }
+    string memory name = string(buf);
+    uint256 id = _sn.create(name, _defaultSafetyNet(address(_token)));
+    assertEq(bytes(_sn.safetyNetNames(id)).length, _sn.MAX_NAME_BYTES());
+    assertEq(_sn.safetyNetNames(id), name);
+  }
+
+  function test_CreateRevertsWhenNameTooLong() external {
+    _allowToken(address(_token));
+    bytes memory buf = new bytes(_sn.MAX_NAME_BYTES() + 1);
+    for (uint256 i = 0; i < buf.length; i++) {
+      buf[i] = 'a';
+    }
+    vm.expectRevert(ISafetyNet.NameTooLong.selector);
+    _sn.create(string(buf), _defaultSafetyNet(address(_token)));
+  }
+
+  function test_CreateEmitsName() external {
+    _allowToken(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    string memory name = 'Emitted Name';
+
+    address[] memory expectedMembers = new address[](1);
+    expectedMembers[0] = _alice;
+    vm.expectEmit(true, true, false, true);
+    emit ISafetyNet.SafetyNetCreated(
+      0,
+      _safetyNet.owner,
+      _safetyNet.minimumMembers,
+      _safetyNet.maximumMembers,
+      _safetyNet.contestThreshold,
+      expectedMembers,
+      _safetyNet.token,
+      _safetyNet.initialDeposit,
+      _safetyNet.fixedDeposit,
+      _safetyNet.redeemRatio,
+      _safetyNet.autoThreshold,
+      _safetyNet.epochDuration,
+      _safetyNet.smallWithdrawsLimit,
+      name
+    );
+    _sn.create(name, _safetyNet);
+  }
+
+  function test_CreateWithMultibyteNameRoundTrips() external {
+    _allowToken(address(_token));
+    // "café 🌐" — multibyte: byte length differs from character count
+    string memory name = unicode'café 🌐';
+    // 'c','a','f' (3) + 'é' (2 bytes) + ' ' (1) + '🌐' (4 bytes) = 10 bytes, 6 chars
+    assertEq(bytes(name).length, 10);
+    uint256 id = _sn.create(name, _defaultSafetyNet(address(_token)));
+    assertEq(_sn.safetyNetNames(id), name);
+  }
+
+  function test_CreateCapsNameByByteLengthNotCharCount() external {
+    _allowToken(address(_token));
+    // Each 'é' is 2 bytes; (MAX_NAME_BYTES/2 + 1) of them exceeds the byte cap despite fewer chars
+    uint256 charCount = _sn.MAX_NAME_BYTES() / 2 + 1;
+    bytes memory buf = new bytes(charCount * 2);
+    for (uint256 i = 0; i < charCount; i++) {
+      buf[2 * i] = 0xC3;
+      buf[2 * i + 1] = 0xA9; // UTF-8 for 'é'
+    }
+    assertGt(buf.length, _sn.MAX_NAME_BYTES());
+    vm.expectRevert(ISafetyNet.NameTooLong.selector);
+    _sn.create(string(buf), _defaultSafetyNet(address(_token)));
+  }
+
   // ---------- start ----------
   function test_StartWhenSafetyNetDoesNotExist() external {
     vm.expectRevert(ISafetyNet.NotCommissioned.selector);
@@ -514,7 +603,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_StartWhenCallerIsNotOwner() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
 
     vm.expectRevert(ISafetyNet.InvalidOwner.selector);
@@ -526,7 +615,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
 
     // Only the owner has joined; minimumMembers is 2
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     vm.expectRevert(ISafetyNet.NotEnoughMembers.selector);
     vm.prank(_alice);
     _sn.start(id);
@@ -548,7 +637,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_StartWhenParametersAreValid() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
 
     // Deposits are impossible until started
@@ -581,7 +670,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_DecommissionWhenSafetyNetIsCommissionedButNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
 
     // With no start the epoch index stays 0 forever, so the missed-payment loop never runs
@@ -689,7 +778,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_DepositWhenSafetyNetIsNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
 
     // The owner is a member from creation, but deposits require a started net
     vm.expectRevert(ISafetyNet.DepositBeforeSafetyNetStart.selector);
@@ -911,7 +1000,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_DepositForWhenSafetyNetIsNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     vm.expectRevert(ISafetyNet.DepositBeforeSafetyNetStart.selector);
     vm.prank(_alice);
     _sn.depositFor(id, 1 ether, _alice);
@@ -978,7 +1067,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_WithdrawWhenSafetyNetIsNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
 
     // The owner is a member from creation, but withdrawals require a started net
     vm.expectRevert(ISafetyNet.NotActive.selector);
@@ -1054,7 +1143,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   // ---------- requests before start ----------
   function test_CreateRequestWhenSafetyNetIsNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
 
     // The owner is a member from creation, but requests require a started net
     vm.expectRevert(ISafetyNet.NotActive.selector);
@@ -1220,7 +1309,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   function test_GetSafetyNetWhenSafetyNetExistsAndIsCommissioned() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     ISafetyNet.SafetyNet memory g = _sn.getSafetyNet(id);
     assertEq(g.owner, _safetyNet.owner);
   }
@@ -1232,7 +1321,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_GetSafetyNetsWhenSomeIdsDoNotExist() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     uint256[] memory ids = new uint256[](3);
     ids[0] = id;
     ids[1] = 999;
@@ -1250,7 +1339,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_GetMemberSafetyNetsWhenMemberHasSafetyNets() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     uint256[] memory ids = _sn.getMemberSafetyNets(_alice);
     assertEq(ids.length, 1);
     assertEq(ids[0], id);
@@ -1263,7 +1352,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
 
   function test_GetMemberBalancesWhenSafetyNetExistsAndIsCommissioned() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
     (address[] memory members, uint256[] memory balances) = _sn.getMemberBalances(id);
     assertEq(members.length, 2);
@@ -1289,7 +1378,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   function test_GetCurrentEpochIndexWhenCurrentTimeEdgeCases() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
-    uint256 id = _sn.create(_safetyNet);
+    uint256 id = _sn.create('', _safetyNet);
     _redeemInviteAs(id, _bob, _aliceKey);
 
     // Before start() the epoch index is pinned to 0
@@ -1378,7 +1467,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   // ---------- views before start ----------
   function test_ViewsAreSafeBeforeStart() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
 
     // No epochs, no dues, not decommissionable while commissioned + unstarted
@@ -1411,7 +1500,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     uint256 nonce = 777;
-    uint256 safetyNetId = _sn.create(_safetyNet);
+    uint256 safetyNetId = _sn.create('', _safetyNet);
     ISafetyNet.Invite memory invite = ISafetyNet.Invite(safetyNetId, nonce);
 
     vm.prank(_alice);
@@ -1435,7 +1524,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     uint256 nonce = 777;
-    uint256 safetyNetId = _sn.create(_safetyNet);
+    uint256 safetyNetId = _sn.create('', _safetyNet);
     ISafetyNet.Invite memory invite = ISafetyNet.Invite(safetyNetId, nonce);
 
     bytes memory signature = _inviteGenerator.generateInvite(_impostorKey, safetyNetId, nonce, address(_sn));
@@ -1450,7 +1539,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     uint256 nonce = 777;
-    uint256 safetyNetId = _sn.create(_safetyNet);
+    uint256 safetyNetId = _sn.create('', _safetyNet);
     ISafetyNet.Invite memory invite = ISafetyNet.Invite(safetyNetId, nonce);
 
     vm.prank(_alice);
@@ -1469,7 +1558,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
     uint256 nonce = 777;
-    uint256 safetyNetId = _sn.create(_safetyNet);
+    uint256 safetyNetId = _sn.create('', _safetyNet);
     ISafetyNet.Invite memory invite = ISafetyNet.Invite(safetyNetId, nonce);
 
     vm.prank(_alice);
@@ -1486,7 +1575,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _fullSafetyNet(address(_token));
     uint256 nonce = 777;
-    uint256 safetyNetId = _sn.create(_safetyNet);
+    uint256 safetyNetId = _sn.create('', _safetyNet);
 
     // Fill the net to maximumMembers (2): owner + bob
     _redeemInviteAs(safetyNetId, _bob, _aliceKey);
@@ -1533,7 +1622,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
   function test_RedeemInviteCheckOrderUsedNonceBeatsAlreadyActive() external {
     vm.chainId(_CHAIN_ID);
     _allowToken(address(_token));
-    uint256 safetyNetId = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 safetyNetId = _sn.create('', _defaultSafetyNet(address(_token)));
 
     // Carol redeems nonce 777 before start
     uint256 nonce = 777;
@@ -1600,7 +1689,7 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     ISafetyNet.SafetyNet memory cfg = _defaultSafetyNet(address(_token));
 
     // create: owner is the sole member
-    uint256 id = _sn.create(cfg);
+    uint256 id = _sn.create('', cfg);
     assertEq(_sn.getMembers(id).length, 1);
 
     // invite x2
@@ -1678,7 +1767,7 @@ contract SafetyNetSignatureAndViewsUnit is SafetyNetUnitBase {
 
   function test_CreateRequestWithSignatureWhenSafetyNetIsNotStarted() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _requester, _aliceKey);
     uint256 amount = 60 ether;
     uint256 nonce = 1;
@@ -1913,7 +2002,7 @@ contract SafetyNetSignatureAndViewsUnit is SafetyNetUnitBase {
   // ---------- aggregated views ----------
   function test_GetMembersWhenSafetyNetExists() external {
     _allowToken(address(_token));
-    uint256 id = _sn.create(_defaultSafetyNet(address(_token)));
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
     _redeemInviteAs(id, _bob, _aliceKey);
 
     address[] memory members = _sn.getMembers(id);

--- a/web/README.md
+++ b/web/README.md
@@ -128,7 +128,7 @@ src/
 ├── components/
 │   ├── ui/           # Card/StatCard/Badge, ActionButton, TxStatus, AmountField,
 │   │                 # ConnectGate, AddressDisplay (copy), TimeDisplay (relative+abs)
-│   ├── funding/      # GetBreadModal — mint BREAD 1:1 from xDAI (Privy onramp buys xDAI)
+│   ├── funding/      # "Add funds" hub — see below
 │   ├── net/          # NetCard, NetOverview, MembersList, Deposit/Withdraw panels,
 │   │                 # RequestsList (contest/execute), InvitePanel, DecommissionPanel
 │   └── create/       # create form (react-hook-form + zod)
@@ -155,6 +155,37 @@ Notes:
 - Reads poll every 12 s and are invalidated after every confirmed tx.
 - Invite links: owner signs `Invite(uint256 safetyNetId,uint256 nonce)` under
   domain `SafetyNetInvite` v1 → `/join/?net=…&nonce=…&sig=…` (single-use).
+
+## Add-funds hub (`components/funding/`)
+
+`GetBreadModal({ open, onClose })` (same API as before) is now a shell around
+`FundHub`, a tabbed hub replicating app-stacks' fund-wallet modal. Top of the
+hub shows live BREAD + xDAI balances that refresh after any funding action.
+Rails:
+
+1. **Transfer crypto (LiFi bridge/swap)** — `lifi-bridge.tsx` loads the
+   `@lifi/widget` v4 runtime (`lifi-widget-inner.tsx`) **only** via
+   `next/dynamic(import(...), { ssr: false })`, so it never executes during the
+   `output: "export"` static build. It's themed jade and locked to Gnosis (100)
+   → native xDAI (`lifi-config.ts`). **The embedded widget builds and static
+   exports cleanly** (verified). A `WidgetErrorBoundary` falls back to a
+   `jumper.exchange` link-out (prefilled toChain=100, toAddress) if the widget
+   ever fails at runtime, and the link-out is also used when no wallet is
+   connected.
+2. **Auto-mint after routing** — `use-watch-funded-xdai.ts` watches the wallet's
+   native xDAI via `publicClient.watchBlocks` and fires once per **increase**
+   (ports app-stacks `use-watch-funded-xdai`). Instead of auto-sponsoring a mint
+   (no sponsored-tx path here), the hub surfaces an "N xDAI arrived — mint into
+   BREAD?" offer that routes through the normal `useBreadFunding().mintBread`
+   (wagmi or Privy). The watcher only runs on the bridge/receive/onramp tabs.
+3. **Buy with card (fiat onramp)** — existing Privy onramp, shown only when
+   `PRIVY_ENABLED`.
+4. **Receive** — `receive-panel.tsx` shows the connected address (ENS + copy +
+   explorer via `AddressDisplay`) with "send xDAI/BREAD on Gnosis here" copy.
+5. **Mint BREAD** — the existing direct `mint(receiver)` path with the
+   gas-reserve-on-MAX guard, for users already holding xDAI.
+
+The modal shell owns a11y (labelled dialog, focus, Escape, click-outside).
 
 ## Refreshing the contract ABI
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@breadcoop/ui": "^2.0.1",
     "@hookform/resolvers": "^5.2.2",
+    "@lifi/sdk": "^4.0.0",
+    "@lifi/widget": "^4.1.0",
     "@phosphor-icons/react": "^2.1.10",
     "@privy-io/react-auth": "^3.13.1",
     "@privy-io/wagmi": "^4.0.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   '@hookform/resolvers':
     specifier: ^5.2.2
     version: 5.4.0(react-hook-form@7.80.0)
+  '@lifi/sdk':
+    specifier: ^4.0.0
+    version: 4.1.0
+  '@lifi/widget':
+    specifier: ^4.1.0
+    version: 4.1.0(@tanstack/react-query@5.101.2)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3)
   '@phosphor-icons/react':
     specifier: ^2.1.10
     version: 2.1.10(react-dom@19.1.0)(react@19.1.0)
@@ -118,9 +124,94 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /@babel/code-frame@7.29.7:
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+    dev: false
+
+  /@babel/generator@7.29.7:
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+    dev: false
+
+  /@babel/helper-globals@7.29.7:
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-module-imports@7.29.7:
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-string-parser@7.29.7:
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-validator-identifier@7.29.7:
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/parser@7.29.7:
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.29.7
+    dev: false
+
   /@babel/runtime@7.29.7:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/template@7.29.7:
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+    dev: false
+
+  /@babel/traverse@7.29.7:
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/types@7.29.7:
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
     dev: false
 
   /@base-org/account@1.1.1(@types/react@19.2.17)(react@19.1.0)(typescript@5.9.3)(zod@4.4.3):
@@ -357,6 +448,34 @@ packages:
     dev: true
     optional: true
 
+  /@emotion/babel-plugin@11.13.5:
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@emotion/cache@11.14.0:
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+    dev: false
+
   /@emotion/hash@0.9.2:
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
     dev: false
@@ -369,6 +488,86 @@ packages:
 
   /@emotion/memoize@0.9.0:
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+    dev: false
+
+  /@emotion/react@11.14.0(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      '@types/react': 19.2.17
+      hoist-non-react-statics: 3.3.2
+      react: 19.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@emotion/serialize@1.3.3:
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.2.3
+    dev: false
+
+  /@emotion/sheet@1.4.0:
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+    dev: false
+
+  /@emotion/styled@11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/utils': 1.4.2
+      '@types/react': 19.2.17
+      react: 19.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@emotion/unitless@0.10.0:
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+    dev: false
+
+  /@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0):
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 19.1.0
+    dev: false
+
+  /@emotion/utils@1.4.2:
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+    dev: false
+
+  /@emotion/weak-memoize@0.4.0:
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
     dev: false
 
   /@eslint-community/eslint-utils@4.9.1(eslint@9.39.4):
@@ -868,7 +1067,6 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
-    dev: true
 
   /@jridgewell/remapping@2.3.5:
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
@@ -880,18 +1078,104 @@ packages:
   /@jridgewell/resolve-uri@3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.31:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
+
+  /@lifi/sdk@4.1.0:
+    resolution: {integrity: sha512-rLjP/JXBC7syLimGNZfZmjPUxMpXozhX250IP0UwqnUB7K1lunvQA0NTGC4n6KcsMAHU210XkiTqpbjtFG4q3g==}
+    dependencies:
+      '@lifi/types': 17.85.0
+    dev: false
+
+  /@lifi/types@17.85.0:
+    resolution: {integrity: sha512-EueQyqhyvZbHygkyxj9EPAhUwn69ViRn9zJ56UnZlXsHlOZ/NdNVWxUwrVFVuRt/8qkdZH35R/1vE+SOxFHCNw==}
+    dev: false
+
+  /@lifi/wallet-management@4.1.0(@tanstack/react-query@5.101.2)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-Zu1FQdqD4QQJWDTrCOyq5Lw84bXWDJzjlj0AtdUjLwfFeQkjwXFNwkTdAq6Kcfb4LWFISBmgHMaa5bp4WeY39Q==}
+    peerDependencies:
+      '@tanstack/react-query': '>=5.90.0'
+      react: '>=19'
+      react-dom: '>=19'
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0)
+      '@lifi/sdk': 4.1.0
+      '@lifi/widget-provider': 4.1.0(react@19.1.0)
+      '@mui/icons-material': 9.2.0(@mui/material@9.2.0)(@types/react@19.2.17)(react@19.1.0)
+      '@mui/material': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)
+      '@mui/system': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react@19.1.0)
+      '@tanstack/react-query': 5.101.2(react@19.1.0)
+      eventemitter3: 5.0.4
+      i18next: 26.3.4(typescript@5.9.3)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-i18next: 17.0.8(i18next@26.3.4)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3)
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.1.0)(use-sync-external-store@1.4.0)
+    transitivePeerDependencies:
+      - '@mui/material-pigment-css'
+      - '@types/react'
+      - immer
+      - react-native
+      - supports-color
+      - typescript
+      - use-sync-external-store
+    dev: false
+
+  /@lifi/widget-provider@4.1.0(react@19.1.0):
+    resolution: {integrity: sha512-hQP3wlIbQUs6jwm3zzLEwarKz0IRHmArHoeTb4cXkmZBwUjdUJvK5BQXi/jJ30a2QPQZtsqQ4af9llvsTPdJ+Q==}
+    peerDependencies:
+      react: '>=19'
+    dependencies:
+      '@lifi/sdk': 4.1.0
+      react: 19.1.0
+    dev: false
+
+  /@lifi/widget@4.1.0(@tanstack/react-query@5.101.2)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-bbJYjR/hFuwstQs/+wSjHPp95k2XxpjrBaI3UirBfJWkMbSnSUQdAKVn3is7FTOhIKJ5VWnybZng1wkH7EC1ng==}
+    peerDependencies:
+      '@tanstack/react-query': '>=5.90.0'
+      react: '>=19'
+      react-dom: '>=19'
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0)
+      '@lifi/sdk': 4.1.0
+      '@lifi/wallet-management': 4.1.0(@tanstack/react-query@5.101.2)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3)
+      '@lifi/widget-provider': 4.1.0(react@19.1.0)
+      '@mui/icons-material': 9.2.0(@mui/material@9.2.0)(@types/react@19.2.17)(react@19.1.0)
+      '@mui/material': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)
+      '@mui/system': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react@19.1.0)
+      '@tanstack/react-query': 5.101.2(react@19.1.0)
+      '@tanstack/react-router': 1.170.17(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/react-virtual': 3.14.5(react-dom@19.1.0)(react@19.1.0)
+      eventemitter3: 5.0.4
+      i18next: 26.3.4(typescript@5.9.3)
+      microdiff: 1.5.0
+      motion: 12.42.2(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-i18next: 17.0.8(i18next@26.3.4)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3)
+      react-intersection-observer: 10.0.3(react-dom@19.1.0)(react@19.1.0)
+      react-transition-group: 4.4.5(react-dom@19.1.0)(react@19.1.0)
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.1.0)(use-sync-external-store@1.4.0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@mui/material-pigment-css'
+      - '@types/react'
+      - immer
+      - react-native
+      - supports-color
+      - typescript
+      - use-sync-external-store
+    dev: false
 
   /@lit-labs/ssr-dom-shim@1.6.0:
     resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
@@ -1173,6 +1457,169 @@ packages:
     engines: {node: '>= 18'}
     dev: false
 
+  /@mui/core-downloads-tracker@9.2.0:
+    resolution: {integrity: sha512-+XMav+ZaXkZKUFUgzjrfMEedfyJKxxviAske2q8N8CWDMeqZdDU2lWMkiUPiB388hGaDqhwvOAwkrsc/pUyp8g==}
+    dev: false
+
+  /@mui/icons-material@9.2.0(@mui/material@9.2.0)(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-VgBd3z7Qc3vd/thcNSMC03nHRh/U4DzMUd+1dRyJTbm/hGo7+N6N4GDuJZDNHa6LZhhwG6Cu1X3DNvrVv8sNag==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^9.2.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.17
+      react: 19.1.0
+    dev: false
+
+  /@mui/material@9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^9.2.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0)
+      '@mui/core-downloads-tracker': 9.2.0
+      '@mui/system': 9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react@19.1.0)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.1.0)
+      '@popperjs/core': 2.11.8
+      '@types/react': 19.2.17
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 19.2.7
+      react-transition-group: 4.4.5(react-dom@19.1.0)(react@19.1.0)
+    dev: false
+
+  /@mui/private-theming@9.2.0(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-w9wpyDxGPGnAACPB2hKhCDmILJIAvQxrfjUbIAEa0AznX1rOjaz5N+yB1uuw8ixnJcpEh/tPbD9oEe19wcWPHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.1.0)
+      '@types/react': 19.2.17
+      prop-types: 15.8.1
+      react: 19.1.0
+    dev: false
+
+  /@mui/styled-engine@9.1.1(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(react@19.1.0):
+    resolution: {integrity: sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0)
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.1.0
+    dev: false
+
+  /@mui/system@9.2.0(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-YvUJwKoGVtbnOm2PyPi5TvX2d1rOA6sqSpEWVs4WmXNIaFTuYmNUaVdU2o1NKUEe31URnD3E8ZVUMcsLQXwcYg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0)(@types/react@19.2.17)(react@19.1.0)
+      '@mui/private-theming': 9.2.0(@types/react@19.2.17)(react@19.1.0)
+      '@mui/styled-engine': 9.1.1(@emotion/react@11.14.0)(@emotion/styled@11.14.1)(react@19.1.0)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.1.0)
+      '@types/react': 19.2.17
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.1.0
+    dev: false
+
+  /@mui/types@9.1.1(@types/react@19.2.17):
+    resolution: {integrity: sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/react': 19.2.17
+    dev: false
+
+  /@mui/utils@9.2.0(@types/react@19.2.17)(react@19.1.0):
+    resolution: {integrity: sha512-OsUH5zhlSOM4xmLl53+agug1M1UyWb4zxFxWQCqwKTKUeQPvTENtg3JhrroBD2qpCLKsX5W/DYGERJ4mBUbc8g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@types/prop-types': 15.7.15
+      '@types/react': 19.2.17
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-is: 19.2.7
+    dev: false
+
   /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     requiresBuild: true
@@ -1385,6 +1832,10 @@ packages:
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
     dependencies:
       lit: 3.3.0
+    dev: false
+
+  /@popperjs/core@2.11.8:
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
   /@privy-io/api-base@1.9.1:
@@ -3801,6 +4252,11 @@ packages:
       tailwindcss: 4.3.2
     dev: true
 
+  /@tanstack/history@1.162.0:
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+    dev: false
+
   /@tanstack/query-core@5.101.2:
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
     dev: false
@@ -3814,6 +4270,33 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@tanstack/react-router@1.170.17(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/router-core': 1.171.14
+      isbot: 5.1.44
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@tanstack/react-store@0.9.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+    dev: false
+
   /@tanstack/react-virtual@3.14.5(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
     peerDependencies:
@@ -3823,6 +4306,20 @@ packages:
       '@tanstack/virtual-core': 3.17.3
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@tanstack/router-core@1.171.14:
+    resolution: {integrity: sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==}
+    engines: {node: '>=20.19'}
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+    dev: false
+
+  /@tanstack/store@0.9.3:
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
     dev: false
 
   /@tanstack/virtual-core@3.17.3:
@@ -3873,12 +4370,28 @@ packages:
       undici-types: 6.21.0
     dev: true
 
+  /@types/parse-json@4.0.2:
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+    dev: false
+
+  /@types/prop-types@15.7.15:
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+    dev: false
+
   /@types/react-dom@19.2.3(@types/react@19.2.17):
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
     dependencies:
       '@types/react': 19.2.17
+
+  /@types/react-transition-group@4.4.12(@types/react@19.2.17):
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
+    dependencies:
+      '@types/react': 19.2.17
+    dev: false
 
   /@types/react@19.2.17:
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -6211,6 +6724,15 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+    dependencies:
+      '@babel/runtime': 7.29.7
+      cosmiconfig: 7.1.0
+      resolve: 1.22.12
+    dev: false
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -6317,7 +6839,6 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -6412,12 +6933,31 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: false
+
   /cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
     dev: false
 
+  /cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+    dev: false
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: false
+
+  /cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.3
     dev: false
 
   /crc-32@1.2.2:
@@ -6662,6 +7202,13 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+    dev: false
+
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -6733,6 +7280,12 @@ packages:
       graceful-fs: 4.2.11
       tapable: 2.3.3
     dev: true
+
+  /error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: false
 
   /es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -6879,7 +7432,6 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
 
   /eslint-config-next@15.4.6(eslint@9.39.4)(typescript@5.9.3):
     resolution: {integrity: sha512-4uznvw5DlTTjrZgYZjMciSdDDMO2SWIuQgUNaFyC2O3Zw3Z91XeIejeVa439yRq2CnJb/KEvE4U2AeN/66FpUA==}
@@ -7352,6 +7904,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -7405,6 +7961,27 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+    dev: false
+
+  /framer-motion@12.42.2(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
     dev: false
 
   /function-bind@1.1.2:
@@ -7571,9 +8148,32 @@ packages:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
     dev: false
 
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
+
   /hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
+    dev: false
+
+  /html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+    dependencies:
+      void-elements: 3.1.0
+    dev: false
+
+  /i18next@26.3.4(typescript@5.9.3):
+    resolution: {integrity: sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.9.3
     dev: false
 
   /idb-keyval@6.2.1:
@@ -7604,7 +8204,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -7644,6 +8243,10 @@ packages:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
     dev: true
+
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: false
 
   /is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -7690,7 +8293,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       hasown: 2.0.4
-    dev: true
 
   /is-data-view@1.0.2:
     resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
@@ -7858,6 +8460,11 @@ packages:
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
+  /isbot@5.1.44:
+    resolution: {integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==}
+    engines: {node: '>=18'}
+    dev: false
+
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
@@ -7922,7 +8529,6 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
 
   /js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -7931,9 +8537,19 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: false
+
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
     dev: true
+
+  /json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: false
 
   /json-rpc-engine@6.1.0:
     resolution: {integrity: sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==}
@@ -8133,6 +8749,10 @@ packages:
       lightningcss-win32-x64-msvc: 1.32.0
     dev: true
 
+  /lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: false
+
   /lit-element@4.2.2:
     resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
     dependencies:
@@ -8182,7 +8802,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -8234,6 +8853,10 @@ packages:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
     dev: false
 
+  /microdiff@1.5.0:
+    resolution: {integrity: sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==}
+    dev: false
+
   /micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -8283,6 +8906,36 @@ packages:
 
   /modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
+    dev: false
+
+  /motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+    dependencies:
+      motion-utils: 12.39.0
+    dev: false
+
+  /motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+    dev: false
+
+  /motion@12.42.2(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      framer-motion: 12.42.2(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
     dev: false
 
   /ms@2.1.2:
@@ -8409,7 +9062,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -8791,7 +9443,16 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
+
+  /parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -8804,7 +9465,11 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
+
+  /path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: false
 
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -9092,7 +9757,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /proxy-compare@2.6.0:
     resolution: {integrity: sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==}
@@ -9215,9 +9879,50 @@ packages:
       react: 19.1.0
     dev: false
 
+  /react-i18next@17.0.8(i18next@26.3.4)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
+    peerDependencies:
+      i18next: '>= 26.2.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      html-parse-stringify: 3.0.1
+      i18next: 26.3.4(typescript@5.9.3)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.9.3
+      use-sync-external-store: 1.6.0(react@19.1.0)
+    dev: false
+
+  /react-intersection-observer@10.0.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
+
+  /react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+    dev: false
 
   /react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.1.0):
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -9282,6 +9987,20 @@ packages:
       get-nonce: 1.0.1
       react: 19.1.0
       tslib: 2.8.1
+    dev: false
+
+  /react-transition-group@4.4.5(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /react@19.1.0:
@@ -9374,11 +10093,21 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
     dev: true
+
+  /resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
@@ -9471,6 +10200,20 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  /seroval-plugins@1.5.4(seroval@1.5.4):
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+    dependencies:
+      seroval: 1.5.4
+    dev: false
+
+  /seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -9658,6 +10401,11 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  /source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
@@ -9834,6 +10582,10 @@ packages:
       react: 19.1.0
     dev: false
 
+  /stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+    dev: false
+
   /stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
     dev: false
@@ -9857,7 +10609,6 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
@@ -10452,6 +11203,11 @@ packages:
       - zod
     dev: false
 
+  /void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /wagmi@2.19.5(@tanstack/react-query@5.101.2)(@types/react@19.2.17)(react@19.1.0)(typescript@5.9.3)(viem@2.54.1)(zod@3.25.76):
     resolution: {integrity: sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==}
     peerDependencies:
@@ -10789,6 +11545,11 @@ packages:
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: false
+
+  /yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
     dev: false
 
   /yargs-parser@18.1.3:

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useAccount } from "wagmi";
 import { Button } from "@breadcoop/ui";
@@ -14,12 +14,18 @@ import {
   PageHeader,
 } from "@/components/ui/ui";
 import { NetCard } from "@/components/net/net-card";
-import { useMemberDashboard } from "@/hooks/use-safety-net";
+import { useMemberDashboard, useSafetyNetNames } from "@/hooks/use-safety-net";
 import { isContractConfigured } from "@/lib/config";
 import { parseContractError } from "@/lib/parse-contract-error";
 
 function Dashboard() {
   const { data: dashboard, isLoading, error, refetch } = useMemberDashboard();
+
+  const ids = useMemo(
+    () => (dashboard ?? []).map((d) => d.safetyNet.id),
+    [dashboard],
+  );
+  const names = useSafetyNetNames(ids);
 
   if (!isContractConfigured)
     return (
@@ -55,7 +61,11 @@ function Dashboard() {
   return (
     <div className="flex flex-col gap-4">
       {dashboard.map((details, i) => (
-        <NetCard key={`${details.safetyNet.id}-${i}`} details={details} />
+        <NetCard
+          key={`${details.safetyNet.id}-${i}`}
+          details={details}
+          name={names.get(details.safetyNet.id)}
+        />
       ))}
     </div>
   );

--- a/web/src/components/create/create-form.tsx
+++ b/web/src/components/create/create-form.tsx
@@ -118,6 +118,7 @@ export function CreateForm() {
   const form = useForm<CreateNetValues>({
     resolver: zodResolver(createNetSchema),
     defaultValues: {
+      name: "",
       memberCount: DEFAULTS.memberCount,
       tokenChoice: "bread",
       customToken: "",
@@ -201,6 +202,22 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
 
   return (
     <Card className="flex flex-col gap-5">
+      <Field
+        id={id("name")}
+        label="Safety Net name"
+        help="A friendly name for your group (optional). Members see this everywhere instead of just an id."
+        error={errors.name?.message}
+      >
+        <input
+          {...fieldAria(id("name"), errors.name?.message, "help")}
+          type="text"
+          maxLength={128}
+          placeholder="e.g. Carla's Art Collective"
+          className={inputClass}
+          {...register("name")}
+        />
+      </Field>
+
       <Field
         label="Token"
         help="The ERC20 everyone saves in. BREAD is the default; pick Custom for another allowed token."
@@ -494,6 +511,7 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
   const { decimals } = useTokenInfo(token);
   const symbol = useNetSymbol(form);
 
+  const name = watch("name")?.trim();
   const members = watch("memberCount");
   const initial = watch("initialDeposit");
   const fixed = watch("fixedDeposit");
@@ -530,7 +548,7 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
     )
       return;
 
-    create({
+    create(v.name.trim(), {
       id: 0n, // assigned by the contract
       owner: address,
       minimumMembers: BigInt(v.minimumMembers),
@@ -561,7 +579,14 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
       </Heading4>
 
       <Body className="text-surface-grey-2 leading-relaxed">
-        A {symbol} saving circle of up to{" "}
+        {name ? (
+          <>
+            <strong className="text-text-standard">{name}</strong> — a {symbol}{" "}
+            saving circle of up to{" "}
+          </>
+        ) : (
+          <>A {symbol} saving circle of up to </>
+        )}
         <strong className="text-text-standard">{members || "—"}</strong> members.
         Everyone pays{" "}
         <strong className="text-text-standard">{amt(initial)}</strong> to join and{" "}
@@ -596,7 +621,7 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
                 weight="fill"
                 className="text-system-green shrink-0"
               />
-              Safety Net{" "}
+              {name ? `${name} ` : "Safety Net "}
               {createdId !== undefined ? `#${createdId.toString()} ` : ""}
               created
             </Heading4>
@@ -615,7 +640,7 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
                 href={createdId !== undefined ? `/net/?id=${createdId}` : "/"}
               >
                 {createdId !== undefined
-                  ? `Open Safety Net #${createdId.toString()}`
+                  ? `Open ${name || `Safety Net #${createdId.toString()}`}`
                   : "Go to your dashboard"}
               </Button>
             </div>

--- a/web/src/components/create/schema.ts
+++ b/web/src/components/create/schema.ts
@@ -11,8 +11,17 @@ const amountString = z
     "Enter an amount greater than 0",
   );
 
+/** UTF-8 byte length — must match the contract's MAX_NAME_BYTES check. */
+const utf8Bytes = (v: string) => new TextEncoder().encode(v).length;
+
 export const createNetSchema = z
   .object({
+    // Optional human-readable name (contract MAX_NAME_BYTES = 128). Empty is
+    // allowed on-chain; we cap the byte length to match the NameTooLong revert.
+    name: z
+      .string()
+      .trim()
+      .refine((v) => utf8Bytes(v) <= 128, "Name is too long (max 128 bytes)"),
     // Group size cap (contract maximumMembers). The owner is the sole member
     // at creation — everyone else joins via invite links before start().
     memberCount: z

--- a/web/src/components/funding/fund-hub.tsx
+++ b/web/src/components/funding/fund-hub.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { formatUnits, type Address } from "viem";
+import { useAccount } from "wagmi";
+import { Body, Button, Caption, Heading4 } from "@breadcoop/ui";
+import { AmountField } from "@/components/ui/amount-field";
+import { TxStatus } from "@/components/ui/tx-status";
+import { PRIVY_ENABLED } from "@/lib/config";
+import { formatAmount, parseAmount } from "@/lib/format";
+import { GAS_RESERVE_XDAI, useBreadFunding } from "@/hooks/use-bread-funding";
+import { useWatchFundedXdai } from "@/hooks/use-watch-funded-xdai";
+import { LiFiBridge } from "./lifi-bridge";
+import { ReceivePanel } from "./receive-panel";
+
+type RailId = "bridge" | "onramp" | "receive" | "mint";
+
+interface Rail {
+  id: RailId;
+  label: string;
+  heading: string;
+  blurb: string;
+}
+
+/** "Get BREAD" funding hub — a sectioned set of ways to add funds. */
+export function FundHub({ onClose }: { onClose: () => void }) {
+  const { address } = useAccount();
+  const {
+    breadBalance,
+    xdaiBalance,
+    refetchBreadBalance,
+    refetchXdaiBalance,
+    mintBread,
+    tx,
+    openOnramp,
+  } = useBreadFunding();
+
+  const showOnramp = PRIVY_ENABLED && Boolean(openOnramp);
+
+  const rails: Rail[] = useMemo(() => {
+    const base: Rail[] = [
+      {
+        id: "bridge",
+        label: "Transfer crypto",
+        heading: "Bring crypto from any chain",
+        blurb:
+          "Bridge or swap tokens from Ethereum, Arbitrum, Base and more into xDAI on Gnosis. Best if you already hold crypto elsewhere.",
+      },
+    ];
+    if (showOnramp) {
+      base.push({
+        id: "onramp",
+        label: "Buy with card",
+        heading: "Buy xDAI with card",
+        blurb: "Top up your wallet with a card or bank transfer via Privy. Best if you're starting from fiat.",
+      });
+    }
+    base.push(
+      {
+        id: "receive",
+        label: "Receive",
+        heading: "Receive from another wallet",
+        blurb: "Send xDAI or BREAD on Gnosis directly to your wallet address. Best if a friend or exchange is paying you.",
+      },
+      {
+        id: "mint",
+        label: "Mint BREAD",
+        heading: "Mint BREAD from xDAI",
+        blurb: "Already holding xDAI? Convert it to BREAD 1:1 — redeemable back to xDAI anytime.",
+      },
+    );
+    return base;
+  }, [showOnramp]);
+
+  const [rail, setRail] = useState<RailId>("bridge");
+  const active = rails.find((r) => r.id === rail) ?? rails[0];
+
+  // ---- Direct mint state ----------------------------------------------------
+  const [amount, setAmount] = useState("");
+  const mintableXdai = useMemo(() => {
+    if (xdaiBalance === undefined) return undefined;
+    return xdaiBalance > GAS_RESERVE_XDAI ? xdaiBalance - GAS_RESERVE_XDAI : 0n;
+  }, [xdaiBalance]);
+  const parsed = useMemo(() => parseAmount(amount, 18), [amount]);
+  const insufficientXdai =
+    parsed !== null && parsed > 0n && mintableXdai !== undefined && parsed > mintableXdai;
+
+  const submitMint = () => {
+    if (parsed === null || parsed === 0n || insufficientXdai) return;
+    mintBread(parsed);
+  };
+
+  // ---- Post-route auto-mint offer ------------------------------------------
+  // Watch xDAI while on the bridge/receive/onramp rails; when new xDAI lands,
+  // offer to mint it into BREAD (one prompt per arrival). Users on the "mint"
+  // rail are already minting manually, so we don't watch there.
+  const [pendingMint, setPendingMint] = useState<bigint | null>(null);
+  const watchEnabled = rail === "bridge" || rail === "receive" || rail === "onramp";
+
+  const onFunded = useCallback((delta: bigint) => {
+    setPendingMint((cur) => (cur ?? 0n) + delta);
+  }, []);
+  useWatchFundedXdai(address, onFunded, watchEnabled);
+
+  const acceptPendingMint = () => {
+    if (!pendingMint) return;
+    // Reserve gas so the mint tx itself can pay for gas.
+    const value = pendingMint > GAS_RESERVE_XDAI ? pendingMint - GAS_RESERVE_XDAI : pendingMint;
+    setPendingMint(null);
+    mintBread(value);
+  };
+
+  // Refresh balances (and clear inputs) after a successful action.
+  useEffect(() => {
+    if (!tx.isSuccess) return;
+    refetchBreadBalance();
+    refetchXdaiBalance();
+    setAmount("");
+    setPendingMint(null);
+  }, [tx.isSuccess, refetchBreadBalance, refetchXdaiBalance]);
+
+  return (
+    <div>
+      <Heading4 className="text-text-standard">Add funds</Heading4>
+      <Body className="text-surface-grey-2 mt-1 text-sm">
+        Fund your wallet, then mint BREAD — the savings token your Safety Net
+        holds. BREAD mints 1:1 from xDAI and redeems back anytime.
+      </Body>
+
+      {/* Live balances */}
+      <dl className="border-paper-2 bg-paper-main mt-4 grid grid-cols-2 gap-px overflow-hidden rounded-xl border">
+        <div className="bg-paper-0 p-3">
+          <dt className="text-surface-grey-2 text-xs font-medium">Your BREAD</dt>
+          <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
+            {breadBalance !== undefined ? formatAmount(breadBalance, 18) : "…"}
+          </dd>
+        </div>
+        <div className="bg-paper-0 p-3">
+          <dt className="text-surface-grey-2 text-xs font-medium">Your xDAI</dt>
+          <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
+            {xdaiBalance !== undefined ? formatAmount(xdaiBalance, 18) : "…"}
+          </dd>
+        </div>
+      </dl>
+
+      {/* Auto-mint offer after funds land */}
+      {pendingMint !== null && pendingMint > 0n && rail !== "mint" && (
+        <div className="border-primary-jade bg-paper-main mt-4 rounded-xl border p-3">
+          <p className="text-text-standard text-sm font-medium">
+            {formatAmount(pendingMint, 18)} xDAI just arrived. Mint it into BREAD?
+          </p>
+          <div className="mt-2 flex gap-2">
+            <Button app="net" variant="primary" className="flex-1" isLoading={tx.isBusy} onClick={acceptPendingMint}>
+              Mint BREAD
+            </Button>
+            <Button app="net" variant="secondary" onClick={() => setPendingMint(null)}>
+              Keep xDAI
+            </Button>
+          </div>
+          <TxStatus status={tx.status} hash={tx.hash} error={tx.error} successLabel="Minted BREAD" />
+        </div>
+      )}
+
+      {/* Rail tabs */}
+      <div role="tablist" aria-label="Funding methods" className="mt-4 flex flex-wrap gap-2">
+        {rails.map((r) => (
+          <button
+            key={r.id}
+            role="tab"
+            type="button"
+            aria-selected={r.id === rail}
+            aria-controls={`fund-panel-${r.id}`}
+            id={`fund-tab-${r.id}`}
+            onClick={() => setRail(r.id)}
+            className={
+              r.id === rail
+                ? "bg-primary-jade rounded-full px-3 py-1.5 text-sm font-medium text-white"
+                : "border-paper-2 text-surface-grey-2 hover:border-primary-jade rounded-full border px-3 py-1.5 text-sm font-medium"
+            }
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`fund-panel-${active.id}`}
+        aria-labelledby={`fund-tab-${active.id}`}
+        className="mt-4"
+      >
+        <Heading4 className="text-text-standard text-base">{active.heading}</Heading4>
+        <Caption className="text-surface-grey mt-1 block">{active.blurb}</Caption>
+
+        <div className="mt-3">
+          {rail === "bridge" && (
+            <LiFiBridge address={address as Address | undefined} onXdaiRouted={() => refetchXdaiBalance()} />
+          )}
+
+          {rail === "onramp" && showOnramp && (
+            <Button app="net" variant="secondary" className="w-full" onClick={() => openOnramp?.()}>
+              Buy xDAI with card
+            </Button>
+          )}
+
+          {rail === "receive" && <ReceivePanel address={address as Address | undefined} />}
+
+          {rail === "mint" && (
+            <div className="flex flex-col gap-3">
+              <AmountField
+                label="Mint from xDAI"
+                value={amount}
+                onChange={setAmount}
+                balance={mintableXdai}
+                balanceLabel="Available"
+                symbol="xDAI"
+                decimals={18}
+                error={insufficientXdai}
+                help="1 xDAI = 1 BREAD. A little xDAI is kept back for gas when you use MAX."
+              />
+              {insufficientXdai && (
+                <p className="text-system-red text-xs font-medium">
+                  That&apos;s more xDAI than you have available
+                  {mintableXdai !== undefined
+                    ? ` (${formatAmount(mintableXdai, 18)} xDAI, keeping ${formatUnits(GAS_RESERVE_XDAI, 18)} for gas)`
+                    : ""}
+                  .
+                </p>
+              )}
+              <Button
+                app="net"
+                variant="primary"
+                className="w-full"
+                isLoading={tx.isBusy}
+                onClick={submitMint}
+                {...(parsed === null || parsed === 0n || insufficientXdai ? { disabled: true } : {})}
+              >
+                {parsed !== null && parsed > 0n
+                  ? `Mint ${formatAmount(parsed, 18)} BREAD from xDAI`
+                  : "Mint BREAD from xDAI"}
+              </Button>
+              <TxStatus status={tx.status} hash={tx.hash} error={tx.error} successLabel="Minted BREAD" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Button app="net" variant="secondary" className="mt-4 w-full" onClick={onClose}>
+        Close
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/funding/get-bread-modal.tsx
+++ b/web/src/components/funding/get-bread-modal.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { formatUnits } from "viem";
-import { Body, Button, Heading4 } from "@breadcoop/ui";
-import { AmountField } from "@/components/ui/amount-field";
-import { TxStatus } from "@/components/ui/tx-status";
-import { PRIVY_ENABLED } from "@/lib/config";
-import { formatAmount, parseAmount } from "@/lib/format";
-import { GAS_RESERVE_XDAI, useBreadFunding } from "@/hooks/use-bread-funding";
-
-/** Below this much xDAI we nudge the user toward the (Privy) onramp. */
-const LOW_XDAI = GAS_RESERVE_XDAI;
+import { useEffect, useId, useRef } from "react";
+import { FundHub } from "./fund-hub";
 
 /**
- * "Get BREAD" funding modal. BREAD is the Safety Net savings token and mints
- * 1:1 from xDAI via BREAD's payable `mint(receiver)` (app-stacks
- * fund-wallet / use-auto-bake-bread pattern).
+ * "Add funds" hub modal. Keeps the original `GetBreadModal({ open, onClose })`
+ * API so navbar.tsx / deposit-panel.tsx keep working unchanged; the body is now
+ * the full funding hub (LiFi bridge, fiat onramp, receive, and direct BREAD
+ * mint) — see fund-hub.tsx.
  *
- * Shows live BREAD + xDAI balances; when Privy is enabled and xDAI is low it
- * offers a "Buy xDAI" onramp; and it mints N BREAD from N xDAI (reserving a
- * little xDAI for gas on MAX). Works in both wagmi and Privy-sponsored modes —
- * minting routes through the shared `useTx` path.
+ * This shell owns the a11y concerns: labelled dialog, Escape-to-close,
+ * click-outside, and initial focus.
  */
 export function GetBreadModal({
   open,
@@ -31,30 +21,6 @@ export function GetBreadModal({
 }) {
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
-  const [amount, setAmount] = useState("");
-
-  const {
-    breadBalance,
-    xdaiBalance,
-    refetchBreadBalance,
-    refetchXdaiBalance,
-    mintBread,
-    tx,
-    openOnramp,
-  } = useBreadFunding();
-
-  // MAX mints all xDAI minus a gas reserve (app-stacks gas-reserve-on-MAX).
-  const mintableXdai = useMemo(() => {
-    if (xdaiBalance === undefined) return undefined;
-    return xdaiBalance > GAS_RESERVE_XDAI ? xdaiBalance - GAS_RESERVE_XDAI : 0n;
-  }, [xdaiBalance]);
-
-  const parsed = useMemo(() => parseAmount(amount, 18), [amount]);
-  const insufficientXdai =
-    parsed !== null &&
-    parsed > 0n &&
-    mintableXdai !== undefined &&
-    parsed > mintableXdai;
 
   useEffect(() => {
     if (!open) return;
@@ -62,29 +28,11 @@ export function GetBreadModal({
       if (e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", onKey);
-    dialogRef.current
-      ?.querySelector<HTMLElement>("input,button")
-      ?.focus();
+    dialogRef.current?.querySelector<HTMLElement>("input,button")?.focus();
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
-  // Refresh balances (and clear the field) after a successful mint.
-  useEffect(() => {
-    if (!tx.isSuccess) return;
-    refetchBreadBalance();
-    refetchXdaiBalance();
-    setAmount("");
-  }, [tx.isSuccess, refetchBreadBalance, refetchXdaiBalance]);
-
   if (!open) return null;
-
-  const showOnramp = PRIVY_ENABLED && Boolean(openOnramp);
-  const lowXdai = xdaiBalance !== undefined && xdaiBalance < LOW_XDAI;
-
-  const submit = () => {
-    if (parsed === null || parsed === 0n || insufficientXdai) return;
-    mintBread(parsed);
-  };
 
   return (
     <div
@@ -99,111 +47,12 @@ export function GetBreadModal({
         aria-modal="true"
         aria-labelledby={titleId}
         onClick={(e) => e.stopPropagation()}
-        className="border-paper-2 bg-paper-0 relative w-full max-w-md rounded-2xl border p-6 shadow-xl"
+        className="border-paper-2 bg-paper-0 relative max-h-[90vh] w-full max-w-md overflow-y-auto rounded-2xl border p-6 shadow-xl"
       >
-        <div id={titleId}>
-          <Heading4 className="text-text-standard">Get BREAD</Heading4>
+        <div id={titleId} className="sr-only">
+          Add funds
         </div>
-        <Body className="text-surface-grey-2 mt-2 text-sm">
-          BREAD is the savings token your Safety Net holds. It mints 1:1 from
-          xDAI — 1 xDAI becomes 1 BREAD, redeemable back to xDAI anytime.
-        </Body>
-
-        <dl className="border-paper-2 bg-paper-main mt-4 grid grid-cols-2 gap-px overflow-hidden rounded-xl border">
-          <div className="bg-paper-0 p-3">
-            <dt className="text-surface-grey-2 text-xs font-medium">
-              Your BREAD
-            </dt>
-            <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
-              {breadBalance !== undefined
-                ? formatAmount(breadBalance, 18)
-                : "…"}
-            </dd>
-          </div>
-          <div className="bg-paper-0 p-3">
-            <dt className="text-surface-grey-2 text-xs font-medium">
-              Your xDAI
-            </dt>
-            <dd className="font-breadDisplay text-text-standard mt-0.5 text-lg font-bold">
-              {xdaiBalance !== undefined ? formatAmount(xdaiBalance, 18) : "…"}
-            </dd>
-          </div>
-        </dl>
-
-        {showOnramp && lowXdai && (
-          <div className="mt-4">
-            <p className="text-surface-grey-2 text-xs font-medium">
-              You&apos;ll need xDAI to mint BREAD. Buy some with card or another
-              wallet:
-            </p>
-            <Button
-              app="net"
-              variant="secondary"
-              className="mt-2 w-full"
-              onClick={() => openOnramp?.()}
-            >
-              Buy xDAI
-            </Button>
-          </div>
-        )}
-
-        <div className="mt-4 flex flex-col gap-3">
-          <AmountField
-            label="Mint from xDAI"
-            value={amount}
-            onChange={setAmount}
-            balance={mintableXdai}
-            balanceLabel="Available"
-            symbol="xDAI"
-            decimals={18}
-            error={insufficientXdai}
-            help="1 xDAI = 1 BREAD. A little xDAI is kept back for gas when you use MAX."
-          />
-
-          {insufficientXdai && (
-            <p className="text-system-red text-xs font-medium">
-              That&apos;s more xDAI than you have available
-              {mintableXdai !== undefined
-                ? ` (${formatAmount(mintableXdai, 18)} xDAI, keeping ${formatUnits(
-                    GAS_RESERVE_XDAI,
-                    18,
-                  )} for gas)`
-                : ""}
-              .
-            </p>
-          )}
-
-          <Button
-            app="net"
-            variant="primary"
-            className="w-full"
-            isLoading={tx.isBusy}
-            onClick={submit}
-            {...(parsed === null || parsed === 0n || insufficientXdai
-              ? { disabled: true }
-              : {})}
-          >
-            {parsed !== null && parsed > 0n
-              ? `Mint ${formatAmount(parsed, 18)} BREAD from xDAI`
-              : "Mint BREAD from xDAI"}
-          </Button>
-
-          <TxStatus
-            status={tx.status}
-            hash={tx.hash}
-            error={tx.error}
-            successLabel="Minted BREAD"
-          />
-
-          <Button
-            app="net"
-            variant="secondary"
-            className="w-full"
-            onClick={onClose}
-          >
-            Close
-          </Button>
-        </div>
+        <FundHub onClose={onClose} />
       </div>
     </div>
   );

--- a/web/src/components/funding/lifi-bridge.tsx
+++ b/web/src/components/funding/lifi-bridge.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import dynamic from "next/dynamic";
+import type { Address } from "viem";
+import type { Route } from "@lifi/widget";
+import { ArrowSquareOut } from "@phosphor-icons/react";
+import { Button } from "@breadcoop/ui";
+import { CHAIN_ID } from "@/lib/config";
+
+/**
+ * Static-export-safe entry point for the LiFi cross-chain bridge/swap.
+ *
+ * CRITICAL: the widget runtime lives in `./lifi-widget-inner` and is loaded
+ * ONLY via `next/dynamic(..., { ssr: false })`, so it is never imported during
+ * `output: "export"` static generation. If the widget bundle throws at runtime
+ * (e.g. an environment it can't initialise in), the error boundary below swaps
+ * in a jumper.exchange link-out prefilled for Gnosis — the documented safe
+ * fallback.
+ */
+
+const LiFiWidgetInner = dynamic(() => import("./lifi-widget-inner"), {
+  ssr: false,
+  loading: () => (
+    <div className="border-paper-2 bg-paper-main flex h-72 items-center justify-center rounded-xl border">
+      <span className="text-surface-grey-2 text-sm">Loading bridge…</span>
+    </div>
+  ),
+});
+
+/** Jumper (LiFi's hosted app) prefilled to receive xDAI on Gnosis. */
+function jumperUrl(address?: Address) {
+  const p = new URLSearchParams({
+    toChain: String(CHAIN_ID),
+    toToken: "0x0000000000000000000000000000000000000000",
+  });
+  if (address) p.set("toAddress", address);
+  return `https://jumper.exchange/?${p.toString()}`;
+}
+
+export function LiFiLinkOut({ address }: { address?: Address }) {
+  return (
+    <div className="border-paper-2 bg-paper-main rounded-xl border p-4">
+      <p className="text-surface-grey-2 text-sm">
+        Bridge or swap from any chain into xDAI on Gnosis using Jumper (powered
+        by LiFi). It opens in a new tab prefilled for your wallet.
+      </p>
+      <Button
+        app="net"
+        variant="secondary"
+        className="mt-3 w-full"
+        onClick={() => window.open(jumperUrl(address), "_blank", "noopener")}
+      >
+        <span className="inline-flex items-center gap-2">
+          Open Jumper <ArrowSquareOut size={16} />
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+class WidgetErrorBoundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  componentDidCatch(error: unknown) {
+    console.warn("[lifi] widget failed, falling back to link-out", error);
+  }
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}
+
+export function LiFiBridge({
+  address,
+  onXdaiRouted,
+}: {
+  address?: Address;
+  onXdaiRouted?: (route: Route) => void;
+}) {
+  if (!address) return <LiFiLinkOut address={address} />;
+  return (
+    <WidgetErrorBoundary fallback={<LiFiLinkOut address={address} />}>
+      <LiFiWidgetInner address={address} onXdaiRouted={onXdaiRouted} />
+    </WidgetErrorBoundary>
+  );
+}

--- a/web/src/components/funding/lifi-config.ts
+++ b/web/src/components/funding/lifi-config.ts
@@ -1,0 +1,54 @@
+import type { WidgetConfig } from "@lifi/widget";
+import { CHAIN_ID } from "@/lib/config";
+
+/**
+ * LiFi widget config, themed to Safety Net's jade palette and locked to
+ * Gnosis (chain 100) as the destination so any chain/token routes into xDAI.
+ *
+ * Mirrors app-stacks `src/components/lifi/config.ts`, but:
+ *  - target token is native xDAI (`0x000…0`) on Gnosis — after it lands we
+ *    auto-offer minting BREAD (use-watch-funded-xdai), same as app-stacks;
+ *  - the theme is recoloured from Breadchain orange to Safety Net jade.
+ *
+ * Kept as a plain object (no JSX / no widget import that executes) so it can be
+ * imported from a static build without pulling the widget runtime in.
+ */
+export const lifiConfig: Partial<WidgetConfig> = {
+  variant: "compact",
+  appearance: "light",
+  tokens: {
+    from: {
+      deny: [{ address: "0x0000000000000000000000000000000000000000", chainId: CHAIN_ID }],
+    },
+  },
+  chains: {
+    allow: [1, CHAIN_ID, 42161, 8453, 56, 137, 10],
+  },
+  // Initialize destination to native xDAI on Gnosis.
+  toToken: "0x0000000000000000000000000000000000000000",
+  toChain: CHAIN_ID,
+  disabledUI: { toToken: true },
+  theme: {
+    colorSchemes: {
+      light: {
+        palette: {
+          primary: { main: "#1f7a5c" },
+          secondary: { main: "#8fd0b8" },
+          info: { main: "#1f7a5c" },
+          background: { default: "#fbfdfb", paper: "#f1f6f2" },
+          text: { secondary: "#4a5750" },
+          success: { main: "#1f9d5b" },
+          error: { main: "#d64545" },
+          common: { white: "#f7faf7" },
+          grey: { 200: "#808080", 300: "#e2ebe4", 700: "#4a5750", 800: "#6d6d6d" },
+        },
+      },
+    },
+    typography: { fontFamily: "Inter, sans-serif" },
+    container: {
+      boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.08)",
+      borderRadius: "1rem",
+    },
+    shape: { borderRadius: 8 },
+  },
+};

--- a/web/src/components/funding/lifi-widget-inner.tsx
+++ b/web/src/components/funding/lifi-widget-inner.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSyncExternalStore } from "react";
+import type { Address } from "viem";
+import {
+  ChainType,
+  LiFiWidget,
+  useWidgetEvents,
+  WidgetEvent,
+  WidgetSkeleton,
+  type Route,
+  type RouteExecutionUpdate,
+  type WidgetConfig,
+} from "@lifi/widget";
+import { lifiConfig } from "./lifi-config";
+import { CHAIN_ID } from "@/lib/config";
+
+/**
+ * The actual LiFi widget. This module imports `@lifi/widget`'s runtime, so it
+ * MUST only ever be reached through `next/dynamic(..., { ssr: false })` (see
+ * lifi-bridge.tsx) — it never executes during static generation.
+ *
+ * app-stacks isolates the widget the same way (bridge.tsx + wrapper.tsx). We
+ * additionally gate the render behind a client-hydration check so the widget's
+ * DOM only mounts after hydration.
+ */
+
+function subscribe() {
+  return () => {};
+}
+
+/** True only after client hydration (false during SSR / first render). */
+function useHydrated() {
+  return useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
+}
+
+export default function LiFiWidgetInner({
+  address,
+  onXdaiRouted,
+}: {
+  address: Address;
+  onXdaiRouted?: (route: Route) => void;
+}) {
+  // Per LiFi docs, subscribe to widget events OUTSIDE the widget component to
+  // avoid re-render glitches.
+  const widgetEvents = useWidgetEvents();
+
+  useEffect(() => {
+    const onCompleted = (route: Route) => {
+      if (route.toAddress && route.toAddress !== address) return;
+      if (route.toToken.chainId !== CHAIN_ID) return;
+      // xDAI landed on Gnosis — hand off to the auto-mint offer.
+      onXdaiRouted?.(route);
+    };
+    const onFailed = (update: RouteExecutionUpdate) => {
+      console.warn("[lifi] route execution failed", update.action?.status);
+    };
+
+    widgetEvents.on(WidgetEvent.RouteExecutionCompleted, onCompleted);
+    widgetEvents.on(WidgetEvent.RouteExecutionFailed, onFailed);
+    return () => {
+      widgetEvents.off(WidgetEvent.RouteExecutionCompleted, onCompleted);
+      widgetEvents.off(WidgetEvent.RouteExecutionFailed, onFailed);
+    };
+  }, [widgetEvents, address, onXdaiRouted]);
+
+  const config: Partial<WidgetConfig> = {
+    ...lifiConfig,
+    toAddress: {
+      address,
+      chainType: ChainType.EVM,
+      name: "Your Safety Net wallet",
+    },
+  };
+
+  const hydrated = useHydrated();
+  if (!hydrated) return <WidgetSkeleton config={config} />;
+
+  return <LiFiWidget config={config} integrator="SafetyNet" />;
+}

--- a/web/src/components/funding/receive-panel.tsx
+++ b/web/src/components/funding/receive-panel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { Address } from "viem";
+import { AddressDisplay } from "@/components/ui/address-display";
+
+/**
+ * Receive / transfer panel: shows the connected wallet address (ENS + copy +
+ * explorer via AddressDisplay) with instructions to send xDAI or BREAD on
+ * Gnosis. Mirrors app-stacks' "receive to this address" affordance without a
+ * hosted onramp dependency.
+ */
+export function ReceivePanel({ address }: { address?: Address }) {
+  if (!address) {
+    return (
+      <p className="text-surface-grey-2 text-sm">
+        Connect a wallet to see the address to send funds to.
+      </p>
+    );
+  }
+  return (
+    <div className="border-paper-2 bg-paper-main rounded-xl border p-4">
+      <p className="text-surface-grey-2 text-sm">
+        Send <strong>xDAI</strong> or <strong>BREAD</strong> on{" "}
+        <strong>Gnosis chain</strong> to your wallet address below. Anything on
+        another chain must be bridged first (use Transfer crypto above).
+      </p>
+      <div className="border-paper-2 bg-paper-0 mt-3 flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+        <AddressDisplay address={address} chars={6} />
+      </div>
+      <p className="text-surface-grey mt-2 text-xs">
+        Once xDAI arrives you can mint BREAD from it below.
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/join/join-content.tsx
+++ b/web/src/components/join/join-content.tsx
@@ -23,6 +23,7 @@ import {
 import {
   useInviteNonceUsed,
   useSafetyNetDetails,
+  useSafetyNetName,
 } from "@/hooks/use-safety-net";
 import { useRedeemInvite } from "@/hooks/use-safety-net-writes";
 import { useTokenInfo } from "@/hooks/use-token";
@@ -61,6 +62,7 @@ function JoinInner() {
     invite?.safetyNetId,
     invite?.nonce,
   );
+  const { data: name } = useSafetyNetName(invite?.safetyNetId);
   const redeemTx = useRedeemInvite();
 
   // One-shot confetti burst on successful redeem (decorative; respects
@@ -150,8 +152,11 @@ function JoinInner() {
         {full && <Badge tone="warning">Group is full</Badge>}
       </div>
       <h3 className="font-breadDisplay text-text-standard mt-1 text-2xl font-bold">
-        Safety Net #{net.id.toString()}
+        {name || `Safety Net #${net.id.toString()}`}
       </h3>
+      {name && (
+        <Caption className="text-surface-grey">#{net.id.toString()}</Caption>
+      )}
 
       <div className="mt-4">
         <InfoRow label="Owner">
@@ -209,7 +214,7 @@ function JoinInner() {
                   href={`/net/?id=${net.id}`}
                   className="text-primary-jade text-sm font-medium underline"
                 >
-                  Open Safety Net #{net.id.toString()} →
+                  Open {name || `Safety Net #${net.id.toString()}`} →
                 </Link>
               </>
             ) : (

--- a/web/src/components/net/net-card.tsx
+++ b/web/src/components/net/net-card.tsx
@@ -37,8 +37,28 @@ export function NetStatusBadges({ details }: { details: SafetyNetDetails }) {
   );
 }
 
+/** Title block: the name (or "Safety Net #N") with "#N" kept as a subtitle. */
+function NetCardTitle({ id, name }: { id: bigint; name?: string }) {
+  return (
+    <div className="min-w-0">
+      <Heading4 className="text-text-standard truncate">
+        {name || `Safety Net #${id.toString()}`}
+      </Heading4>
+      {name && (
+        <Caption className="text-surface-grey">#{id.toString()}</Caption>
+      )}
+    </div>
+  );
+}
+
 /** Dashboard card for one Safety Net the user belongs to. */
-export function NetCard({ details }: { details: SafetyNetDetails }) {
+export function NetCard({
+  details,
+  name,
+}: {
+  details: SafetyNetDetails;
+  name?: string;
+}) {
   const net = details.safetyNet;
   const pending = net.safetyNetStart === 0n;
   const { symbol, decimals } = useTokenInfo(
@@ -49,9 +69,7 @@ export function NetCard({ details }: { details: SafetyNetDetails }) {
     return (
       <Card className="opacity-70">
         <div className="flex items-center justify-between gap-3">
-          <Heading4 className="text-text-standard">
-            Safety Net #{net.id.toString()}
-          </Heading4>
+          <NetCardTitle id={net.id} name={name} />
           <NetStatusBadges details={details} />
         </div>
         <Body className="text-surface-grey-2 mt-2">
@@ -65,9 +83,7 @@ export function NetCard({ details }: { details: SafetyNetDetails }) {
     <Link href={`/net/?id=${net.id}`} className="group block">
       <Card className="hover:border-primary-jade/50 transition-colors">
         <div className="flex items-center justify-between gap-3">
-          <Heading4 className="text-text-standard">
-            Safety Net #{net.id.toString()}
-          </Heading4>
+          <NetCardTitle id={net.id} name={name} />
           <NetStatusBadges details={details} />
         </div>
 

--- a/web/src/components/net/net-overview.tsx
+++ b/web/src/components/net/net-overview.tsx
@@ -5,6 +5,7 @@ import { AddressDisplay } from "@/components/ui/address-display";
 import { Card, InfoRow, ProgressBar, StatCard } from "@/components/ui/ui";
 import { useNow } from "@/hooks/use-now";
 import { useTokenInfo } from "@/hooks/use-token";
+import { useSafetyNetName } from "@/hooks/use-safety-net";
 import { formatAmount, formatDateTime, formatDuration } from "@/lib/format";
 import type { SafetyNetDetails } from "@/lib/types";
 
@@ -13,6 +14,7 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
   const now = useNow();
   const net = details.safetyNet;
   const { symbol, decimals } = useTokenInfo(net.token);
+  const { data: name } = useSafetyNetName(net.id);
 
   // safetyNetStart is 0 until the owner calls start() (then it's stamped
   // with the block timestamp), so a nonzero start means "running".
@@ -82,6 +84,7 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
       <Card>
         <Caption className="text-surface-grey-2">Rules</Caption>
         <div className="mt-2">
+          {name && <InfoRow label="Name">{name}</InfoRow>}
           <InfoRow label="Token">
             {symbol} <AddressDisplay address={net.token} />
           </InfoRow>

--- a/web/src/components/net/net-page-content.tsx
+++ b/web/src/components/net/net-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo } from "react";
+import { Suspense, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { zeroAddress } from "viem";
@@ -21,7 +21,7 @@ import { StartNetBanner } from "@/components/net/start-panel";
 import { DecommissionPanel } from "@/components/net/decommission-panel";
 import { DepositReminder } from "@/components/net/deposit-reminder";
 import { ActivityFeed } from "@/components/net/activity-feed";
-import { useSafetyNetDetails } from "@/hooks/use-safety-net";
+import { useSafetyNetDetails, useSafetyNetName } from "@/hooks/use-safety-net";
 import { isContractConfigured } from "@/lib/config";
 import { parseContractError } from "@/lib/parse-contract-error";
 
@@ -44,6 +44,14 @@ function NetDetail() {
   }, [rawId]);
 
   const { data: details, isLoading, error, refetch } = useSafetyNetDetails(id);
+  const { data: name } = useSafetyNetName(id);
+
+  // Static export builds a single generic <title> for /net; reflect the net's
+  // name (or id) in the document title client-side once it's known.
+  useEffect(() => {
+    if (id === undefined) return;
+    document.title = `${name || `Safety Net #${id.toString()}`} · Safety Net`;
+  }, [id, name]);
 
   if (!isContractConfigured)
     return (
@@ -93,7 +101,8 @@ function NetDetail() {
   return (
     <>
       <PageHeader
-        title={`Safety Net #${id.toString()}`}
+        title={name || `Safety Net #${id.toString()}`}
+        subtitle={name ? `Safety Net #${id.toString()}` : undefined}
         actions={<NetStatusBadges details={details} />}
       />
 

--- a/web/src/components/notification-banner.tsx
+++ b/web/src/components/notification-banner.tsx
@@ -42,7 +42,7 @@ function NotificationRow({
             href={`/net/?id=${notification.netId}`}
             className="underline underline-offset-2"
           >
-            View Safety Net #{notification.netId.toString()}
+            View {notification.netName || `Safety Net #${notification.netId.toString()}`}
           </Link>
         </span>
       </span>

--- a/web/src/hooks/use-notifications.ts
+++ b/web/src/hooks/use-notifications.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
 import type { Address } from "viem";
-import { useMemberDashboard } from "@/hooks/use-safety-net";
+import { useMemberDashboard, useSafetyNetNames } from "@/hooks/use-safety-net";
 import { requestStatus, type RequestStatus } from "@/lib/types";
 
 const STORAGE_KEY = "safetynet.dismissedNotifications";
@@ -12,6 +12,8 @@ export interface RequestNotification {
   /** Stable identity: requestId + the outcome it announces. */
   key: string;
   netId: bigint;
+  /** Human-readable net name, when set (else undefined → fall back to #id). */
+  netName?: string;
   requestId: bigint;
   status: Exclude<RequestStatus, "contestable">;
   amount: bigint;
@@ -37,6 +39,11 @@ function loadDismissed(): Set<string> {
 export function useRequestNotifications() {
   const { address } = useAccount();
   const { data: dashboard } = useMemberDashboard();
+  const ids = useMemo(
+    () => (dashboard ?? []).map((d) => d.safetyNet.id),
+    [dashboard],
+  );
+  const names = useSafetyNetNames(ids);
   const [dismissed, setDismissed] = useState<Set<string> | null>(null);
 
   // Read localStorage after mount (static export → no window at build time).
@@ -58,6 +65,7 @@ export function useRequestNotifications() {
         out.push({
           key,
           netId: details.safetyNet.id,
+          netName: names.get(details.safetyNet.id),
           requestId: view.id,
           status,
           amount: view.request.amount,
@@ -66,7 +74,7 @@ export function useRequestNotifications() {
       }
     }
     return out;
-  }, [address, dashboard, dismissed]);
+  }, [address, dashboard, dismissed, names]);
 
   const dismiss = useCallback((key: string) => {
     setDismissed((prev) => {

--- a/web/src/hooks/use-safety-net-writes.ts
+++ b/web/src/hooks/use-safety-net-writes.ts
@@ -11,20 +11,23 @@ import { useTx } from "@/hooks/use-tx";
  * render inline lifecycle feedback.
  */
 
-type CreateInput = ContractFunctionArgs<
+// create(string _name, SafetyNet _safetyNet) — name is the first arg.
+type CreateArgs = ContractFunctionArgs<
   typeof safetyNetAbi,
   "nonpayable",
   "create"
->[0];
+>;
+type CreateName = CreateArgs[0];
+type CreateInput = CreateArgs[1];
 
 export function useCreateSafetyNet() {
   const tx = useTx();
-  const create = (safetyNet: CreateInput) =>
+  const create = (name: CreateName, safetyNet: CreateInput) =>
     tx.run({
       address: SAFETYNET_ADDRESS,
       abi: safetyNetAbi,
       functionName: "create",
-      args: [safetyNet],
+      args: [name, safetyNet],
     });
   return { create, ...tx };
 }

--- a/web/src/hooks/use-safety-net.ts
+++ b/web/src/hooks/use-safety-net.ts
@@ -151,6 +151,41 @@ export function useMemberDepositInfo(
   };
 }
 
+/**
+ * The human-readable name of one Safety Net (safetyNetNames mapping). Names
+ * are a separate mapping — not part of getSafetyNetDetails/getMemberDashboard —
+ * so this is an extra read. May be "" when the owner left it blank.
+ */
+export function useSafetyNetName(id: bigint | undefined) {
+  return useReadContract({
+    ...safetyNetContract,
+    functionName: "safetyNetNames",
+    args: [id ?? 0n],
+    query: { enabled: isContractConfigured && id !== undefined },
+  });
+}
+
+/** Names for many Safety Nets at once (dashboard cards) — batched multicall. */
+export function useSafetyNetNames(ids: readonly bigint[]) {
+  const { data } = useReadContracts({
+    contracts: ids.map((id) => ({
+      ...safetyNetContract,
+      functionName: "safetyNetNames" as const,
+      args: [id] as const,
+    })),
+    query: { enabled: isContractConfigured && ids.length > 0 },
+  });
+
+  return useMemo(() => {
+    const map = new Map<bigint, string>();
+    ids.forEach((id, i) => {
+      const name = data?.[i]?.result;
+      if (typeof name === "string" && name.length > 0) map.set(id, name);
+    });
+    return map;
+  }, [data, ids]);
+}
+
 /** Whether the protocol allows the given ERC20 for Safety Nets. */
 export function useIsTokenAllowed(token: Address | undefined) {
   return useReadContract({

--- a/web/src/hooks/use-watch-funded-xdai.ts
+++ b/web/src/hooks/use-watch-funded-xdai.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Address } from "viem";
+import { usePublicClient } from "wagmi";
+import { CHAIN_ID } from "@/lib/config";
+
+/**
+ * Watch a wallet's native xDAI balance and fire `onFunded(delta)` once each
+ * time it goes UP (funds arriving from a LiFi route, an onramp, or a plain
+ * transfer). Ports app-stacks `use-watch-funded-xdai.ts`, but instead of
+ * auto-sponsoring a BREAD mint (this app has no sponsored-tx path) it just
+ * surfaces the delta so the caller can OFFER minting via the normal wagmi/Privy
+ * `mintBread` flow.
+ *
+ * Safety:
+ *  - only fires on a strict increase, and only once per increase (the ref
+ *    advances to the new balance immediately);
+ *  - `enabled=false` (or no address) tears the block watcher down, so it never
+ *    runs unless the funding hub explicitly turns it on.
+ */
+export function useWatchFundedXdai(
+  address: Address | undefined,
+  onFunded: (delta: bigint, newBalance: bigint) => void,
+  enabled: boolean,
+) {
+  const publicClient = usePublicClient({ chainId: CHAIN_ID });
+  const prevBalance = useRef<bigint | undefined>(undefined);
+  // Keep the latest callback without re-subscribing the watcher every render.
+  const onFundedRef = useRef(onFunded);
+  onFundedRef.current = onFunded;
+
+  useEffect(() => {
+    if (!enabled || !address || !publicClient) {
+      prevBalance.current = undefined;
+      return;
+    }
+
+    let cancelled = false;
+    publicClient.getBalance({ address }).then((bal) => {
+      if (!cancelled && prevBalance.current === undefined) {
+        prevBalance.current = bal;
+      }
+    });
+
+    const unwatch = publicClient.watchBlocks({
+      onBlock: async () => {
+        const balance = await publicClient.getBalance({ address });
+        const prev = prevBalance.current;
+        if (prev === undefined) {
+          prevBalance.current = balance;
+          return;
+        }
+        if (balance > prev) {
+          const delta = balance - prev;
+          prevBalance.current = balance; // advance first → fire once per delta
+          onFundedRef.current(delta, balance);
+        } else if (balance < prev) {
+          prevBalance.current = balance;
+        }
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      unwatch();
+    };
+  }, [address, publicClient, enabled]);
+}

--- a/web/src/lib/abi/safety-net.ts
+++ b/web/src/lib/abi/safety-net.ts
@@ -34,6 +34,19 @@ export const safetyNetAbi = [
   },
   {
     "type": "function",
+    "name": "MAX_NAME_BYTES",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "MAX_PREPAY_EPOCHS",
     "inputs": [],
     "outputs": [
@@ -138,6 +151,11 @@ export const safetyNetAbi = [
     "type": "function",
     "name": "create",
     "inputs": [
+      {
+        "name": "_name",
+        "type": "string",
+        "internalType": "string"
+      },
       {
         "name": "_safetyNet",
         "type": "tuple",
@@ -1683,6 +1701,25 @@ export const safetyNetAbi = [
   },
   {
     "type": "function",
+    "name": "safetyNetNames",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "safetyNets",
     "inputs": [
       {
@@ -2164,6 +2201,12 @@ export const safetyNetAbi = [
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       }
     ],
     "anonymous": false
@@ -2524,6 +2567,11 @@ export const safetyNetAbi = [
   {
     "type": "error",
     "name": "InviteAlreadyUsed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NameTooLong",
     "inputs": []
   },
   {

--- a/web/src/lib/contract-errors.ts
+++ b/web/src/lib/contract-errors.ts
@@ -58,6 +58,8 @@ export const SAFETY_NET_ERRORS: Record<string, string> = {
   InvalidSigner: "This invite wasn't signed by the Safety Net owner.",
   AlreadyMember: "You are already a member of this Safety Net.",
   SafetyNetFull: "This Safety Net has reached its maximum number of members.",
+  NameTooLong:
+    "That Safety Net name is too long — please shorten it (max 128 bytes on-chain).",
   ReasonTooLong:
     "Your reason is too long — please shorten it (max 2000 bytes on-chain).",
   RequestNonceAlreadyUsed: "This signed request has already been submitted.",


### PR DESCRIPTION
Two features requested on top of the earlier funding/reminders/onboarding work.

## Named Safety Nets (contract → subgraph → UI)
- **Contract**: `create(string name, SafetyNet)` — name is now the first arg; new `safetyNetNames(id)` getter (appended `mapping` at slot 19, layout-safe); `MAX_NAME_BYTES=128` + `NameTooLong`; name added to the `SafetyNetCreated` event. 168 tests, lint clean, upgrades-core validate exit 0. **Upgraded in place on the live proxy** (impl v4 [`0xa1A4…8408`](https://gnosis.blockscout.com/address/0xa1A489D6070d191079E30D912bfA76174A658408), verified) and live-tested (net #2 "Carla's Art Collective" reads back onchain).
- **Frontend**: "Safety Net name" as the first create-form field (optional, ≤128 bytes) shown in the live Overview; name displays across dashboard cards, net page header + `<title>`, overview, join page, success box, and notifications, with `#N` kept as a secondary subtitle. Batched name reads for dashboards.
- **Subgraph**: `name` on the SafetyNet entity + handler + tests (6 green); redeployed to Studio v0.0.2; the app's `NEXT_PUBLIC_SUBGRAPH_URL` now points at v0.0.2.

## Full wallet funding hub (replaces the basic Get-BREAD modal)
Tabbed "Add funds" hub (same `GetBreadModal` entry points), rails:
- **Transfer crypto** — embedded **LiFi v4 widget** (bridge/swap any chain→Gnosis), static-export-safe via `next/dynamic ssr:false`, jade-themed, with a jumper.exchange link-out fallback + error boundary.
- **Post-route auto-mint** — watches xDAI balance; when funds land it offers "mint into BREAD" via the existing 1:1 `mint(receiver)`.
- **Buy with card** — Privy fiat onramp (Privy mode).
- **Receive** — wallet address with ENS + copy/explorer.
- **Mint BREAD** — direct xDAI→BREAD with gas-reserve-on-MAX.

Lint clean; standard, base-path, and Privy-enabled static-export builds all pass. `@lifi/sdk` + `@lifi/widget` added.