### PR TITLE
feat: complete funding-rail parity (connected wallet + zkp2p peer)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -45,9 +45,53 @@ absent vars fall back to working defaults with a console warning. See
 | `NEXT_PUBLIC_VERIFY_PRIVATE_KEY`       | _(empty)_                                   | Dev-wallet key — **ignored outside development builds**, see below.        |
 | `NEXT_PUBLIC_PRIVY_APP_ID`             | _(empty)_                                   | Enables Privy embedded wallets when set — see below. Absent ⇒ RainbowKit.  |
 | `NEXT_PUBLIC_PRIVY_CLIENT_ID`          | _(empty)_                                   | Optional Privy client id (passed alongside the app id).                    |
+| `NEXT_PUBLIC_ZKP2P_ENABLED`            | _(empty)_                                   | `"true"` shows the **Peer onramp** (ZKP2P) funding rail — see below.       |
 
 Known tokens: WXDAI `0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d` (default),
 BREAD `0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3` — see `src/lib/config.ts`.
+
+## Add-funds hub (funding rails)
+
+The **Add funds** modal (`src/components/funding/`) offers several ways to fund a
+wallet and mint BREAD. Balances refresh live and, after xDAI arrives on any rail,
+the hub offers a one-tap BREAD mint (`use-watch-funded-xdai`).
+
+- **Transfer crypto** — LiFi bridge/swap from any chain into xDAI on Gnosis.
+- **From my wallet** _(Privy only)_ — fund the embedded (Privy) wallet from a
+  separately-linked **injected** browser wallet (MetaMask / Rabby / …). Reads the
+  external wallet's xDAI balance and offers "Send xDAI" (plain transfer) or "Mint
+  BREAD" (`mint(embeddedAddress){ value }`) straight to the app wallet, signed by
+  the external wallet over `window.ethereum`. Hidden when Privy is disabled (the
+  connected wallet is then the active account, so this would be a self-transfer —
+  the Receive + Mint rails cover it).
+- **Buy with card** _(Privy only)_ — Privy fiat onramp for xDAI.
+- **Peer onramp** _(gated)_ — see below.
+- **Receive** — show the wallet address to receive xDAI/BREAD on Gnosis.
+- **Mint BREAD** — convert existing xDAI to BREAD 1:1.
+
+### Peer onramp (ZKP2P) — opt-in
+
+Hidden by default. Set **`NEXT_PUBLIC_ZKP2P_ENABLED=true`** to show the **Peer
+onramp** rail. It uses [`@zkp2p/sdk`](https://www.npmjs.com/package/@zkp2p/sdk),
+isolated in a `next/dynamic({ ssr: false })` client component
+(`peer-onramp-inner.tsx`) so it never loads during `output: "export"` static
+generation.
+
+Requirements / caveats:
+
+- **No API key or relayer is needed for the rail as shipped** — the published SDK
+  (0.7.2) is a bridge to the **ZKP2P browser extension**. The rail detects the
+  extension (`isAvailable`/`getState`), lets the user connect to it
+  (`requestConnection`), and links to the install page (`openInstallPage`) if it's
+  missing. The end user must have the ZKP2P extension installed.
+- The full in-page fiat→xDAI `onramp()` + `onIntentFulfilled()` flow that
+  app-stacks sketched is **not present** in the published SDK version (it is WIP
+  and commented out upstream), so the rail hands off to the extension for the
+  actual purchase rather than driving it in-app. Once xDAI lands in the wallet the
+  hub's post-arrival watcher offers the BREAD mint like the other rails.
+- If a future SDK version exposes the in-page onramp API (and any relayer/config
+  it needs), extend `peer-onramp-inner.tsx`; the gate and static-export isolation
+  already in place mean no other wiring changes.
 
 ## Privy embedded wallets (optional)
 

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "@rainbow-me/rainbowkit": "^2.2.8",
     "@tanstack/react-query": "^5.85.6",
     "@wagmi/core": "2.x.x",
+    "@zkp2p/sdk": "0.7.2",
     "blo": "^1.1.1",
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   '@wagmi/core':
     specifier: 2.x.x
     version: 2.22.1(@types/react@19.2.17)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0)(viem@2.54.1)
