### PR TITLE
feat: #32 delegated allowance-based & batch deposits

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -14,6 +14,9 @@ with deadlines, aggregated frontend views.
 | SafetyNet (implementation v2 — saving-circles membership model) | [`0x515D1cFec5B21a2648a504bc1B4A9e1977f14743`](https://gnosis.blockscout.com/address/0x515D1cFec5B21a2648a504bc1B4A9e1977f14743) |
 | SafetyNet (implementation v1) | [`0x32A0C6BeCceBe89E852faBEF29cC6016CFa380Ed`](https://gnosis.blockscout.com/address/0x32A0C6BeCceBe89E852faBEF29cC6016CFa380Ed) |
 | ProxyAdmin (auto-deployed by proxy) | [`0x1039CD43f31EC060F114B881264aD7799A24980A`](https://gnosis.blockscout.com/address/0x1039CD43f31EC060F114B881264aD7799A24980A) |
+| DelegatedSafetyNet (standalone extension — allowance-based & batch deposits, #32) | [`0x78ac9A4839E94da38F8535e22e64b004afA4e133`](https://gnosis.blockscout.com/address/0x78ac9A4839E94da38F8535e22e64b004afA4e133) |
+
+The `DelegatedSafetyNet` extension is a standalone (non-upgradeable) contract that references the proxy above. Members opt in (`setDelegatedDepositsEnabled(true)`) and approve the **proxy** for their token; anyone/a keeper can then call `depositIfAllowed(id, member)` / `batchDepositIfAllowed(ids, members)` to pay a member's owed dues from their allowance. `getAddressesForDeposit()` enumerates eligible members. No proxy upgrade was needed (the proxy's `depositFor` already pulls from the member).
 
 Upgraded in place to v2 on 2026-07-03 via `ProxyAdmin.upgradeAndCall`
 ([tx `0xab6fbdb0…f80584`](https://gnosis.blockscout.com/tx/0xab6fbdb079520e8e8b89ef6339f0e8a440d3fee32fa117f3d747b4e138f80584)),

--- a/script/DeployDelegated.sol
+++ b/script/DeployDelegated.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script} from 'forge-std/Script.sol';
+import {DelegatedSafetyNet} from 'src/contracts/DelegatedSafetyNet.sol';
+
+/**
+ * @title DeployDelegated
+ * @notice Deploys the standalone {DelegatedSafetyNet} extension pointed at an existing SafetyNet proxy.
+ * @dev Set `SAFETY_NET_ADDRESS` to the deployed SafetyNet proxy. Optionally set `PRIVATE_KEY`.
+ */
+contract DeployDelegated is Script {
+  function run() public {
+    uint256 _privateKey = vm.envOr('PRIVATE_KEY', uint256(0));
+    address _safetyNet = vm.envAddress('SAFETY_NET_ADDRESS');
+
+    if (_privateKey == 0) {
+      vm.startBroadcast();
+    } else {
+      vm.startBroadcast(_privateKey);
+    }
+
+    new DelegatedSafetyNet(_safetyNet);
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/contracts/DelegatedSafetyNet.sol
+++ b/src/contracts/DelegatedSafetyNet.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IDelegatedSafetyNet, ISafetyNetExtra} from '../interfaces/IDelegatedSafetyNet.sol';
+import {ISafetyNet} from '../interfaces/ISafetyNet.sol';
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {ReentrancyGuard} from '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
+
+/**
+ * @title DelegatedSafetyNet
+ * @notice Standalone extension enabling delegated ERC20 allowance-based deposits and batch operations
+ *         for the main SafetyNet contract.
+ * @dev Token flow adaptation: SafetyNet's `_deposit` pulls tokens from the member directly via its own
+ *      `safeTransferFrom(member, ...)`, and `depositFor(id, value, member)` is callable by anyone.
+ *      Therefore members approve the MAIN SafetyNet proxy (NOT this extension); this contract only
+ *      checks opt-in, the owed amount, and the member's allowance on the proxy, then calls
+ *      `SAFETY_NET.depositFor(...)` which performs the transfer. No tokens ever touch this contract.
+ * @author @RonTuretzky
+ */
+contract DelegatedSafetyNet is IDelegatedSafetyNet, ReentrancyGuard {
+  /// @notice The main SafetyNet contract (proxy)
+  ISafetyNet public immutable SAFETY_NET;
+
+  /// @notice Mapping to track which members have enabled delegated deposits
+  mapping(address member => bool enabled) public delegatedDepositsEnabled;
+
+  /**
+   * @notice Constructor
+   * @param _safetyNet Address of the main SafetyNet contract (proxy)
+   */
+  constructor(address _safetyNet) {
+    SAFETY_NET = ISafetyNet(_safetyNet);
+  }
+
+  /// @inheritdoc IDelegatedSafetyNet
+  function setDelegatedDepositsEnabled(bool _enabled) external override {
+    delegatedDepositsEnabled[msg.sender] = _enabled;
+    emit DelegatedDepositsToggled(msg.sender, _enabled);
+  }
+
+  /// @inheritdoc IDelegatedSafetyNet
+  function depositIfAllowed(uint256 _id, address _member) external override nonReentrant {
+    _depositIfAllowed(_id, _member);
+  }
+
+  /// @inheritdoc IDelegatedSafetyNet
+  function batchDepositIfAllowed(uint256[] calldata _ids, address[] calldata _members) external override nonReentrant {
+    // Validate array lengths match
+    if (_ids.length != _members.length) revert ArrayLengthMismatch();
+
+    // All-or-nothing: any single failure reverts the whole batch, mirroring the reference extension
+    for (uint256 i = 0; i < _ids.length; i++) {
+      _depositIfAllowed(_ids[i], _members[i]);
+    }
+  }
+
+  /// @inheritdoc IDelegatedSafetyNet
+  function isDelegatedDepositsEnabled(address _member) external view override returns (bool) {
+    return delegatedDepositsEnabled[_member];
+  }
+
+  /// @inheritdoc IDelegatedSafetyNet
+  function getAddressesForDeposit() external view override returns (uint256[] memory ids, address[] memory members) {
+    uint256 _nextId = ISafetyNetExtra(address(SAFETY_NET)).nextId();
+
+    // First pass: count eligible (net, member) pairs across all Safety Nets
+    uint256 _eligibleCount = 0;
+    for (uint256 _id = 0; _id < _nextId; _id++) {
+      // Skip decommissioned nets (getSafetyNet reverts NotCommissioned for them)
+      try SAFETY_NET.getSafetyNet(_id) returns (ISafetyNet.SafetyNet memory _safetyNet) {
+        if (_safetyNet.safetyNetStart == 0) continue; // Not started: no dues yet
+
+        address[] memory _members = SAFETY_NET.getMembers(_id);
+        for (uint256 j = 0; j < _members.length; j++) {
+          if (_isEligible(_id, _safetyNet, _members[j])) _eligibleCount++;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    ids = new uint256[](_eligibleCount);
+    members = new address[](_eligibleCount);
+
+    // Second pass: fill the parallel arrays
+    uint256 _index = 0;
+    for (uint256 _id = 0; _id < _nextId; _id++) {
+      try SAFETY_NET.getSafetyNet(_id) returns (ISafetyNet.SafetyNet memory _safetyNet) {
+        if (_safetyNet.safetyNetStart == 0) continue;
+
+        address[] memory _members = SAFETY_NET.getMembers(_id);
+        for (uint256 j = 0; j < _members.length; j++) {
+          if (_isEligible(_id, _safetyNet, _members[j])) {
+            ids[_index] = _id;
+            members[_index] = _members[j];
+            _index++;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return (ids, members);
+  }
+
+  /**
+   * @notice Executes a delegated deposit for a member if all conditions are met
+   * @dev Internal delegated deposit: opt-in + owed-amount + allowance checks, then `depositFor`.
+   * @param _id Safety Net ID
+   * @param _member Member address to deposit for
+   */
+  function _depositIfAllowed(uint256 _id, address _member) internal {
+    // Member must have opted in to delegated deposits
+    if (!delegatedDepositsEnabled[_member]) revert DelegatedDepositsNotEnabled();
+
+    // Reads the net; reverts NotCommissioned for decommissioned nets (propagated)
+    ISafetyNet.SafetyNet memory _safetyNet = SAFETY_NET.getSafetyNet(_id);
+
+    // Deposits are only valid after the net has been started
+    if (_safetyNet.safetyNetStart == 0) revert ISafetyNet.NotActive();
+
+    // Member must belong to the net
+    if (!ISafetyNetExtra(address(SAFETY_NET)).isMember(_id, _member)) revert ISafetyNet.NotMember();
+
+    uint256 _required = _requiredDeposit(_id, _safetyNet, _member);
+    // Nothing owed this epoch (already onboarded and dues fully paid)
+    if (_required == 0) revert ISafetyNet.AlreadyDeposited();
+
+    // Member must have approved the MAIN proxy for at least the owed amount
+    if (IERC20(_safetyNet.token).allowance(_member, address(SAFETY_NET)) < _required) revert InsufficientAllowance();
+
+    // Main pulls `_required` from `_member` via its own transferFrom
+    SAFETY_NET.depositFor(_id, _required, _member);
+  }
+
+  /**
+   * @notice Computes the deposit amount a member currently owes
+   * @dev Computes the amount a member owes right now, matching SafetyNet's deposit rules.
+   *      Onboarding (contribution not yet set): exact `initialDeposit`. Otherwise: dues remaining
+   *      this epoch (0 when fully paid).
+   * @param _id Safety Net ID
+   * @param _safetyNet The Safety Net struct
+   * @param _member Member address
+   * @return required The amount owed
+   */
+  function _requiredDeposit(uint256 _id, ISafetyNet.SafetyNet memory _safetyNet, address _member) internal view returns (uint256 required) {
+    bool _onboarding = ISafetyNetExtra(address(SAFETY_NET)).safetyNetMemberContribute(_id, _member) == 0;
+    required = _onboarding ? _safetyNet.initialDeposit : SAFETY_NET.duesRemainingThisEpoch(_id, _member);
+  }
+
+  /**
+   * @notice Returns whether a member is eligible for a delegated deposit right now
+   * @dev Whether a (net, member) pair is eligible for a delegated deposit right now.
+   * @param _id Safety Net ID
+   * @param _safetyNet The Safety Net struct
+   * @param _member Member address
+   * @return eligible True when opted in, still owes a positive amount, and the proxy allowance covers it
+   */
+  function _isEligible(uint256 _id, ISafetyNet.SafetyNet memory _safetyNet, address _member) internal view returns (bool eligible) {
+    if (!delegatedDepositsEnabled[_member]) return false;
+
+    uint256 _required = _requiredDeposit(_id, _safetyNet, _member);
+    if (_required == 0) return false;
+
+    return IERC20(_safetyNet.token).allowance(_member, address(SAFETY_NET)) >= _required;
+  }
+}

--- a/src/interfaces/IDelegatedSafetyNet.sol
+++ b/src/interfaces/IDelegatedSafetyNet.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title Extra SafetyNet public getters used by the delegated deposits extension
+/// @notice Re-declares SafetyNet public state getters that exist on the concrete contract but are
+///         not part of {ISafetyNet}. The extension reads them without modifying the main interface.
+/// @author @RonTuretzky
+interface ISafetyNetExtra {
+  /// @notice The next Safety Net ID to be assigned (also the count of created Safety Nets)
+  /// @return id The next Safety Net ID
+  function nextId() external view returns (uint256 id);
+
+  /// @notice Whether an address is a member of a Safety Net
+  /// @param id The Safety Net ID
+  /// @param member The address to check
+  /// @return status True if the address is a member of the Safety Net
+  function isMember(uint256 id, address member) external view returns (bool status);
+
+  /// @notice The stored monthly contribution for a member; 0 until the member's onboarding deposit
+  /// @param id The Safety Net ID
+  /// @param member The member address
+  /// @return monthlyContribute The member's monthly contribution amount, 0 before onboarding
+  function safetyNetMemberContribute(uint256 id, address member) external view returns (uint256 monthlyContribute);
+}
+
+/// @title IDelegatedSafetyNet
+/// @notice Interface for the SafetyNet delegated deposits extension contract
+/// @dev This extension enables delegated ERC20 allowance-based deposits and batch operations. Members
+///      opt in here and approve the MAIN SafetyNet proxy (not this extension); a keeper then triggers
+///      their owed deposit through {depositIfAllowed} / {batchDepositIfAllowed}.
+/// @author @RonTuretzky
+interface IDelegatedSafetyNet {
+  /*///////////////////////////////////////////////////////////////
+                            EVENTS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Emitted when a member enables or disables delegated deposits
+  /// @param member The address of the member
+  /// @param enabled Whether delegated deposits are enabled
+  event DelegatedDepositsToggled(address indexed member, bool indexed enabled);
+
+  /*///////////////////////////////////////////////////////////////
+                            ERRORS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Thrown when a member has insufficient allowance on the main SafetyNet proxy for the deposit
+  error InsufficientAllowance();
+
+  /// @notice Thrown when array lengths don't match in batch operations
+  error ArrayLengthMismatch();
+
+  /// @notice Thrown when delegated deposits are not enabled for a member
+  error DelegatedDepositsNotEnabled();
+
+  /*///////////////////////////////////////////////////////////////
+                            EXTERNAL
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Enable or disable delegated deposits for the caller
+  /// @param enabled Whether to enable delegated deposits
+  function setDelegatedDepositsEnabled(bool enabled) external;
+
+  /// @notice Deposit the amount a member owes for a Safety Net if they opted in and approved the proxy
+  /// @dev The member must have opted in here and approved the MAIN SafetyNet proxy for the owed amount.
+  ///      The owed amount is the exact `initialDeposit` for an un-onboarded member, otherwise the dues
+  ///      remaining for the current epoch. Reverts if the member hasn't opted in, isn't a member, the
+  ///      net isn't started, nothing is owed, or the allowance is insufficient.
+  /// @param id The Safety Net ID
+  /// @param member The address of the member to deposit for
+  function depositIfAllowed(uint256 id, address member) external;
+
+  /// @notice Batch deposit for multiple members across multiple Safety Nets
+  /// @dev Arrays must be the same length. All deposits must succeed or the entire transaction reverts
+  ///      (all-or-nothing), mirroring the reference extension.
+  /// @param ids Array of Safety Net IDs
+  /// @param members Array of member addresses, parallel to `ids`
+  function batchDepositIfAllowed(uint256[] calldata ids, address[] calldata members) external;
+
+  /// @notice Check if delegated deposits are enabled for a member
+  /// @param member The address to check
+  /// @return enabled Whether delegated deposits are enabled
+  function isDelegatedDepositsEnabled(address member) external view returns (bool enabled);
+
+  /// @notice Enumerate (Safety Net, member) pairs eligible for a delegated deposit right now
+  /// @dev Two-pass count-then-fill over all Safety Nets. A pair is eligible when the net is started,
+  ///      the member opted in, still owes a positive amount this epoch (or their onboarding deposit),
+  ///      and has approved the main proxy for at least that amount. Decommissioned nets are skipped.
+  /// @return ids Array of Safety Net IDs with eligible members
+  /// @return members Array of eligible member addresses, parallel to `ids`
+  function getAddressesForDeposit() external view returns (uint256[] memory ids, address[] memory members);
+}

--- a/test/unit/DelegatedSafetyNetUnit.sol
+++ b/test/unit/DelegatedSafetyNetUnit.sol
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {DelegatedSafetyNet} from 'src/contracts/DelegatedSafetyNet.sol';
+import {IDelegatedSafetyNet} from 'src/interfaces/IDelegatedSafetyNet.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+
+import {SafetyNetUnitBase} from 'test/unit/SafetyNetUnit.sol';
+
+contract DelegatedSafetyNetUnit is SafetyNetUnitBase {
+  DelegatedSafetyNet internal _delegated;
+
+  function setUp() public override {
+    super.setUp();
+    _delegated = new DelegatedSafetyNet(address(_sn));
+    _allowToken(address(_token));
+  }
+
+  // ---------- helpers ----------
+
+  /// @dev Started default net [alice(owner), bob]; members approve the PROXY and opt into delegation
+  function _startedWithDelegation() internal returns (uint256 id) {
+    id = _createDefaultStarted(_defaultSafetyNet(address(_token)));
+    // Members already approve the proxy for max in the base setUp; opt in here
+    vm.prank(_alice);
+    _delegated.setDelegatedDepositsEnabled(true);
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+  }
+
+  function _initialDeposit(uint256 id) internal view returns (uint256) {
+    return _sn.getSafetyNet(id).initialDeposit;
+  }
+
+  // ---------- opt-in ----------
+
+  function test_SetDelegatedDepositsEnabledTogglesAndEmits() external {
+    vm.expectEmit(true, true, false, false, address(_delegated));
+    emit IDelegatedSafetyNet.DelegatedDepositsToggled(_bob, true);
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+    assertTrue(_delegated.isDelegatedDepositsEnabled(_bob));
+
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(false);
+    assertFalse(_delegated.isDelegatedDepositsEnabled(_bob));
+  }
+
+  // ---------- depositIfAllowed: happy path ----------
+
+  function test_DepositIfAllowedOnboardsMemberWithInitialDeposit() external {
+    uint256 id = _startedWithDelegation();
+    uint256 initial = _initialDeposit(id);
+
+    _delegated.depositIfAllowed(id, _bob);
+
+    (address[] memory members, uint256[] memory balances) = _sn.getMemberBalances(id);
+    // bob is index 1 (alice owner is index 0)
+    assertEq(members[1], _bob);
+    assertEq(balances[1], initial);
+    // onboarding recorded the monthly contribution
+    assertEq(_sn.safetyNetMemberContribute(id, _bob), _sn.getSafetyNet(id).fixedDeposit);
+  }
+
+  function test_DepositIfAllowedPaysRecurringDuesAfterOnboarding() external {
+    uint256 id = _startedWithDelegation();
+
+    // Onboard bob
+    _delegated.depositIfAllowed(id, _bob);
+
+    // Advance one epoch so dues accrue again
+    _nextEpoch(id);
+    uint256 fixedDeposit = _sn.getSafetyNet(id).fixedDeposit;
+    assertEq(_sn.duesRemainingThisEpoch(id, _bob), fixedDeposit);
+
+    _delegated.depositIfAllowed(id, _bob);
+    assertEq(_sn.duesRemainingThisEpoch(id, _bob), 0);
+  }
+
+  // ---------- depositIfAllowed: reverts ----------
+
+  function test_DepositIfAllowedRevertsWhenNotOptedIn() external {
+    uint256 id = _createDefaultStarted(_defaultSafetyNet(address(_token)));
+    vm.expectRevert(IDelegatedSafetyNet.DelegatedDepositsNotEnabled.selector);
+    _delegated.depositIfAllowed(id, _bob);
+  }
+
+  function test_DepositIfAllowedRevertsWhenNotMember() external {
+    uint256 id = _startedWithDelegation();
+    // carol opted in but never joined the net
+    vm.prank(_carol);
+    _delegated.setDelegatedDepositsEnabled(true);
+    vm.expectRevert(ISafetyNet.NotMember.selector);
+    _delegated.depositIfAllowed(id, _carol);
+  }
+
+  function test_DepositIfAllowedRevertsWhenNetNotStarted() external {
+    // create but do not start
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
+    _redeemInviteAs(id, _bob, _aliceKey);
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+    vm.expectRevert(ISafetyNet.NotActive.selector);
+    _delegated.depositIfAllowed(id, _bob);
+  }
+
+  function test_DepositIfAllowedRevertsWhenAlreadyDeposited() external {
+    uint256 id = _startedWithDelegation();
+    _delegated.depositIfAllowed(id, _bob); // onboards
+    // Same epoch, dues fully paid -> nothing owed
+    vm.expectRevert(ISafetyNet.AlreadyDeposited.selector);
+    _delegated.depositIfAllowed(id, _bob);
+  }
+
+  function test_DepositIfAllowedRevertsWhenInsufficientAllowance() external {
+    uint256 id = _createDefaultStarted(_defaultSafetyNet(address(_token)));
+    // bob opts in but revokes the proxy allowance
+    vm.startPrank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+    _token.approve(address(_sn), 0);
+    vm.stopPrank();
+    vm.expectRevert(IDelegatedSafetyNet.InsufficientAllowance.selector);
+    _delegated.depositIfAllowed(id, _bob);
+  }
+
+  function test_DepositIfAllowedRevertsForDecommissionedNet() external {
+    uint256 id = _startedWithDelegation();
+    // A net only becomes decommissionable once a past epoch has an unpaid member;
+    // warp past one epoch (nobody has deposited) so decommission() is allowed.
+    vm.warp(block.timestamp + _sn.getSafetyNet(id).epochDuration + 1);
+    vm.prank(_alice);
+    _sn.decommission(id);
+    // getSafetyNet reverts NotCommissioned for decommissioned nets
+    vm.expectRevert(ISafetyNet.NotCommissioned.selector);
+    _delegated.depositIfAllowed(id, _bob);
+  }
+
+  // ---------- batch ----------
+
+  function test_BatchDepositIfAllowedOnboardsMultiple() external {
+    uint256 id = _startedWithDelegation();
+    uint256 initial = _initialDeposit(id);
+
+    uint256[] memory ids = new uint256[](2);
+    address[] memory members = new address[](2);
+    ids[0] = id;
+    ids[1] = id;
+    members[0] = _alice;
+    members[1] = _bob;
+
+    _delegated.batchDepositIfAllowed(ids, members);
+
+    (, uint256[] memory balances) = _sn.getMemberBalances(id);
+    assertEq(balances[0], initial); // alice
+    assertEq(balances[1], initial); // bob
+  }
+
+  function test_BatchDepositIfAllowedRevertsOnLengthMismatch() external {
+    uint256[] memory ids = new uint256[](2);
+    address[] memory members = new address[](1);
+    vm.expectRevert(IDelegatedSafetyNet.ArrayLengthMismatch.selector);
+    _delegated.batchDepositIfAllowed(ids, members);
+  }
+
+  function test_BatchDepositIfAllowedIsAllOrNothing() external {
+    uint256 id = _startedWithDelegation();
+
+    // carol opted in but is NOT a member -> her entry fails, reverting the whole batch
+    vm.prank(_carol);
+    _delegated.setDelegatedDepositsEnabled(true);
+
+    uint256[] memory ids = new uint256[](2);
+    address[] memory members = new address[](2);
+    ids[0] = id;
+    ids[1] = id;
+    members[0] = _bob; // valid
+    members[1] = _carol; // invalid: not a member
+
+    vm.expectRevert(ISafetyNet.NotMember.selector);
+    _delegated.batchDepositIfAllowed(ids, members);
+
+    // Nothing was deposited: bob's onboarding was rolled back
+    assertEq(_sn.safetyNetMemberContribute(id, _bob), 0);
+    (, uint256[] memory balances) = _sn.getMemberBalances(id);
+    assertEq(balances[1], 0);
+  }
+
+  // ---------- getAddressesForDeposit ----------
+
+  function test_GetAddressesForDepositEnumeratesOptedInOwing() external {
+    uint256 id = _startedWithDelegation();
+    // alice + bob opted in, both owe their initial deposit, both approved the proxy
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    assertEq(ids.length, 2);
+    assertEq(members.length, 2);
+    // Both entries belong to `id`
+    assertEq(ids[0], id);
+    assertEq(ids[1], id);
+    // Members are alice and bob in net order
+    assertEq(members[0], _alice);
+    assertEq(members[1], _bob);
+  }
+
+  function test_GetAddressesForDepositExcludesNotOptedIn() external {
+    uint256 id = _createDefaultStarted(_defaultSafetyNet(address(_token)));
+    // Only bob opts in
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    assertEq(ids.length, 1);
+    assertEq(members[0], _bob);
+    assertEq(ids[0], id);
+  }
+
+  function test_GetAddressesForDepositExcludesAlreadyPaid() external {
+    uint256 id = _startedWithDelegation();
+    // Onboard bob so he owes nothing this epoch
+    _delegated.depositIfAllowed(id, _bob);
+
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    // Only alice remains owing
+    assertEq(ids.length, 1);
+    assertEq(members[0], _alice);
+  }
+
+  function test_GetAddressesForDepositExcludesInsufficientAllowance() external {
+    uint256 id = _startedWithDelegation();
+    // bob revokes his proxy allowance
+    vm.prank(_bob);
+    _token.approve(address(_sn), 0);
+
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    assertEq(ids.length, 1);
+    assertEq(members[0], _alice);
+    assertEq(ids[0], id);
+  }
+
+  function test_GetAddressesForDepositExcludesDecommissionedNet() external {
+    uint256 id = _startedWithDelegation();
+    // Warp past one epoch (nobody deposited) so the net is decommissionable.
+    vm.warp(block.timestamp + _sn.getSafetyNet(id).epochDuration + 1);
+    vm.prank(_alice);
+    _sn.decommission(id);
+
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    assertEq(ids.length, 0);
+    assertEq(members.length, 0);
+  }
+
+  function test_GetAddressesForDepositExcludesNotStartedNet() external {
+    // Create but do not start; owner (alice) is a member and opts in
+    uint256 id = _sn.create('', _defaultSafetyNet(address(_token)));
+    _redeemInviteAs(id, _bob, _aliceKey);
+    vm.prank(_alice);
+    _delegated.setDelegatedDepositsEnabled(true);
+    vm.prank(_bob);
+    _delegated.setDelegatedDepositsEnabled(true);
+
+    (uint256[] memory ids, address[] memory members) = _delegated.getAddressesForDeposit();
+    assertEq(ids.length, 0);
+    assertEq(members.length, 0);
+  }
+}

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -55,7 +55,7 @@ abstract contract SafetyNetUnitBase is Test {
   /// @dev Monotonic nonce used by the invite helpers to avoid collisions across joins
   uint256 internal _inviteNonce;
 
-  function setUp() public {
+  function setUp() public virtual {
     (_owner, _ownerKey) = makeAddrAndKey('owner');
     (_impostor, _impostorKey) = makeAddrAndKey('impostor');
     (_requester, _requesterKey) = makeAddrAndKey('requester');

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -46,6 +46,7 @@ const SECTIONS: Section[] = [
       "After that, you owe the recurring deposit every epoch. You can pay it in parts, and you can also pay another member's dues for them (the tokens still come from their wallet — they only save the gas). Every deposit adds 1:1 to your withdrawable balance.",
       "You can also pay ahead: deposit more than this epoch's dues and the extra prepays future epochs — the current epoch's remaining dues fill first, then the next epoch, and so on, up to 12 epochs ahead. The app previews exactly how a deposit will be allocated before you send it.",
       "Short on BREAD? Use the \"Get BREAD\" button in the nav (or the prompt on the deposit form) to mint BREAD 1:1 from xDAI — and, on embedded-wallet sign-ins, to buy xDAI first.",
+      "Turn on automatic deposits so the group can cover your dues from a pre-approved allowance — approve the SafetyNet proxy once, flip it on, and a keeper or another member can pay your owed dues so you never miss an epoch. It's non-custodial and you can turn it off any time.",
     ],
   },
   {

--- a/web/src/components/net/auto-deposit-toggle.tsx
+++ b/web/src/components/net/auto-deposit-toggle.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import { maxUint256 } from "viem";
+import { Caption } from "@breadcoop/ui";
+import { ActionButton } from "@/components/ui/action-button";
+import { TxStatus } from "@/components/ui/tx-status";
+import { Card } from "@/components/ui/ui";
+import {
+  useDelegatedEnabled,
+  useToggleDelegated,
+} from "@/hooks/use-delegated-deposits";
+import { useAllowance, useApprove, useTokenInfo } from "@/hooks/use-token";
+import { addressUrl, SAFETYNET_ADDRESS } from "@/lib/config";
+import { formatAmount, shortenAddress } from "@/lib/format";
+import type { SafetyNetDetails } from "@/lib/types";
+
+/**
+ * "Automatic deposits" opt-in for the connected member on a STARTED net
+ * (DelegatedSafetyNet extension, issue #32).
+ *
+ * Approve → enable flow: enabling needs two txs — first approve the *main
+ * proxy* to spend enough of the net's token to cover future dues, then toggle
+ * `setDelegatedDepositsEnabled(true)` on the extension. If the allowance is
+ * already sufficient we skip straight to the toggle. Both txs run through the
+ * shared `useTx` path (so Privy + wagmi both work) and every on-chain read in
+ * the app is invalidated on success.
+ */
+export function AutoDepositToggle({ details }: { details: SafetyNetDetails }) {
+  const { address } = useAccount();
+  const net = details.safetyNet;
+  const { symbol, decimals } = useTokenInfo(net.token);
+
+  const {
+    data: enabled,
+    isLoading: enabledLoading,
+    refetch: refetchEnabled,
+  } = useDelegatedEnabled(address);
+  const { data: allowance, refetch: refetchAllowance } = useAllowance(
+    net.token,
+    address,
+  );
+
+  const approveTx = useApprove();
+  const toggleTx = useToggleDelegated();
+
+  // Two-step "Approve & enable": once the approval confirms, chain into the
+  // toggle automatically so the member only clicks once.
+  const [pendingEnable, setPendingEnable] = useState(false);
+
+  useEffect(() => {
+    if (approveTx.isSuccess) refetchAllowance();
+  }, [approveTx.isSuccess, refetchAllowance]);
+
+  useEffect(() => {
+    if (approveTx.isSuccess && pendingEnable) {
+      setPendingEnable(false);
+      toggleTx.toggle(true);
+    }
+  }, [approveTx.isSuccess, pendingEnable, toggleTx]);
+
+  useEffect(() => {
+    if (toggleTx.isSuccess) refetchEnabled();
+  }, [toggleTx.isSuccess, refetchEnabled]);
+
+  // Enough allowance to cover at least the next epoch's dues. We approve
+  // maxUint256 so future epochs are covered without re-approving; treat any
+  // allowance that already covers one recurring deposit as "approved".
+  const hasAllowance =
+    allowance !== undefined && allowance >= net.fixedDeposit && allowance > 0n;
+
+  const enable = () => {
+    if (hasAllowance) {
+      toggleTx.toggle(true);
+    } else {
+      setPendingEnable(true);
+      approveTx.approve(net.token, maxUint256);
+    }
+  };
+
+  if (enabledLoading && enabled === undefined) return null;
+
+  if (enabled) {
+    return (
+      <Card>
+        <div className="flex items-center justify-between gap-2">
+          <Caption className="text-surface-grey-2">Automatic deposits</Caption>
+          <span className="text-system-green inline-flex items-center gap-1.5 text-xs font-bold">
+            <span
+              aria-hidden
+              className="bg-system-green inline-block h-2 w-2 rounded-full"
+            />
+            On
+          </span>
+        </div>
+
+        <p className="text-text-standard mt-3 text-sm">
+          You&apos;re opted in. The group can top up your dues from your
+          pre-approved allowance so you never miss an epoch.
+        </p>
+
+        <dl className="text-surface-grey-2 mt-3 space-y-1 text-xs">
+          <div className="flex justify-between gap-2">
+            <dt>Approved allowance</dt>
+            <dd className="text-text-standard font-medium">
+              {allowance !== undefined && allowance >= maxUint256 / 2n
+                ? "Unlimited"
+                : `${formatAmount(allowance, decimals)} ${symbol}`}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-2">
+            <dt>Spender (proxy)</dt>
+            <dd>
+              <a
+                href={addressUrl(SAFETYNET_ADDRESS)}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary-jade hover:underline"
+              >
+                {shortenAddress(SAFETYNET_ADDRESS)}
+              </a>
+            </dd>
+          </div>
+        </dl>
+
+        <p className="text-surface-grey-2 mt-3 text-xs">
+          Turning this off — or reducing your allowance to the proxy — stops
+          automatic deposits. Your funds only ever move as dues into this net.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-2">
+          <ActionButton
+            variant="destructive"
+            onClick={() => toggleTx.toggle(false)}
+            isLoading={toggleTx.isBusy}
+          >
+            Turn off automatic deposits
+          </ActionButton>
+          <ActionButton
+            variant="secondary"
+            onClick={() => approveTx.approve(net.token, maxUint256)}
+            isLoading={approveTx.isBusy}
+          >
+            Manage allowance (re-approve unlimited)
+          </ActionButton>
+        </div>
+        <TxStatus
+          status={toggleTx.status}
+          hash={toggleTx.hash}
+          error={toggleTx.error}
+          successLabel="Automatic deposits updated"
+        />
+        {toggleTx.status === "idle" && (
+          <TxStatus
+            status={approveTx.status}
+            hash={approveTx.hash}
+            error={approveTx.error}
+            successLabel="Allowance updated"
+          />
+        )}
+      </Card>
+    );
+  }
+
+  const enabling = pendingEnable || approveTx.isBusy || toggleTx.isBusy;
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-2">
+        <Caption className="text-surface-grey-2">Automatic deposits</Caption>
+        <span className="text-surface-grey-2 text-xs font-bold">Off</span>
+      </div>
+
+      <p className="text-text-standard mt-3 text-sm">
+        Never miss an epoch — let the group top up your dues from a pre-approved
+        allowance. Opt in and a keeper or another member can pay your owed dues
+        for you. It&apos;s non-custodial: funds only ever move as dues into this
+        net, up to the allowance you approve, and you can revoke any time by
+        turning it off or reducing the allowance.
+      </p>
+
+      {!hasAllowance && (
+        <p className="text-surface-grey-2 mt-3 text-xs">
+          Enabling takes two quick steps: approve the SafetyNet proxy to spend{" "}
+          {symbol} (we approve an unlimited amount so future epochs are covered),
+          then switch automatic deposits on.
+        </p>
+      )}
+
+      <div className="mt-4">
+        <ActionButton onClick={enable} isLoading={enabling}>
+          {hasAllowance ? "Enable automatic deposits" : "Approve & enable"}
+        </ActionButton>
+      </div>
+
+      <TxStatus
+        status={approveTx.status}
+        hash={approveTx.hash}
+        error={approveTx.error}
+        successLabel={
+          pendingEnable || toggleTx.status !== "idle"
+            ? "Approved — enabling…"
+            : "Allowance approved"
+        }
+      />
+      <TxStatus
+        status={toggleTx.status}
+        hash={toggleTx.hash}
+        error={toggleTx.error}
+        successLabel="Automatic deposits on"
+      />
+    </Card>
+  );
+}

--- a/web/src/components/net/net-page-content.tsx
+++ b/web/src/components/net/net-page-content.tsx
@@ -20,6 +20,7 @@ import { InvitePanel } from "@/components/net/invite-panel";
 import { StartNetBanner } from "@/components/net/start-panel";
 import { DecommissionPanel } from "@/components/net/decommission-panel";
 import { DepositReminder } from "@/components/net/deposit-reminder";
+import { AutoDepositToggle } from "@/components/net/auto-deposit-toggle";
 import { ActivityFeed } from "@/components/net/activity-feed";
 import { useSafetyNetDetails, useSafetyNetName } from "@/hooks/use-safety-net";
 import { isContractConfigured } from "@/lib/config";
@@ -146,6 +147,7 @@ function NetDetail() {
               <>
                 <DepositPanel details={details} />
                 <DepositReminder details={details} />
+                <AutoDepositToggle details={details} />
                 <WithdrawPanel details={details} />
               </>
             ) : (

--- a/web/src/hooks/use-delegated-deposits.ts
+++ b/web/src/hooks/use-delegated-deposits.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { zeroAddress, type Address } from "viem";
+import { useReadContract } from "wagmi";
+import { delegatedAbi } from "@/lib/abi/delegated";
+import { CHAIN_ID, DELEGATED_SAFETYNET_ADDRESS } from "@/lib/config";
+import { useTx } from "@/hooks/use-tx";
+
+const REFETCH_MS = 12_000;
+
+/**
+ * Automatic deposits (DelegatedSafetyNet extension, issue #32).
+ *
+ * A member opts in by (1) approving the *main proxy* (SAFETYNET_ADDRESS) for
+ * enough of the net's token to cover future dues, and (2) toggling
+ * `setDelegatedDepositsEnabled(true)` on this extension. Then anyone can call
+ * `depositIfAllowed(id, member)` to pay that member's owed dues from their
+ * allowance. It's opt-in and non-custodial: funds only ever move as dues into
+ * nets the member already belongs to, up to their allowance, and the member
+ * can revoke by toggling off or reducing the allowance.
+ *
+ * The token allowance to the proxy is read/written with the existing
+ * `useAllowance` / `useApprove` hooks in use-token.ts, which already target
+ * SAFETYNET_ADDRESS — this hook covers only the delegated-toggle state.
+ */
+
+/** Whether `member` has opted into automatic (delegated) deposits. */
+export function useDelegatedEnabled(member: Address | undefined) {
+  return useReadContract({
+    address: DELEGATED_SAFETYNET_ADDRESS,
+    abi: delegatedAbi,
+    chainId: CHAIN_ID,
+    functionName: "isDelegatedDepositsEnabled",
+    args: [member ?? zeroAddress],
+    query: {
+      enabled: Boolean(member),
+      refetchInterval: REFETCH_MS,
+    },
+  });
+}
+
+/** Toggle automatic deposits on/off for the connected member. */
+export function useToggleDelegated() {
+  const tx = useTx();
+  const toggle = (enabled: boolean) =>
+    tx.run({
+      address: DELEGATED_SAFETYNET_ADDRESS,
+      abi: delegatedAbi,
+      functionName: "setDelegatedDepositsEnabled",
+      args: [enabled],
+    });
+  return { toggle, ...tx };
+}

--- a/web/src/lib/abi/delegated.ts
+++ b/web/src/lib/abi/delegated.ts
@@ -1,0 +1,186 @@
+// Auto-generated from DelegatedSafetyNet build output.
+export const delegatedAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_safetyNet",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "SAFETY_NET",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract ISafetyNet"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "batchDepositIfAllowed",
+    "inputs": [
+      {
+        "name": "_ids",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "_members",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "delegatedDepositsEnabled",
+    "inputs": [
+      {
+        "name": "member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "depositIfAllowed",
+    "inputs": [
+      {
+        "name": "_id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getAddressesForDeposit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ids",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "members",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isDelegatedDepositsEnabled",
+    "inputs": [
+      {
+        "name": "_member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setDelegatedDepositsEnabled",
+    "inputs": [
+      {
+        "name": "_enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "DelegatedDepositsToggled",
+    "inputs": [
+      {
+        "name": "member",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyDeposited",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DelegatedDepositsNotEnabled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientAllowance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotActive",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotMember",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  }
+] as const;

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -113,6 +113,19 @@ export const SAFETYNET_ADDRESS: Address = withDefault(
 
 export const isContractConfigured = SAFETYNET_ADDRESS !== zeroAddress;
 
+/**
+ * The DelegatedSafetyNet extension on Gnosis (see issue #32). It references
+ * the main proxy and lets a member opt into automatic deposits: anyone (a
+ * keeper/agent or another member) can then pay that member's owed dues from a
+ * pre-approved allowance, so they never miss an epoch. Overridable via
+ * NEXT_PUBLIC_DELEGATED_ADDRESS for other deployments.
+ */
+export const DELEGATED_SAFETYNET_ADDRESS: Address = withDefault(
+  optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS),
+  "0x78ac9A4839E94da38F8535e22e64b004afA4e133",
+  "NEXT_PUBLIC_DELEGATED_ADDRESS",
+) as Address;
+
 /** Optional base path for project-subpath hosting (GitHub Pages). */
 export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 


### PR DESCRIPTION
Implements issue #32 (Automated ERC20 allowance-based & batch deposits), mirroring saving-circles' \`DelegatedSavingCircles\` — as a **standalone extension contract**, so no proxy upgrade was needed.

## Contract — \`DelegatedSafetyNet\` (standalone, deployed + verified)
[`0x78ac9A4839E94da38F8535e22e64b004afA4e133`](https://gnosis.blockscout.com/address/0x78ac9A4839E94da38F8535e22e64b004afA4e133), references the main proxy. Adapted to SafetyNet's token flow: our \`depositFor\` already pulls from the *member*, so a member approves the **proxy** (not the extension) and the extension just orchestrates:
- \`setDelegatedDepositsEnabled(bool)\` — member opt-in (event \`DelegatedDepositsToggled\`).
- \`depositIfAllowed(id, member)\` — pays the member's owed dues from their allowance (onboarding = exact \`initialDeposit\`; recurring = \`duesRemainingThisEpoch\`); reverts if not opted-in / not a member / net not started / already paid / insufficient allowance.
- \`batchDepositIfAllowed(ids[], members[])\` — all-or-nothing batch (matches reference).
- \`getAddressesForDeposit()\` — enumerates opted-in members who owe and have allowance, for a keeper/agent.
- Main SafetyNet contract **untouched** (no upgrade, no storage change). 186 forge tests (18 new), lint clean. Live-sanity checked (view + opt-in toggle onchain).

## Frontend — "Automatic deposits" opt-in
On a started net, a member sees an Automatic-deposits card: an "Approve & enable" flow (approve the proxy + toggle on), an enabled state showing the allowance with "Turn off", explaining it's opt-in/non-custodial (funds only move as dues, up to the allowance). Reuses the shared tx path (works in wagmi + Privy). Extension ABI at \`web/src/lib/abi/delegated.ts\`.

Lint clean; default, base-path, and Privy-enabled static-export builds pass.