+  '@zkp2p/sdk':
+    specifier: 0.7.2
+    version: 0.7.2(react@19.1.0)(typescript@5.9.3)(viem@2.54.1)(zod@4.4.3)
   blo:
     specifier: ^1.1.1
     version: 1.2.0
@@ -1725,6 +1728,12 @@ packages:
     engines: {node: ^14.21.3 || >=16}
     dev: false
 
+  /@noble/curves@1.2.0:
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
+
   /@noble/curves@1.4.2:
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
     dependencies:
@@ -1764,6 +1773,11 @@ packages:
     engines: {node: ^14.21.3 || >=16}
     dependencies:
       '@noble/hashes': 1.8.0
+    dev: false
+
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
     dev: false
 
   /@noble/hashes@1.4.0:
@@ -1815,6 +1829,125 @@ packages:
   /@paulmillr/qr@0.2.1:
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+    dev: false
+
+  /@peculiar/asn1-cms@2.8.0:
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-csr@2.8.0:
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-ecc@2.8.0:
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pfx@2.8.0:
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pkcs8@2.8.0:
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-pkcs9@2.8.0:
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-rsa@2.8.0:
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-schema@2.8.0:
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-x509-attr@2.8.0:
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/asn1-x509@2.8.0:
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/utils@2.0.3:
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@peculiar/x509@1.14.3:
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
     dev: false
 
   /@phosphor-icons/react@2.1.10(react-dom@19.1.0)(react@19.1.0):
@@ -4370,6 +4503,12 @@ packages:
       undici-types: 6.21.0
     dev: true
 
+  /@types/node@22.7.5:
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+    dependencies:
+      undici-types: 6.19.8
+    dev: false
+
   /@types/parse-json@4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
     dev: false
@@ -6389,6 +6528,59 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@zkp2p/contracts-v2@0.2.4(ethers@6.17.0)(typescript@5.9.3)(zod@4.4.3):
+    resolution: {integrity: sha512-2MIPKWdKYCcgA/BjoasJh0VdTvP25UYyDi0TyTMx/8Z+6Qc/wzWnJTRMOzUP07P069XoQ2sTCcgS246Rb9AiHw==}
+    peerDependencies:
+      ethers: ^5.0.0 || ^6.0.0
+    dependencies:
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      ethers: 6.17.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+    dev: false
+
+  /@zkp2p/indexer-schema@0.5.0:
+    resolution: {integrity: sha512-L2ShEBv7HjghRElZSYtGcBNdnRVchVW7c/wnN3S5VLZQA4V2IUmVv8BPZzYYiQ53y+7F/qPKtUQOW+p9ZbZEiQ==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /@zkp2p/sdk@0.7.2(react@19.1.0)(typescript@5.9.3)(viem@2.54.1)(zod@4.4.3):
+    resolution: {integrity: sha512-ZtRMfnI4LOUHZ+pYGjTi6rxQsch1kDFeTLIeRd7ytARWW1GT3+7qeXmT7FSxvq8sJCyrNkY6xmnLirtsC6De5Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: '>=16.8.0'
+      viem: ^2.37.3
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@zkp2p/contracts-v2': 0.2.4(ethers@6.17.0)(typescript@5.9.3)(zod@4.4.3)
+      '@zkp2p/indexer-schema': 0.5.0
+      '@zkp2p/zkp2p-attestation': 1.6.3
+      ethers: 6.17.0
+      ox: 0.11.3(typescript@5.9.3)(zod@4.4.3)
+      react: 19.1.0
+      viem: 2.54.1(typescript@5.9.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@zkp2p/zkp2p-attestation@1.6.3:
+    resolution: {integrity: sha512-gGBNrbULr/livdR7wkyDto+zRVsAxIBUx6YBT+VEFW5stgZBwxv6sEuQ4AguBnmSe9WKFrWZWYC3fLgdFcPT6g==}
+    engines: {node: '>=20'}
+    hasBin: true
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      ethers: 6.17.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
@@ -6530,6 +6722,10 @@ packages:
     hasBin: true
     dev: true
 
+  /aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+    dev: false
+
   /ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
     dependencies:
@@ -6664,6 +6860,15 @@ packages:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
     dev: true
+
+  /asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+    dev: false
 
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -7792,6 +7997,22 @@ packages:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+    dev: false
+
+  /ethers@6.17.0:
+    resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /event-target-shim@5.0.1:
@@ -9178,6 +9399,27 @@ packages:
       safe-push-apply: 1.0.0
     dev: true
 
+  /ox@0.11.3(typescript@5.9.3)(zod@4.4.3):
+    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    dev: false
+
   /ox@0.14.27(typescript@5.9.3)(zod@4.4.3):
     resolution: {integrity: sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==}
     peerDependencies:
@@ -9271,11 +9513,11 @@ packages:
         optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9291,11 +9533,11 @@ packages:
         optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.4.3)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9356,7 +9598,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.4.3)
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9783,6 +10025,17 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+    dev: false
+
   /qr@0.6.0:
     resolution: {integrity: sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA==}
     engines: {node: '>= 20.19.0'}
@@ -10053,6 +10306,10 @@ packages:
   /real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+    dev: false
+
+  /reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
     dev: false
 
   /reflect.getprototypeof@1.0.10:
@@ -10693,8 +10950,19 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: false
 
+  /tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+    dev: false
+
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  /tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      tslib: 1.14.1
+    dev: false
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -10798,6 +11066,10 @@ packages:
 
   /uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+    dev: false
+
+  /undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
     dev: false
 
   /undici-types@6.21.0:

--- a/web/src/components/funding/fund-hub.tsx
+++ b/web/src/components/funding/fund-hub.tsx
@@ -12,8 +12,17 @@ import { GAS_RESERVE_XDAI, useBreadFunding } from "@/hooks/use-bread-funding";
 import { useWatchFundedXdai } from "@/hooks/use-watch-funded-xdai";
 import { LiFiBridge } from "./lifi-bridge";
 import { ReceivePanel } from "./receive-panel";
+import { FundWithWallet } from "./fund-with-wallet";
+import { PeerOnramp } from "./peer-onramp";
 
-type RailId = "bridge" | "onramp" | "receive" | "mint";
+/**
+ * RAIL 2 (peer/zkp2p) is gated behind this build-time flag: hidden by default
+ * so `@zkp2p/sdk` never loads or errors unless an operator opts in. Config
+ * requirements are documented in web/README.md.
+ */
+const PEER_ONRAMP_ENABLED = process.env.NEXT_PUBLIC_ZKP2P_ENABLED === "true";
+
+type RailId = "bridge" | "wallet" | "onramp" | "peer" | "receive" | "mint";
 
 interface Rail {
   id: RailId;
@@ -47,12 +56,34 @@ export function FundHub({ onClose }: { onClose: () => void }) {
           "Bridge or swap tokens from Ethereum, Arbitrum, Base and more into xDAI on Gnosis. Best if you already hold crypto elsewhere.",
       },
     ];
+    // RAIL 1 — fund the embedded wallet from a linked external injected wallet.
+    // Meaningless outside Privy (the connected wallet IS the active account), so
+    // gate on PRIVY_ENABLED — the Receive + Mint rails cover that case.
+    if (PRIVY_ENABLED) {
+      base.push({
+        id: "wallet",
+        label: "From my wallet",
+        heading: "Fund from a connected wallet",
+        blurb:
+          "Move xDAI (or mint BREAD directly) from a browser wallet like MetaMask or Rabby into your app wallet. Best if you already hold xDAI on Gnosis elsewhere.",
+      });
+    }
     if (showOnramp) {
       base.push({
         id: "onramp",
         label: "Buy with card",
         heading: "Buy xDAI with card",
         blurb: "Top up your wallet with a card or bank transfer via Privy. Best if you're starting from fiat.",
+      });
+    }
+    // RAIL 2 — peer (zkp2p) fiat onramp; hidden unless explicitly enabled.
+    if (PEER_ONRAMP_ENABLED) {
+      base.push({
+        id: "peer",
+        label: "Peer onramp",
+        heading: "Buy xDAI peer-to-peer",
+        blurb:
+          "Buy xDAI from a peer via ZKP2P — no KYC, straight to your wallet on Gnosis. Requires the ZKP2P browser extension.",
       });
     }
     base.push(
@@ -71,6 +102,8 @@ export function FundHub({ onClose }: { onClose: () => void }) {
     );
     return base;
   }, [showOnramp]);
+  // PRIVY_ENABLED and PEER_ONRAMP_ENABLED are build-time constants, so the rail
+  // set is stable per build — no need to list them as deps.
 
   const [rail, setRail] = useState<RailId>("bridge");
   const active = rails.find((r) => r.id === rail) ?? rails[0];
@@ -95,7 +128,12 @@ export function FundHub({ onClose }: { onClose: () => void }) {
   // offer to mint it into BREAD (one prompt per arrival). Users on the "mint"
   // rail are already minting manually, so we don't watch there.
   const [pendingMint, setPendingMint] = useState<bigint | null>(null);
-  const watchEnabled = rail === "bridge" || rail === "receive" || rail === "onramp";
+  const watchEnabled =
+    rail === "bridge" ||
+    rail === "receive" ||
+    rail === "onramp" ||
+    rail === "wallet" ||
+    rail === "peer";
 
   const onFunded = useCallback((delta: bigint) => {
     setPendingMint((cur) => (cur ?? 0n) + delta);
@@ -195,6 +233,17 @@ export function FundHub({ onClose }: { onClose: () => void }) {
         <div className="mt-3">
           {rail === "bridge" && (
             <LiFiBridge address={address as Address | undefined} onXdaiRouted={() => refetchXdaiBalance()} />
+          )}
+
+          {rail === "wallet" && PRIVY_ENABLED && (
+            <FundWithWallet
+              embeddedAddress={address as Address | undefined}
+              onFunded={() => refetchXdaiBalance()}
+            />
+          )}
+
+          {rail === "peer" && PEER_ONRAMP_ENABLED && (
+            <PeerOnramp address={address as Address | undefined} />
           )}
 
           {rail === "onramp" && showOnramp && (

--- a/web/src/components/funding/fund-with-wallet.tsx
+++ b/web/src/components/funding/fund-with-wallet.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createWalletClient,
+  custom,
+  encodeFunctionData,
+  formatUnits,
+  type Address,
+  type WalletClient,
+} from "viem";
+import { usePrivy, type WalletWithMetadata } from "@privy-io/react-auth";
+import { usePublicClient } from "wagmi";
+import { Body, Button } from "@breadcoop/ui";
+import { AmountField } from "@/components/ui/amount-field";
+import { AddressDisplay } from "@/components/ui/address-display";
+import { BREAD_ADDRESS, CHAIN, CHAIN_ID } from "@/lib/config";
+import { breadAbi } from "@/lib/abi/bread";
+import { formatAmount, parseAmount } from "@/lib/format";
+import { GAS_RESERVE_XDAI } from "@/hooks/use-bread-funding";
+
+type Phase = "idle" | "signing" | "confirming" | "success" | "error";
+
+/**
+ * RAIL 1 — Fund the embedded (Privy) wallet from a separately-connected
+ * INJECTED external wallet (MetaMask / Rabby / …).
+ *
+ * Ports app-stacks `fund-with-connected-wallet{,-modal-amount}.tsx`: when the
+ * active account is a Privy EMBEDDED wallet, the user funds it from an injected
+ * browser wallet they've linked. Two actions on the external wallet:
+ *   (a) "Send xDAI" — plain native transfer to the embedded address, or
+ *   (b) "Mint BREAD" — call BREAD `mint(embeddedAddress){ value }` so BREAD
+ *       lands straight in the embedded wallet.
+ *
+ * This component uses Privy hooks unconditionally, so it must ONLY be rendered
+ * when `PRIVY_ENABLED` (fund-hub gates it). In non-Privy mode the connected
+ * wallet *is* the active account, so "fund from connected wallet" would be a
+ * self-transfer — the Receive + Mint rails already cover that, and this rail is
+ * hidden.
+ *
+ * Sends go through a viem walletClient over `window.ethereum`
+ * (sendTransaction / writeContract with value) rather than the app's shared
+ * `useTx` (which is bound to the embedded/sponsored signer, not the external
+ * wallet). Balances refresh via the caller's `onFunded` after xDAI lands.
+ */
+export function FundWithWallet({
+  embeddedAddress,
+  onFunded,
+}: {
+  /** The current active account — the embedded wallet being funded. */
+  embeddedAddress?: Address;
+  /** Called after a successful send so the hub can refresh balances. */
+  onFunded: () => void;
+}) {
+  const { user, linkWallet, ready } = usePrivy();
+  const publicClient = usePublicClient({ chainId: CHAIN_ID });
+
+  // The user's injected external wallet as tracked by Privy linked accounts
+  // (app-stacks pattern: type === "wallet" && connectorType === "injected").
+  const injected = useMemo(
+    () =>
+      user?.linkedAccounts.find(
+        (a): a is WalletWithMetadata =>
+          a.type === "wallet" && a.connectorType === "injected",
+      ),
+    [user?.linkedAccounts],
+  );
+  const externalAddress = injected?.address as Address | undefined;
+  const walletLabel = injected?.walletClientType ?? "wallet";
+
+  const [externalBalance, setExternalBalance] = useState<bigint | undefined>();
+  const [amount, setAmount] = useState("");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [hash, setHash] = useState<`0x${string}` | undefined>();
+
+  // Read the external wallet's native xDAI balance on Gnosis.
+  const refreshExternalBalance = useCallback(async () => {
+    if (!externalAddress || !publicClient) return;
+    try {
+      const bal = await publicClient.getBalance({ address: externalAddress });
+      setExternalBalance(bal);
+    } catch {
+      // Non-fatal — leave the balance unknown.
+    }
+  }, [externalAddress, publicClient]);
+
+  useEffect(() => {
+    void refreshExternalBalance();
+  }, [refreshExternalBalance]);
+
+  const spendable = useMemo(() => {
+    if (externalBalance === undefined) return undefined;
+    return externalBalance > GAS_RESERVE_XDAI
+      ? externalBalance - GAS_RESERVE_XDAI
+      : 0n;
+  }, [externalBalance]);
+
+  const parsed = useMemo(() => parseAmount(amount, 18), [amount]);
+  const insufficient =
+    parsed !== null && parsed > 0n && spendable !== undefined && parsed > spendable;
+  const invalidAmount = parsed === null || parsed === 0n || insufficient;
+  const busy = phase === "signing" || phase === "confirming";
+
+  // Build a viem walletClient over the injected provider, pinned to Gnosis.
+  const getWalletClient = useCallback(async (): Promise<{
+    client: WalletClient;
+    account: Address;
+  }> => {
+    const ethereum = (globalThis as { ethereum?: unknown }).ethereum;
+    if (!ethereum) throw new Error("No injected wallet detected in this browser.");
+    const client = createWalletClient({
+      chain: CHAIN,
+      transport: custom(ethereum as Parameters<typeof custom>[0]),
+    });
+    const [account] = await client.requestAddresses();
+    if (!account) throw new Error("No account authorized in the external wallet.");
+    const currentChain = await client.getChainId();
+    if (currentChain !== CHAIN_ID) {
+      await client.switchChain({ id: CHAIN_ID });
+    }
+    return { client, account };
+  }, []);
+
+  const runSend = useCallback(
+    async (kind: "send" | "mint") => {
+      if (!embeddedAddress || invalidAmount || parsed === null) return;
+      setError(null);
+      setHash(undefined);
+      setPhase("signing");
+      try {
+        const { client, account } = await getWalletClient();
+        let txHash: `0x${string}`;
+        if (kind === "send") {
+          txHash = await client.sendTransaction({
+            account,
+            chain: CHAIN,
+            to: embeddedAddress,
+            value: parsed,
+          });
+        } else {
+          txHash = await client.sendTransaction({
+            account,
+            chain: CHAIN,
+            to: BREAD_ADDRESS,
+            value: parsed,
+            data: encodeFunctionData({
+              abi: breadAbi,
+              functionName: "mint",
+              args: [embeddedAddress],
+            }),
+          });
+        }
+        setHash(txHash);
+        setPhase("confirming");
+        if (publicClient) {
+          await publicClient.waitForTransactionReceipt({ hash: txHash });
+        }
+        setPhase("success");
+        setAmount("");
+        void refreshExternalBalance();
+        onFunded();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Transaction failed");
+        setPhase("error");
+      }
+    },
+    [
+      embeddedAddress,
+      invalidAmount,
+      parsed,
+      getWalletClient,
+      publicClient,
+      refreshExternalBalance,
+      onFunded,
+    ],
+  );
+
+  if (!ready) {
+    return <p className="text-surface-grey-2 text-sm">Loading wallet…</p>;
+  }
+
+  // No injected wallet linked yet — prompt to connect one.
+  if (!externalAddress) {
+    return (
+      <div className="border-paper-2 bg-paper-main rounded-xl border p-4">
+        <Body className="text-surface-grey-2 text-sm">
+          Connect a browser wallet (MetaMask, Rabby, …) that already holds xDAI
+          on Gnosis, then move funds into your app wallet in one click.
+        </Body>
+        <Button
+          app="net"
+          variant="secondary"
+          className="mt-3 w-full"
+          onClick={() => linkWallet()}
+        >
+          Connect a wallet
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="border-paper-2 bg-paper-main rounded-xl border p-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-surface-grey-2 text-xs font-medium capitalize">
+            {walletLabel} (external)
+          </span>
+          <AddressDisplay address={externalAddress} chars={4} />
+        </div>
+        <p className="text-surface-grey mt-1 text-xs">
+          Balance:{" "}
+          {externalBalance !== undefined
+            ? `${formatAmount(externalBalance, 18)} xDAI`
+            : "…"}
+        </p>
+      </div>
+
+      <AmountField
+        label="Amount to move"
+        value={amount}
+        onChange={setAmount}
+        balance={spendable}
+        balanceLabel="Spendable"
+        symbol="xDAI"
+        decimals={18}
+        error={insufficient}
+        help={`Sent from your external wallet to your app wallet. A little xDAI is kept back for gas when you use MAX (${formatUnits(GAS_RESERVE_XDAI, 18)} xDAI).`}
+      />
+
+      {insufficient && (
+        <p className="text-system-red text-xs font-medium">
+          That&apos;s more xDAI than the external wallet has spendable
+          {spendable !== undefined
+            ? ` (${formatAmount(spendable, 18)} xDAI, keeping ${formatUnits(GAS_RESERVE_XDAI, 18)} for gas)`
+            : ""}
+          .
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          app="net"
+          variant="secondary"
+          className="flex-1"
+          isLoading={busy}
+          onClick={() => runSend("send")}
+          {...(invalidAmount ? { disabled: true } : {})}
+        >
+          Send xDAI
+        </Button>
+        <Button
+          app="net"
+          variant="primary"
+          className="flex-1"
+          isLoading={busy}
+          onClick={() => runSend("mint")}
+          {...(invalidAmount ? { disabled: true } : {})}
+        >
+          Mint BREAD
+        </Button>
+      </div>
+
+      <div role="status" aria-live="polite">
+        {phase === "error" && (
+          <p className="text-system-red text-sm font-medium">
+            {error ?? "Transaction failed"}
+          </p>
+        )}
+        {phase === "success" && (
+          <p className="text-system-green text-sm font-medium">
+            Sent from your external wallet.
+          </p>
+        )}
+        {busy && (
+          <p className="text-surface-grey-2 text-sm font-medium">
+            {phase === "signing"
+              ? "Confirm in your external wallet…"
+              : "Waiting for confirmation…"}
+          </p>
+        )}
+        {hash && phase !== "signing" && (
+          <p className="text-surface-grey mt-1 text-xs">Tx submitted.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/funding/peer-onramp-inner.tsx
+++ b/web/src/components/funding/peer-onramp-inner.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Address } from "viem";
+import { Body, Button } from "@breadcoop/ui";
+import { ArrowSquareOut } from "@phosphor-icons/react";
+
+/**
+ * RAIL 2 — Peer onramp (zkp2p), SDK runtime.
+ *
+ * CRITICAL: this module statically imports `@zkp2p/sdk` (which pulls ethers/ox
+ * and a browser-extension bridge), so it MUST only ever be loaded via
+ * `next/dynamic(..., { ssr: false })` from `peer-onramp.tsx` — never during
+ * `output: "export"` static generation, and never on the general path.
+ *
+ * The published SDK (0.7.2) is a bridge to the ZKP2P *browser extension*: it
+ * exposes availability/connection/install primitives (`isAvailable`,
+ * `getState`, `requestConnection`, `openInstallPage`). The end-to-end
+ * fiat→xDAI `onramp()` + `onIntentFulfilled()` flow app-stacks sketched is not
+ * present in this published version (it is WIP and commented out upstream), so
+ * we implement the real, available path: detect the extension, connect to it,
+ * and hand off — guiding the user to install it if missing. Once xDAI lands in
+ * the wallet, the hub's post-arrival watcher offers the BREAD mint (same as the
+ * bridge/receive rails).
+ */
+export default function PeerOnrampInner({
+  address,
+}: {
+  address?: Address;
+}) {
+  const sdkRef = useRef<ReturnType<
+    typeof import("@zkp2p/sdk").createPeerExtensionSdk
+  > | null>(null);
+  const [state, setState] = useState<
+    "loading" | "available" | "needs_install" | "connecting" | "connected" | "error"
+  >("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { createPeerExtensionSdk } = await import("@zkp2p/sdk");
+        if (cancelled) return;
+        const sdk = createPeerExtensionSdk({ window });
+        sdkRef.current = sdk;
+        const available = await sdk.isAvailable();
+        if (cancelled) return;
+        setState(available ? "available" : "needs_install");
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load peer onramp.");
+        setState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const connect = async () => {
+    const sdk = sdkRef.current;
+    if (!sdk) return;
+    setError(null);
+    setState("connecting");
+    try {
+      const approved = await sdk.requestConnection();
+      setState(approved ? "connected" : "available");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Connection failed.");
+      setState("error");
+    }
+  };
+
+  const install = () => {
+    sdkRef.current?.openInstallPage();
+  };
+
+  return (
+    <div className="border-paper-2 bg-paper-main rounded-xl border p-4">
+      <Body className="text-surface-grey-2 text-sm">
+        Buy xDAI peer-to-peer via ZKP2P — no KYC, funds land in{" "}
+        {address ? "your app wallet" : "your wallet"} on Gnosis. Requires the
+        ZKP2P browser extension. Once xDAI arrives you can mint BREAD from it.
+      </Body>
+
+      {state === "loading" && (
+        <p className="text-surface-grey mt-3 text-sm">Checking for extension…</p>
+      )}
+
+      {state === "needs_install" && (
+        <Button
+          app="net"
+          variant="secondary"
+          className="mt-3 w-full"
+          onClick={install}
+        >
+          <span className="inline-flex items-center gap-2">
+            Install ZKP2P extension <ArrowSquareOut size={16} />
+          </span>
+        </Button>
+      )}
+
+      {(state === "available" || state === "connecting") && (
+        <Button
+          app="net"
+          variant="primary"
+          className="mt-3 w-full"
+          isLoading={state === "connecting"}
+          onClick={connect}
+        >
+          Connect ZKP2P
+        </Button>
+      )}
+
+      {state === "connected" && (
+        <p className="text-system-green mt-3 text-sm font-medium">
+          ZKP2P connected. Continue in the extension to buy xDAI to{" "}
+          {address ? "your wallet address" : "your wallet"}.
+        </p>
+      )}
+
+      {state === "error" && (
+        <p className="text-system-red mt-3 text-sm font-medium">
+          {error ?? "Peer onramp unavailable."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/funding/peer-onramp.tsx
+++ b/web/src/components/funding/peer-onramp.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Address } from "viem";
+
+/**
+ * RAIL 2 — Peer onramp (zkp2p) entry point, static-export-safe.
+ *
+ * The SDK runtime lives in `./peer-onramp-inner` and is loaded ONLY via
+ * `next/dynamic(..., { ssr: false })`, so `@zkp2p/sdk` (ethers/ox + browser
+ * extension bridge) is never imported during `output: "export"` static
+ * generation.
+ *
+ * The rail is GATED behind `NEXT_PUBLIC_ZKP2P_ENABLED` (see `PEER_ONRAMP_ENABLED`
+ * in fund-hub.tsx): hidden by default so nothing loads/errors unless an operator
+ * explicitly opts in. See web/README.md for the required config.
+ */
+
+const PeerOnrampInner = dynamic(() => import("./peer-onramp-inner"), {
+  ssr: false,
+  loading: () => (
+    <div className="border-paper-2 bg-paper-main flex h-24 items-center justify-center rounded-xl border">
+      <span className="text-surface-grey-2 text-sm">Loading peer onramp…</span>
+    </div>
+  ),
+});
+
+export function PeerOnramp({ address }: { address?: Address }) {
+  return <PeerOnrampInner address={address} />;
+}


### PR DESCRIPTION
Adds the two funding rails our hub still lacked vs app-stacks, giving the "Add funds" hub ALL of app-stacks' options.

**Fund from a connected external wallet** (Privy mode) — detect the user's injected external wallet (MetaMask/Rabby) via Privy linked accounts, read its xDAI balance, and send **xDAI** or **mint BREAD** straight to the embedded wallet through a viem walletClient (Gnosis-pinned, gas-reserve on MAX, auto-mint offer on arrival). Hidden in non-Privy mode (self-transfer — Receive/Mint already cover it).

**Peer onramp (zkp2p)** — `@zkp2p/sdk@0.7.2`, isolated behind `next/dynamic ssr:false` so it never runs at static-generation. Note: the published SDK exposes a browser-extension bridge (not the in-page `onramp()` flow app-stacks was written against, which is commented-out/WIP upstream), so the rail does detect-extension → connect → install link-out, then the hub's BREAD-mint offer fires when xDAI lands. **Gated behind `NEXT_PUBLIC_ZKP2P_ENABLED`** (hidden by default; needs the ZKP2P extension, no API key/relayer). Documented in web/README.

Hub now has 6 rails: LiFi bridge, Buy with card (Privy), Connected wallet, Peer onramp, Receive, Mint. Lint clean; default, base-path, Privy-enabled, and zkp2p-enabled static-export builds all pass.