### PR TITLE
feat: Broodfonds solidarity ratio with actuarial risk formula, sliders, and runtime-addressed fresh deploys

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -1,0 +1,190 @@
+name: Deploy contracts
+
+# Manual full-stack deploy via etherform's helper scripts (prepare-env.sh +
+# verify-blockscout.sh, sparse-checked-out), keeping the key in a secret.
+#
+# One run of script/Deploy.sol:Deploy broadcasts the complete stack: SafetyNet
+# implementation, TransparentProxy (which self-deploys its ProxyAdmin), the
+# DelegatedSafetyNet extension, and the ALLOWED_TOKENS allowlisting.
+#
+# Afterwards the run publishes/updates the rolling `contract-addresses` GitHub
+# release with a per-chain addresses.json manifest. The static frontend fetches
+# that manifest at runtime (web/src/lib/remote-addresses.ts), so NO frontend
+# rebuild/redeploy is needed to pick up a fresh deployment.
+#
+# Requires repo secrets: PRIVATE_KEY (funded on the target chain) and
+# optionally RPC_URL (else the public Gnosis RPC).
+
+on:
+  workflow_dispatch:
+    inputs:
+      chain:
+        description: "Target chain"
+        type: choice
+        default: gnosis
+        options:
+          - gnosis
+      allowed_tokens:
+        description: "Comma-separated ERC20s to allowlist (blank = Gnosis WXDAI + BREAD)"
+        required: false
+        default: ""
+      admin:
+        description: "Proxy admin / SafetyNet owner (blank = deployer)"
+        required: false
+        default: ""
+
+permissions:
+  # write: the publish step creates/updates the rolling contract-addresses release.
+  contents: write
+
+concurrency:
+  group: contracts-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sparse-checkout etherform deploy scripts
+        uses: actions/checkout@v4
+        with:
+          repository: BreadchainCoop/etherform
+          ref: main
+          sparse-checkout: scripts
+          path: .etherform
+
+      - uses: foundry-rs/foundry-toolchain@v1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies (remappings resolve through node_modules)
+        run: yarn --frozen-lockfile
+
+      - name: Resolve chain (id + RPC + explorer)
+        id: chain
+        run: |
+          case "${{ inputs.chain }}" in
+            gnosis)
+              ID=100
+              RPC="${{ secrets.RPC_URL || 'https://rpc.gnosischain.com' }}"
+              BS="https://gnosis.blockscout.com" ;;
+          esac
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "rpc=$RPC" >> "$GITHUB_OUTPUT"
+          echo "blockscout=$BS" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy full stack
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          RPC_URL: ${{ steps.chain.outputs.rpc }}
+          ADMIN_INPUT: ${{ inputs.admin }}
+          TOKENS_INPUT: ${{ inputs.allowed_tokens }}
+        run: |
+          source .etherform/scripts/deploy/prepare-env.sh
+          # Gnosis defaults: WXDAI + BREAD. Only export optional vars when set, so
+          # the script keeps working defaults (empty env vars fail address parse).
+          export ALLOWED_TOKENS="${TOKENS_INPUT:-0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d,0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3}"
+          [ -n "$ADMIN_INPUT" ] && export ADMIN_ADDRESS="$ADMIN_INPUT"
+          forge script script/Deploy.sol:Deploy \
+            --rpc-url "$RPC_URL" --broadcast --slow -vvvv
+
+      - name: Verify on Blockscout
+        continue-on-error: true
+        # Bounded: Blockscout verification can hang the etherform script.
+        # The deploy already succeeded by here — verification is best-effort.
+        timeout-minutes: 5
+        env:
+          RPC_URL: ${{ steps.chain.outputs.rpc }}
+          BLOCKSCOUT_URL: ${{ steps.chain.outputs.blockscout }}
+        run: |
+          BROADCAST_FILE="broadcast/Deploy.sol/${{ steps.chain.outputs.id }}/run-latest.json"
+          if [ -f "$BROADCAST_FILE" ]; then
+            BROADCAST_FILE="$BROADCAST_FILE" bash .etherform/scripts/deploy/verify-blockscout.sh || true
+          fi
+
+      - name: Upload deployment broadcast
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-${{ inputs.chain }}-broadcast
+          path: broadcast/Deploy.sol/${{ steps.chain.outputs.id }}/run-latest.json
+          if-no-files-found: warn
+
+      # Publish the merged address manifest to the rolling `contract-addresses`
+      # release. The static frontend fetches addresses.json from this release at
+      # runtime, so deploys go live without a frontend rebuild. The manifest is
+      # merged per chain, so deploying one chain never drops another's entry.
+      - name: Publish address manifest (rolling release)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHAIN_ID: ${{ steps.chain.outputs.id }}
+        run: |
+          set -euo pipefail
+          gh release download contract-addresses -p addresses.json -O prev.json -R "$GITHUB_REPOSITORY" \
+            || echo '{}' > prev.json
+          python3 - <<'PY'
+          import json, os, time
+
+          chain = os.environ["CHAIN_ID"]
+          b = json.load(open(f"broadcast/Deploy.sol/{chain}/run-latest.json"))
+
+          created = {}
+          proxy_admin = None
+          for t in b["transactions"]:
+              if t.get("transactionType") != "CREATE" or not t.get("contractName"):
+                  continue
+              created[t["contractName"]] = t["contractAddress"]
+              if t["contractName"] == "TransparentUpgradeableProxy":
+                  # OZ v5 proxies self-deploy their ProxyAdmin inside the constructor,
+                  # so it surfaces as an additionalContracts CREATE, not a top-level one.
+                  extra = t.get("additionalContracts") or []
+                  if extra:
+                      proxy_admin = extra[0].get("address")
+
+          start_block = None
+          for r in b.get("receipts", []):
+              n = int(r.get("blockNumber", "0x0"), 16)
+              if n and (start_block is None or n < start_block):
+                  start_block = n
+
+          try:
+              prev = json.load(open("prev.json"))
+          except Exception:
+              prev = {}
+          chains = prev.get("chains", {})
+          entry = chains.get(chain, {})
+          entry.update({
+              "safetyNet": created["TransparentUpgradeableProxy"],
+              "implementation": created["SafetyNet"],
+              "proxyAdmin": proxy_admin,
+              "delegatedSafetyNet": created.get("DelegatedSafetyNet"),
+              "startBlock": start_block,
+              "commit": os.environ.get("GITHUB_SHA", ""),
+              "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+          })
+          chains[chain] = entry
+          json.dump({"version": 1, "chains": chains}, open("addresses.json", "w"), indent=2)
+          print(json.dumps({"version": 1, "chains": chains}, indent=2))
+          PY
+          gh release view contract-addresses -R "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create contract-addresses -R "$GITHUB_REPOSITORY" \
+                 --title "Contract addresses (latest)" \
+                 --notes "Rolling manifest of live contract addresses. The static frontend fetches addresses.json from this release at runtime."
+          gh release upload contract-addresses addresses.json --clobber -R "$GITHUB_REPOSITORY"
+          gh release edit contract-addresses -R "$GITHUB_REPOSITORY" \
+            --notes "Rolling manifest of live contract addresses (last update: chain $CHAIN_ID @ ${GITHUB_SHA::7}, $(date -u +%Y-%m-%dT%H:%MZ)). The static frontend fetches addresses.json from this release at runtime."
+
+      - name: Summary
+        env:
+          CHAIN_ID: ${{ steps.chain.outputs.id }}
+        run: |
+          {
+            echo "### SafetyNet stack deployed on ${{ inputs.chain }} (chain $CHAIN_ID)"
+            python3 -c "import json;d=json.load(open('addresses.json'))['chains']['$CHAIN_ID'];[print(f'- **{k}**: \`{v}\`') for k,v in d.items()]"
+            echo ""
+            echo "Published to the \`contract-addresses\` release — the live frontend picks it up on next page load (no rebuild needed)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,10 +1,28 @@
 # Deployments
 
-## Gnosis Chain (chainId 100) — current
+## Rolling manifest (source of truth)
+
+Fresh stacks are deployed by the manual [`contracts-deploy.yml`](.github/workflows/contracts-deploy.yml)
+workflow (etherform scripts, one broadcast: implementation + proxy + DelegatedSafetyNet + token
+allowlist), which publishes the per-chain `addresses.json` manifest to the rolling
+[`contract-addresses` release](https://github.com/BreadchainCoop/safety-net/releases/tag/contract-addresses).
+**The frontend fetches that manifest at runtime**, so a new deployment goes live without a
+frontend rebuild. The tables below are historical snapshots; the release is the source of truth.
+
+## Gnosis Chain (chainId 100) — solidarity-ratio stack (current)
+
+Deployed via `contracts-deploy.yml` (see the rolling release for addresses). Enables the
+Broodfonds support ratio (configured 1–25, Simple-mode default ×22) with the actuarial
+effective-ratio throttle (`getEffectiveRedeemRatio`: group-size risk loading p=2%, z=1.65,
+plus a 6-month pool-runway cap), pool-solvency reverts (`InsufficientPoolFunds`), and
+pro-rata shortfall decommission (`SafetyNetShortfallDistributed`).
+
+## Gnosis Chain (chainId 100) — ratio-1 stack (frozen 2026-07-04)
 
 Deployed 2026-07-02. All contracts verified on [Gnosis Blockscout](https://gnosis.blockscout.com).
 Includes: redeem ratio locked to 1, deposit prepay up to 12 epochs, EIP-712 signed requests
-with deadlines, aggregated frontend views.
+with deadlines, aggregated frontend views. Superseded by the solidarity-ratio stack above —
+kept live (upgradeable proxy) with its test nets, but the app no longer targets it by default.
 
 | Contract | Address |
 |----------|---------|

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -1,13 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Common} from 'script/Common.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 
+import {Common} from 'script/Common.sol';
+import {DelegatedSafetyNet} from 'src/contracts/DelegatedSafetyNet.sol';
+import {SafetyNet} from 'src/contracts/SafetyNet.sol';
+
+/**
+ * @title Deploy
+ * @notice Deploys the full SafetyNet stack in one broadcast: implementation + TransparentProxy
+ *         (with its internal ProxyAdmin) and the standalone {DelegatedSafetyNet} extension
+ *         pointed at the fresh proxy.
+ * @dev Env:
+ *      - PRIVATE_KEY     deployer key (optional; falls back to the script sender)
+ *      - ADMIN_ADDRESS   proxy admin owner / SafetyNet owner (optional; defaults to deployer)
+ *      - ALLOWED_TOKENS  comma-separated ERC20 addresses to allowlist (optional). Only applied
+ *                        when the deployer is the admin — otherwise allowlisting stays a
+ *                        documented post-deploy admin action.
+ */
 contract Deploy is Common {
   function run() public {
     uint256 _privateKey = vm.envOr('PRIVATE_KEY', uint256(0));
     address _deployer = _privateKey == 0 ? msg.sender : vm.addr(_privateKey);
     address _admin = vm.envOr('ADMIN_ADDRESS', _deployer);
+    address[] memory _allowedTokens = vm.envOr('ALLOWED_TOKENS', ',', new address[](0));
 
     if (_privateKey == 0) {
       vm.startBroadcast();
@@ -15,7 +32,15 @@ contract Deploy is Common {
       vm.startBroadcast(_privateKey);
     }
 
-    _deployContracts(_admin);
+    TransparentUpgradeableProxy _proxy = _deployContracts(_admin);
+
+    new DelegatedSafetyNet(address(_proxy));
+
+    if (_admin == _deployer) {
+      for (uint256 i = 0; i < _allowedTokens.length; i++) {
+        SafetyNet(address(_proxy)).setTokenAllowed(_allowedTokens[i], true);
+      }
+    }
 
     vm.stopBroadcast();
   }

--- a/src/contracts/SafetyNet.sol
+++ b/src/contracts/SafetyNet.sol
@@ -5,6 +5,7 @@ import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/Own
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import {Math} from '@openzeppelin/contracts/utils/math/Math.sol';
 
 import {ISafetyNet} from '../interfaces/ISafetyNet.sol';
 import {ReentrancyGuard} from './utils/ReentrancyGuard.sol';
@@ -21,15 +22,46 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   /// @notice Number of days in a month (used for calculating monthly withdrawals)
   uint256 public constant DAYS_IN_A_MONTH = 30;
 
-  /// @notice Minimum redeem ratio
-  /// @dev Together with {MAXIMUM_REDEEM_RATIO} this locks `redeemRatio` to exactly 1 in v1
+  /// @notice Minimum redeem (support) ratio — 1 is a pure savings circle: withdrawals 1:1 with deposits
   uint256 public constant MINIMUM_REDEEM_RATIO = 1;
 
-  /// @notice Maximum redeem ratio
-  /// @dev Locked to 1 in v1: with a ratio > 1, member withdrawable balances (deposits x ratio) would
-  ///      exceed the actual pool funds — insolvency by design — and decommission() would underflow
-  ///      when refunding. Leverage (ratio > 1) is deferred to v2 research.
-  uint256 public constant MAXIMUM_REDEEM_RATIO = 1;
+  /// @notice Maximum redeem (support) ratio a Safety Net can be configured with
+  /// @dev The Dutch Broodfonds convention is ~22x (EUR 33.75-112.50/month dues map to EUR 750-2,500/month
+  ///      sickness support). 25 keeps that reachable with headroom while staying anchored to the
+  ///      actuarial heuristic that one claimant's monthly benefit (dues x ratio) should be coverable
+  ///      by one month of group dues — i.e. ratio <= member count — at the Broodfonds-recommended
+  ///      minimum group size of 25. Ratios > 1 are solidarity leverage: claims exceed deposits and are
+  ///      backed by the pool, so withdrawals are additionally throttled by {getEffectiveRedeemRatio}.
+  uint256 public constant MAXIMUM_REDEEM_RATIO = 25;
+
+  /*//////////////////////////////////////////////////////////////
+                    ACTUARIAL RISK PARAMETERS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Basis-point denominator for the risk math
+  uint256 public constant BPS = 10_000;
+
+  /// @notice Expected share of members drawing support at any given time, in basis points (2%)
+  /// @dev Calibration: Dutch Broodfondsen reported ~1% of 5,000+ participants sick at a time (2015,
+  ///      with a 1-month waiting period and 2-year benefit cap); historical US industrial sickness
+  ///      funds show ~2% of the work-year lost to compensated sickness (EH.net). 2% is the prudent
+  ///      middle of that evidence for self-employed mutual sickness funds.
+  uint256 public constant EXPECTED_SICK_SHARE_BPS = 200;
+
+  /// @notice One-sided prudence factor z applied to the sick-share standard deviation, in centi-units (1.65)
+  /// @dev Standard-deviation premium principle: required margin = z * sqrt(p(1-p)/N), shrinking with
+  ///      group size N (law of large numbers). z = 1.65 targets ~5% ruin probability — the strict end
+  ///      of the 5-10% first-year range regulators accept for new insurers — chosen because an onchain
+  ///      fund has no Broodfonds-Alliance-style reinsurance backstop. (Broodfonds' own 22.2x at N = 50
+  ///      corresponds to z ~= 1.28, the loose end of that range.)
+  uint256 public constant RISK_LOADING_Z_CENTI = 165;
+
+  /// @notice Months of a single claimant's support the pool must hold for full-rate withdrawals (6)
+  /// @dev Reserve-adequacy throttle: a member's monthly support rate is capped at pool / 6, so young
+  ///      funds pay out at reduced rates until the buffer builds (Broodfonds funds build buffers over
+  ///      their first years; the average disability claim runs ~8 months, so 6 months of runway covers
+  ///      the bulk of a typical claim before further dues arrive).
+  uint256 public constant POOL_RUNWAY_MONTHS = 6;
 
   /// @notice Maximum number of future epochs a member can prepay beyond the current epoch
   /// @dev Bounds the deposit allocation loop in {_deposit}; roughly one year of monthly epochs
@@ -240,6 +272,13 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /// @inheritdoc ISafetyNet
+  /// @dev Distributes the pool on wind-down. When the pool covers all withdrawable balances (always
+  ///      true at redeemRatio 1, where claims equal net deposits), every member receives their full
+  ///      withdrawable balance and any surplus is split evenly — identical to v1 behavior, with
+  ///      floor-division dust retained by the contract. When claims exceed the pool (possible at
+  ///      redeemRatio > 1, since claims are deposits x ratio), each member receives a pro-rata share
+  ///      `pool x claim / totalClaims` (floored; dust retained) — the same pro-rata benefit cut
+  ///      mutual sickness funds have historically applied under claim pressure.
   function decommission(uint256 _id) external override nonReentrant {
     SafetyNet memory _safetyNet = safetyNets[_id];
     uint256 _safetyNetMembersLength = _safetyNet.members.length;
@@ -250,23 +289,46 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
 
     safetyNetBalance[_id] = 0;
 
+    uint256 _totalWithdrawable;
     for (uint256 i = 0; i < _safetyNetMembersLength; i++) {
-      address _member = _safetyNet.members[i];
-      uint256 _amount = memberWithdrawableBalance[_id][_member];
-      if (_amount > 0) {
-        memberWithdrawableBalance[_id][_member] = 0;
-        _balance -= _amount;
-
-        IERC20(_safetyNet.token).safeTransfer(_member, _amount);
-      }
+      _totalWithdrawable += memberWithdrawableBalance[_id][_safetyNet.members[i]];
     }
 
-    if (_balance > 0) {
-      uint256 _amount = _balance / _safetyNetMembersLength;
+    if (_totalWithdrawable <= _balance) {
+      // Covered: pay claims in full, then split any surplus evenly (dust stays in the contract)
+      for (uint256 i = 0; i < _safetyNetMembersLength; i++) {
+        address _member = _safetyNet.members[i];
+        uint256 _amount = memberWithdrawableBalance[_id][_member];
+        if (_amount > 0) {
+          memberWithdrawableBalance[_id][_member] = 0;
+          _balance -= _amount;
+
+          IERC20(_safetyNet.token).safeTransfer(_member, _amount);
+        }
+      }
+
+      if (_balance > 0) {
+        uint256 _amount = _balance / _safetyNetMembersLength;
+
+        for (uint256 i = 0; i < _safetyNetMembersLength; i++) {
+          address _member = _safetyNet.members[i];
+          IERC20(_safetyNet.token).safeTransfer(_member, _amount);
+        }
+      }
+    } else {
+      // Shortfall (only reachable at redeemRatio > 1): pro-rata by claim, dust stays in the contract
+      emit SafetyNetShortfallDistributed(_id, _balance, _totalWithdrawable);
 
       for (uint256 i = 0; i < _safetyNetMembersLength; i++) {
         address _member = _safetyNet.members[i];
-        IERC20(_safetyNet.token).safeTransfer(_member, _amount);
+        uint256 _claim = memberWithdrawableBalance[_id][_member];
+        if (_claim > 0) {
+          memberWithdrawableBalance[_id][_member] = 0;
+          uint256 _payout = Math.mulDiv(_balance, _claim, _totalWithdrawable);
+          if (_payout > 0) {
+            IERC20(_safetyNet.token).safeTransfer(_member, _payout);
+          }
+        }
       }
     }
 
@@ -589,6 +651,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
       duesRemaining: (_accruingDues && _paid < _target) ? _target - _paid : 0,
       currentEpochIndex: _currentEpochIndex,
       isDecommissionable: isDecommissionable(_id),
+      effectiveRedeemRatio: getEffectiveRedeemRatio(_id, _member),
       requests: getSafetyNetRequests(_id)
     });
   }
@@ -611,9 +674,10 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
    *      remaining dues are filled first, then the next epoch, and so on, up to
    *      `MAX_PREPAY_EPOCHS` epochs beyond the current one. Reverts with
    *      {ExceedsDepositAmount} if the value cannot be fully allocated within that window.
-   *      The full value is credited to `safetyNetBalance` and `memberWithdrawableBalance`
-   *      immediately (redeemRatio is 1, so deposits are fully backed; prepaid funds return
-   *      through the normal withdrawable-balance refund on decommission).
+   *      The pool (`safetyNetBalance`) is credited the deposited value, while the member's
+   *      withdrawable balance is credited `value x redeemRatio` — at ratio 1 deposits are fully
+   *      backed; at higher ratios the excess is a solidarity claim on the shared pool, throttled
+   *      at withdrawal time by {getEffectiveRedeemRatio} and settled pro-rata on decommission.
    */
   function _deposit(uint256 _id, uint256 _value, address _member) internal {
     SafetyNet storage _safetyNet = safetyNets[_id];
@@ -709,7 +773,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     if (!isMember[_id][_member]) revert NotMember();
     if (_safetyNet.safetyNetStart == 0) revert NotActive();
 
-    uint256 _dailyWithdrawableAmount = _getDailyWithdrawableAmount(_id, _member, _safetyNet.redeemRatio);
+    uint256 _dailyWithdrawableAmount = _getDailyWithdrawableAmount(_id, _member);
 
     uint256 _withdrawAmount = _dailyWithdrawableAmount * _daysRequested;
 
@@ -720,8 +784,7 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
       if (smallWithdrawsCount[_id][currentEpochIndex][_member] > _safetyNet.smallWithdrawsLimit) {
         revert ExceedsSmallWithdrawalLimit();
       }
-      memberWithdrawableBalance[_id][_member] -= _withdrawAmount;
-      safetyNetBalance[_id] -= _withdrawAmount;
+      _deduct(_id, _member, _withdrawAmount);
       IERC20(_safetyNet.token).safeTransfer(_member, _withdrawAmount);
 
       emit FundsWithdrawn(_id, _member, _withdrawAmount);
@@ -733,11 +796,36 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     }
   }
 
-  /// @dev Calculates the daily withdrawal for a member in a Safety Net
-  function _getDailyWithdrawableAmount(uint256 _id, address _member, uint256 _redeemRatio) internal view returns (uint256) {
+  /// @dev Calculates the daily withdrawal for a member: monthly contribution x the member's current
+  ///      EFFECTIVE support ratio (configured ratio throttled by the actuarial caps) / 30
+  function _getDailyWithdrawableAmount(uint256 _id, address _member) internal view returns (uint256) {
     uint256 _memberContribute = safetyNetMemberContribute[_id][_member];
-    uint256 _monthlyWithdrawalAmount = _memberContribute * _redeemRatio;
+    uint256 _monthlyWithdrawalAmount = _memberContribute * getEffectiveRedeemRatio(_id, _member);
     return _monthlyWithdrawalAmount / DAYS_IN_A_MONTH;
+  }
+
+  /// @inheritdoc ISafetyNet
+  function getEffectiveRedeemRatio(uint256 _id, address _member) public view override returns (uint256) {
+    uint256 _configured = safetyNets[_id].redeemRatio;
+    // A savings circle (ratio 1) is fully backed by deposits — never throttled. Also covers
+    // nonexistent/decommissioned nets, whose zeroed struct reads ratio 0.
+    if (_configured <= MINIMUM_REDEEM_RATIO) return _configured;
+
+    // Group-size cap (law of large numbers): 1 / (p + z * sqrt(p(1-p)/N)), all in basis points.
+    // sqrt(p_bps * (BPS - p_bps) / N) is the sick-share standard deviation expressed in bps.
+    uint256 _n = safetyNets[_id].members.length;
+    uint256 _loadingBps = (RISK_LOADING_Z_CENTI * Math.sqrt(EXPECTED_SICK_SHARE_BPS * (BPS - EXPECTED_SICK_SHARE_BPS) / _n)) / 100;
+    uint256 _effective = Math.min(_configured, BPS / (EXPECTED_SICK_SHARE_BPS + _loadingBps));
+
+    // Pool-coverage cap (reserve adequacy): the pool must hold POOL_RUNWAY_MONTHS months of this
+    // member's support rate, so monthly support <= pool / POOL_RUNWAY_MONTHS.
+    uint256 _contribute = safetyNetMemberContribute[_id][_member];
+    if (_contribute > 0) {
+      _effective = Math.min(_effective, safetyNetBalance[_id] / (POOL_RUNWAY_MONTHS * _contribute));
+    }
+
+    // The savings-circle floor is always solvent: at ratio 1 every claim is backed 1:1 by deposits
+    return Math.max(_effective, MINIMUM_REDEEM_RATIO);
   }
 
   /// @dev Check if a request is contestable by comparing the current timestamp with the request's timestamp and the contest window
@@ -762,10 +850,16 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /// @dev Deducts `_amount` from a member’s withdrawable balance and the Safety Net’s total balance.
-  ///      Reverts with `NotWithdrawable` if balance is insufficient.
+  ///      Reverts with `NotWithdrawable` if the member's balance is insufficient, and with
+  ///      `InsufficientPoolFunds` if the pool cannot cover the payout (possible at redeemRatio > 1,
+  ///      where withdrawable balances are leveraged claims). Every payout path routes through here,
+  ///      so the pool can never underflow.
   function _deduct(uint256 _safetyNetId, address _member, uint256 _amount) internal {
     if (memberWithdrawableBalance[_safetyNetId][_member] < _amount) {
       revert NotWithdrawable();
+    }
+    if (safetyNetBalance[_safetyNetId] < _amount) {
+      revert InsufficientPoolFunds();
     }
     memberWithdrawableBalance[_safetyNetId][_member] -= _amount;
     safetyNetBalance[_safetyNetId] -= _amount;
@@ -779,7 +873,10 @@ contract SafetyNet is ISafetyNet, ReentrancyGuard, OwnableUpgradeable {
     bool _vetoed = isVetoed[_requestId];
     bool _executed = isExecuted[_requestId];
     bool _commissioned = safetyNets[_request.safetyNetId].owner != address(0);
-    bool _fundsAvailable = memberWithdrawableBalance[_request.safetyNetId][_request.owner] >= _request.amount;
+    // Mirrors _deduct: the member's claim AND the pool must both cover the amount, so the
+    // frontend's Execute gating reflects the real execution rule
+    bool _fundsAvailable = memberWithdrawableBalance[_request.safetyNetId][_request.owner] >= _request.amount
+      && safetyNetBalance[_request.safetyNetId] >= _request.amount;
 
     _requestView = RequestView({
       id: _requestId,

--- a/src/interfaces/ISafetyNet.sol
+++ b/src/interfaces/ISafetyNet.sol
@@ -24,7 +24,11 @@ interface ISafetyNet {
   /// @param members List of joined member addresses; must be empty at creation (the owner is pushed as the sole member) and grows via redeemInvite()
   /// @param initialDeposit Initial deposit required to join
   /// @param fixedDeposit Fixed deposit fee amount
-  /// @param redeemRatio Ratio of deposit to withdrawal; must be exactly 1 in v1 (leverage is disabled), field retained for forward-compatibility
+  /// @param redeemRatio Configured support ratio: a member in need may draw up to `redeemRatio` x their
+  ///        monthly contribution per month (Broodfonds convention is ~22x). Must be within
+  ///        [MINIMUM_REDEEM_RATIO, MAXIMUM_REDEEM_RATIO]. Values > 1 are solidarity leverage — claims are
+  ///        backed by the shared pool, not individual deposits — and are throttled at withdrawal time by
+  ///        the actuarial effective-ratio cap (see getEffectiveRedeemRatio)
   /// @param contestWindow Duration of the contest period for requests
   /// @param epochDuration Duration of each epoch in seconds
   /// @param smallWithdrawsLimit Maximum amount allowed for small withdrawals
@@ -96,6 +100,7 @@ interface ISafetyNet {
   /// @param duesRemaining Amount the queried member still owes this epoch
   /// @param currentEpochIndex The current epoch index of the Safety Net
   /// @param isDecommissionable Whether the Safety Net can be decommissioned
+  /// @param effectiveRedeemRatio The queried member's current effective support ratio (see getEffectiveRedeemRatio)
   /// @param requests The Safety Net's requests with derived status
   struct SafetyNetDetails {
     SafetyNet safetyNet;
@@ -107,6 +112,7 @@ interface ISafetyNet {
     uint256 duesRemaining;
     uint256 currentEpochIndex;
     bool isDecommissionable;
+    uint256 effectiveRedeemRatio;
     RequestView[] requests;
   }
 
@@ -154,6 +160,14 @@ interface ISafetyNet {
   /// @notice Emitted when a Safety Net is decommissioned
   /// @param id Unique identifier of the Safety Net
   event SafetyNetDecommissioned(uint256 indexed id);
+
+  /// @notice Emitted when a decommission distributes a shortfall pool pro-rata
+  /// @dev Only possible when `redeemRatio` > 1: total withdrawable claims exceeded the pool,
+  ///      so each member received `pool x claim / totalClaims` instead of their full balance
+  /// @param id Unique identifier of the Safety Net
+  /// @param poolBalance The pool balance that was distributed
+  /// @param totalWithdrawable The total withdrawable claims the pool could not fully cover
+  event SafetyNetShortfallDistributed(uint256 indexed id, uint256 poolBalance, uint256 totalWithdrawable);
 
   /// @notice Emitted when a member deposits to a Safety Net
   /// @param id Unique identifier of the Safety Net
@@ -249,6 +263,12 @@ interface ISafetyNet {
 
   /// @notice Thrown if the Safety Net cannot be withdrawn from
   error NotWithdrawable();
+
+  /// @notice Thrown when the Safety Net pool balance cannot cover a payout
+  /// @dev Possible when `redeemRatio` > 1: withdrawable balances are leveraged solidarity claims
+  ///      (deposits x ratio), not fully-backed deposits, so the pool can run short. The member can
+  ///      retry once dues replenish the pool, or the net can be decommissioned for a pro-rata split.
+  error InsufficientPoolFunds();
 
   /// @notice Thrown when the deposit window is closed
   error DepositWindowClosed();
@@ -556,6 +576,18 @@ interface ISafetyNet {
   /// @param member The member address to compute member-specific fields for
   /// @return details The aggregated Safety Net details
   function getSafetyNetDetails(uint256 id, address member) external view returns (SafetyNetDetails memory details);
+
+  /// @notice The support ratio actually applied to a member's withdrawals right now
+  /// @dev `min(configured redeemRatio, group-size cap, pool-coverage cap)`, floored at 1.
+  ///      The group-size cap is an actuarial risk-loading bound `1 / (p + z*sqrt(p(1-p)/N))`
+  ///      (expected sick share p, prudence factor z — see the constants in SafetyNet); the
+  ///      pool-coverage cap requires the pool to hold POOL_RUNWAY_MONTHS months of the member's
+  ///      support rate. Ratio-1 nets (pure savings circles) are never throttled: every claim is
+  ///      fully backed by deposits.
+  /// @param id The Safety Net ID
+  /// @param member The member whose contribution level anchors the pool-coverage cap
+  /// @return effectiveRatio The effective support ratio (>= 1)
+  function getEffectiveRedeemRatio(uint256 id, address member) external view returns (uint256 effectiveRatio);
 
   /// @notice Returns aggregated details for every Safety Net a member has joined
   /// @param member The member address

--- a/test/invariants/fuzz/SafetyNetFuzz_Ratio.t.sol
+++ b/test/invariants/fuzz/SafetyNetFuzz_Ratio.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Math} from '@openzeppelin/contracts/utils/math/Math.sol';
+
+import {SafetyNetFuzzBase} from './SafetyNetFuzzBase.t.sol';
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+
+/// @notice Solidarity-ratio invariants fuzzed across the full configurable range [1, 25]:
+///         the pool can never underflow (every payout either moves exactly its amount or
+///         reverts cleanly), the effective ratio stays within [1, configured], and the
+///         pro-rata decommission branch conserves the pool to within member-count dust.
+contract SafetyNetFuzz_Ratio is SafetyNetFuzzBase {
+  /// @dev Deposit/withdraw soak at an arbitrary ratio: token accounting must stay exact and
+  ///      the effective ratio must stay within bounds after every operation.
+  function testFuzz_RatioSoak_PoolNeverUnderflows(uint8 ratioRaw, uint8 epochsRaw, uint8 opsRaw, uint256 seed) public {
+    uint256 ratio = bound(uint256(ratioRaw), 1, 25);
+    uint256 epochs = bound(uint256(epochsRaw), 1, 6);
+    uint256 ops = bound(uint256(opsRaw), 3, 15);
+
+    ISafetyNet.SafetyNet memory config = _safeCfg;
+    config.redeemRatio = ratio;
+    uint256 id = _createStarted(config, _defaultMembers);
+
+    _mintApprove(_member1, 1e24, address(_safetyNet));
+    _mintApprove(_member2, 1e24, address(_safetyNet));
+    _mintApprove(_member3, 1e24, address(_safetyNet));
+
+    for (uint256 e = 0; e < epochs; e++) {
+      for (uint256 k = 0; k < ops; k++) {
+        seed = uint256(keccak256(abi.encodePacked(seed, e, k)));
+        address actor = _pick(_defaultMembers, seed);
+
+        if (seed % 3 != 0) {
+          _depositAs(actor, id, 1e18 + (seed % 50e18));
+        } else {
+          _tryWithdraw(id, actor, 1 + (seed % 40));
+        }
+
+        // The pool is always fully collateralized by real tokens
+        assertGe(_token.balanceOf(address(_safetyNet)), _safetyNet.safetyNetBalance(id), 'pool over-collateralized');
+
+        // The effective ratio never exceeds the configured aspiration and never drops below 1
+        uint256 effective = _safetyNet.getEffectiveRedeemRatio(id, actor);
+        assertLe(effective, ratio, 'effective <= configured');
+        assertGe(effective, 1, 'effective >= 1');
+      }
+      vm.warp(block.timestamp + config.epochDuration + 1);
+    }
+  }
+
+  /// @dev A withdrawal either transfers exactly its amount out of the pool or reverts with one
+  ///      of the expected guards — never a panic/underflow.
+  function _tryWithdraw(uint256 id, address actor, uint256 daysRequested) internal {
+    uint256 poolBefore = _safetyNet.safetyNetBalance(id);
+    uint256 balBefore = _token.balanceOf(actor);
+
+    vm.prank(actor);
+    try _safetyNet.withdraw(id, daysRequested, '') {
+      uint256 poolAfter = _safetyNet.safetyNetBalance(id);
+      uint256 paid = _token.balanceOf(actor) - balBefore;
+      // Instant payout moved exactly the pool delta; a created request moves nothing yet
+      assertEq(poolBefore - poolAfter, paid, 'pool delta matches transfer');
+    } catch (bytes memory err) {
+      bytes4 sel = bytes4(err);
+      assertTrue(
+        sel == ISafetyNet.NotWithdrawable.selector || sel == ISafetyNet.InsufficientPoolFunds.selector
+          || sel == ISafetyNet.ExceedsSmallWithdrawalLimit.selector,
+        'only expected withdraw guards'
+      );
+    }
+  }
+
+  /// @dev Shortfall decommission at ratio > 1: every member receives pool x claim / totalClaims
+  ///      and the whole pool leaves the contract except floor-division dust (< member count wei).
+  function testFuzz_Decommission_ProRataConservesPool(uint8 ratioRaw, uint256 prepaySeed) public {
+    uint256 ratio = bound(uint256(ratioRaw), 2, 25);
+
+    ISafetyNet.SafetyNet memory config = _safeCfg;
+    config.redeemRatio = ratio;
+    uint256 id = _createStarted(config, _defaultMembers);
+
+    _mintApprove(_member1, 1e24, address(_safetyNet));
+    _mintApprove(_member2, 1e24, address(_safetyNet));
+    _mintApprove(_member3, 1e24, address(_safetyNet));
+
+    // Onboard everyone, then skew claims with random prepays so the pro-rata shares differ
+    for (uint256 i = 0; i < _defaultMembers.length; i++) {
+      _depositAs(_defaultMembers[i], id, _safeCfg.initialDeposit);
+      uint256 extra = uint256(keccak256(abi.encodePacked(prepaySeed, i))) % (3 * _safeCfg.fixedDeposit);
+      if (extra > 0) {
+        vm.prank(_defaultMembers[i]);
+        _safetyNet.deposit(id, extra);
+      }
+    }
+
+    uint256 totalClaims;
+    uint256[] memory claims = new uint256[](_defaultMembers.length);
+    for (uint256 i = 0; i < _defaultMembers.length; i++) {
+      claims[i] = _safetyNet.memberWithdrawableBalance(id, _defaultMembers[i]);
+      totalClaims += claims[i];
+    }
+    uint256 pool = _safetyNet.safetyNetBalance(id);
+    // At ratio >= 2 with no withdrawals, claims (deposits x ratio) always exceed the pool
+    assertGt(totalClaims, pool, 'shortfall scenario');
+
+    // Prepays cover at most 3 future epochs, so after 5 epochs some epoch is unpaid for
+    // every member — the net is guaranteed decommissionable
+    vm.warp(block.timestamp + 5 * config.epochDuration + 1);
+
+    uint256[] memory before = new uint256[](_defaultMembers.length);
+    for (uint256 i = 0; i < _defaultMembers.length; i++) {
+      before[i] = _token.balanceOf(_defaultMembers[i]);
+    }
+
+    vm.prank(_member1);
+    _safetyNet.decommission(id);
+
+    uint256 paidOut;
+    for (uint256 i = 0; i < _defaultMembers.length; i++) {
+      uint256 delta = _token.balanceOf(_defaultMembers[i]) - before[i];
+      assertEq(delta, Math.mulDiv(pool, claims[i], totalClaims), 'pro-rata share');
+      paidOut += delta;
+      assertEq(_safetyNet.memberWithdrawableBalance(id, _defaultMembers[i]), 0, 'claim zeroed');
+    }
+
+    assertLe(pool - paidOut, _defaultMembers.length, 'dust below member count');
+    assertEq(_safetyNet.safetyNetBalance(id), 0, 'pool accounting zeroed');
+  }
+}

--- a/test/unit/SafetyNetUnit.sol
+++ b/test/unit/SafetyNetUnit.sol
@@ -408,14 +408,29 @@ contract SafetyNetUnit is SafetyNetUnitBase {
     _sn.create('', _safetyNet);
   }
 
-  function test_CreateWhenRedeemRatioIsGreaterThanOne() external {
+  function test_CreateWhenRedeemRatioIsAboveMaximum() external {
     _allowToken(address(_token));
     ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
-
-    // Leverage is disabled in v1: the redeem ratio must be exactly 1
-    _safetyNet.redeemRatio = 2;
+    _safetyNet.redeemRatio = _sn.MAXIMUM_REDEEM_RATIO() + 1;
     vm.expectRevert(ISafetyNet.InvalidRatio.selector);
     _sn.create('', _safetyNet);
+  }
+
+  function test_CreateWhenRedeemRatioIsAtMaximum() external {
+    _allowToken(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    _safetyNet.redeemRatio = _sn.MAXIMUM_REDEEM_RATIO();
+    uint256 id = _sn.create('', _safetyNet);
+    assertEq(_sn.getSafetyNet(id).redeemRatio, 25);
+  }
+
+  function test_CreateWhenRedeemRatioIsBroodfondsDefault() external {
+    _allowToken(address(_token));
+    ISafetyNet.SafetyNet memory _safetyNet = _defaultSafetyNet(address(_token));
+    // The Broodfonds convention: ~22x monthly contribution of sickness support
+    _safetyNet.redeemRatio = 22;
+    uint256 id = _sn.create('', _safetyNet);
+    assertEq(_sn.getSafetyNet(id).redeemRatio, 22);
   }
 
   function test_CreateWhenRedeemRatioIsOne() external {

--- a/test/unit/SolidarityRatioUnit.sol
+++ b/test/unit/SolidarityRatioUnit.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {ISafetyNet} from 'src/interfaces/ISafetyNet.sol';
+
+import {SafetyNetUnitBase} from 'test/unit/SafetyNetUnit.sol';
+
+/// @dev Broodfonds solidarity-ratio behavior: configured ratios above 1, the actuarial
+///      effective-ratio caps (group size + pool coverage), pool-solvency reverts, and the
+///      pro-rata shortfall branch of decommission().
+///
+///      Expected group-size caps with p = 2% (200 bps) and z = 1.65 (integer math, floors):
+///        N=2 -> x5   N=3 -> x6   N=25 -> x15   N=50 -> x19
+contract SolidarityRatioUnit is SafetyNetUnitBase {
+  function setUp() public override {
+    super.setUp();
+    // The base funds alice/bob/carol; ratio tests also onboard the requester
+    _token.mint(_requester, 1_000_000 ether);
+    vm.prank(_requester);
+    _token.approve(address(_sn), type(uint256).max);
+    _allowToken(address(_token));
+  }
+
+  // ---------- helpers ----------
+
+  /// @dev Default net reconfigured as a Broodfonds-style x22 solidarity fund
+  function _ratioSafetyNet(uint256 _initialDeposit, uint256 _autoThreshold) internal view returns (ISafetyNet.SafetyNet memory _cfg) {
+    _cfg = _defaultSafetyNet(address(_token));
+    _cfg.redeemRatio = 22;
+    _cfg.fixedDeposit = 10 ether;
+    _cfg.initialDeposit = _initialDeposit;
+    _cfg.autoThreshold = _autoThreshold;
+  }
+
+  // ---------- deposit crediting ----------
+
+  function test_DepositCreditsWithdrawableAtConfiguredRatio() external {
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(200 ether, 50 ether));
+    _payInitial(id, _alice);
+
+    // The pool holds the actual tokens; the member's claim is leveraged by the ratio
+    assertEq(_sn.safetyNetBalance(id), 200 ether);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), 200 ether * 22);
+  }
+
+  // ---------- effective ratio ----------
+
+  function test_EffectiveRatioGroupSizeCapBinds() external {
+    // N=2 group cap is x5; pool 400e vs 6 months of 10e dues -> pool cap x6, so group cap binds
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(200 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    assertEq(_sn.getEffectiveRedeemRatio(id, _alice), 5);
+  }
+
+  function test_EffectiveRatioPoolCoverageCapBinds() external {
+    // Pool 200e must hold 6 months of support: cap = 200 / (6 * 10) = x3 < group cap x5
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(100 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    assertEq(_sn.getEffectiveRedeemRatio(id, _alice), 3);
+  }
+
+  function test_EffectiveRatioFloorsAtSavingsCircle() external {
+    // Pool 60e -> pool cap = 60 / 60 = x1: the fund pays out at savings-circle rate, never 0
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(30 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    assertEq(_sn.getEffectiveRedeemRatio(id, _alice), 1);
+  }
+
+  function test_EffectiveRatioNeverThrottlesSavingsCircles() external {
+    // Ratio-1 nets are fully backed by deposits: the risk caps must not apply
+    uint256 id = _createDefaultStarted(_defaultSafetyNet(address(_token)));
+    assertEq(_sn.getEffectiveRedeemRatio(id, _alice), 1);
+  }
+
+  function test_EffectiveRatioExposedInDetails() external {
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(100 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    ISafetyNet.SafetyNetDetails memory _details = _sn.getSafetyNetDetails(id, _alice);
+    assertEq(_details.effectiveRedeemRatio, _sn.getEffectiveRedeemRatio(id, _alice));
+    assertEq(_details.effectiveRedeemRatio, 3);
+  }
+
+  // ---------- withdrawals ----------
+
+  function test_WithdrawPaysAtEffectiveRatio() external {
+    // Effective ratio x5 (group cap, see above): 3 days = 10e * 5 / 30 * 3
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(200 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    uint256 _daily = (_sn.getSafetyNet(id).fixedDeposit * 5) / 30;
+    uint256 _expected = _daily * 3;
+    uint256 _before = _token.balanceOf(_alice);
+
+    vm.prank(_alice);
+    _sn.withdraw(id, 3, '');
+
+    assertEq(_token.balanceOf(_alice) - _before, _expected);
+    assertEq(_sn.safetyNetBalance(id), 400 ether - _expected);
+  }
+
+  function test_WithdrawRevertsWhenPoolCannotCover() external {
+    // Pool 60e, effective ratio floored at x1: 200 days = 66.6e > pool, still under the
+    // instant threshold (100e) so the payout is attempted immediately and must revert
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(30 ether, 100 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+
+    vm.prank(_alice);
+    vm.expectRevert(ISafetyNet.InsufficientPoolFunds.selector);
+    _sn.withdraw(id, 200, '');
+  }
+
+  function test_ExecuteRequestRevertsWhenPoolCannotCover() external {
+    // Two large requests against a pool that only covers one: the second execution reverts
+    ISafetyNet.SafetyNet memory _cfg = _ratioSafetyNet(60 ether, 1 ether);
+    _cfg.minimumMembers = 3;
+    _cfg.maximumMembers = 5;
+    uint256 id = _createRequesterStarted(_cfg);
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+    _payInitial(id, _requester);
+    // Pool 180e; effective ratio min(x22, group x6, pool 180/60 = x3) = x3; daily = 1e
+
+    vm.prank(_requester);
+    _sn.withdraw(id, 120, ''); // request 0: 120e > 1e threshold
+    vm.prank(_alice);
+    _sn.withdraw(id, 100, ''); // request 1: 100e
+
+    vm.warp(block.timestamp + _cfg.contestWindow + 1);
+
+    _sn.executeContestedWithdrawal(1); // pays alice 100e, pool drops to 80e
+
+    // The view must reflect that the pool no longer covers request 0 …
+    ISafetyNet.RequestView memory _view = _sn.getSafetyNetRequests(id)[0];
+    assertEq(_view.request.amount, 120 ether);
+    assertFalse(_view.isExecutable);
+    assertGe(_sn.memberWithdrawableBalance(id, _requester), 120 ether);
+
+    // … and execution must revert rather than underflow the pool
+    vm.expectRevert(ISafetyNet.InsufficientPoolFunds.selector);
+    _sn.executeContestedWithdrawal(0);
+  }
+
+  // ---------- decommission: pro-rata shortfall ----------
+
+  function test_DecommissionShortfallDistributesProRata() external {
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(100 ether, 50 ether));
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+    // Alice prepays 5 future epochs, making the claims unequal
+    vm.prank(_alice);
+    _sn.deposit(id, 50 ether);
+
+    // Pool 250e; claims: alice (100+50)*22 = 3300e, bob 100*22 = 2200e; total 5500e > pool
+    // Bob misses epoch 1 -> decommissionable after epoch 1 fully elapses
+    vm.warp(block.timestamp + 2 * _sn.getSafetyNet(id).epochDuration + 1);
+
+    uint256 _aliceBefore = _token.balanceOf(_alice);
+    uint256 _bobBefore = _token.balanceOf(_bob);
+
+    vm.expectEmit(true, false, false, true, address(_sn));
+    emit ISafetyNet.SafetyNetShortfallDistributed(id, 250 ether, 5500 ether);
+    vm.prank(_alice);
+    _sn.decommission(id);
+
+    // Pro-rata: pool * claim / totalClaims — conservation is exact here (no dust)
+    assertEq(_token.balanceOf(_alice) - _aliceBefore, (250 ether * 3300) / 5500);
+    assertEq(_token.balanceOf(_bob) - _bobBefore, (250 ether * 2200) / 5500);
+    assertEq(_sn.memberWithdrawableBalance(id, _alice), 0);
+    assertEq(_sn.memberWithdrawableBalance(id, _bob), 0);
+    assertEq(_sn.safetyNetBalance(id), 0);
+  }
+
+  function test_DecommissionShortfallSkipsZeroClaimMembers() external {
+    uint256 id = _createDefaultStarted(_ratioSafetyNet(100 ether, 50 ether));
+    // Only alice onboards; bob has no claim
+    _payInitial(id, _alice);
+
+    vm.warp(block.timestamp + _sn.getSafetyNet(id).epochDuration + 1);
+
+    uint256 _aliceBefore = _token.balanceOf(_alice);
+    uint256 _bobBefore = _token.balanceOf(_bob);
+
+    vm.prank(_alice);
+    _sn.decommission(id);
+
+    // Alice holds 100% of claims and receives the whole pool; bob gets nothing
+    assertEq(_token.balanceOf(_alice) - _aliceBefore, 100 ether);
+    assertEq(_token.balanceOf(_bob), _bobBefore);
+  }
+
+  function test_DecommissionShortfallConservesPool() external {
+    // Dust check with a pool that does not divide evenly across claims
+    ISafetyNet.SafetyNet memory _cfg = _ratioSafetyNet(100 ether, 50 ether);
+    _cfg.minimumMembers = 3;
+    uint256 id = _createRequesterStarted(_cfg);
+    _payInitial(id, _alice);
+    _payInitial(id, _bob);
+    _payInitial(id, _requester);
+    // Unequal claims: alice prepays 7e (partial epoch fill)
+    vm.prank(_alice);
+    _sn.deposit(id, 7 ether);
+
+    vm.warp(block.timestamp + 2 * _sn.getSafetyNet(id).epochDuration + 1);
+
+    uint256 _pool = _sn.safetyNetBalance(id);
+    uint256 _contractBefore = _token.balanceOf(address(_sn));
+
+    vm.prank(_alice);
+    _sn.decommission(id);
+
+    // Everything paid out except floor-division dust, which stays in the contract
+    uint256 _paidOut = _contractBefore - _token.balanceOf(address(_sn));
+    assertLe(_pool - _paidOut, 3); // dust < member count wei
+    assertGt(_paidOut, 0);
+  }
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,7 +1,18 @@
-# SafetyNet proxy address on Gnosis (chain 100). Falls back to the canonical
-# deployment in src/lib/config.ts when unset; set to zero address to disable
-# on-chain calls. Malformed values fail the build (zod-validated).
+# SafetyNet proxy address on Gnosis (chain 100). LEAVE UNSET in production:
+# the app fetches the latest deployment at runtime from the repo's rolling
+# `contract-addresses` GitHub release (see contracts-deploy.yml), falling back
+# to the baked default in src/lib/config.ts. Setting this PINS the address —
+# the runtime manifest is ignored for it (deterministic E2E/preview builds).
+# Malformed values fail the build (zod-validated).
 NEXT_PUBLIC_SAFETYNET_ADDRESS=
+
+# DelegatedSafetyNet extension address. Same pin semantics as above.
+NEXT_PUBLIC_DELEGATED_ADDRESS=
+
+# Runtime address manifest control: unset = fetch the GitHub release manifest;
+# "off" = never fetch (baked/pinned addresses only); an http(s) URL = fetch
+# that manifest instead (tests/previews).
+NEXT_PUBLIC_ADDRESSES_URL=
 
 # Gnosis RPC endpoint (default: https://rpc.gnosischain.com, with public
 # fallbacks — see src/lib/wagmi.ts)

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -23,7 +23,7 @@ const SECTIONS: Section[] = [
     title: "1. Create a Safety Net",
     body: [
       "A Safety Net is a shared savings pool with rules everyone agrees to up front: which token you save in, how much everyone deposits, and how withdrawals are approved.",
-      "You create the net alone and become its first member — no address lists. Pick the group size, the one-off initial deposit, and the recurring deposit due every epoch (e.g. every 30 days). Deposits convert 1:1 into withdrawable balance — the redeem ratio is locked to ×1 in v1, so there's no leverage. Small withdrawals below the instant threshold pay out immediately; larger ones go through group review with a contest window and threshold.",
+      "You create the net alone and become its first member — no address lists. Pick the group size, the one-off initial deposit, and the recurring deposit due every epoch (e.g. every 30 days). Pick a support ratio too: at ×1 the net is a pure savings circle, while Broodfonds-style groups use ≈×22 — a member in need can draw about 22× their monthly contribution per month from the shared pool, throttled to what the group size and pool can sustainably back. Small withdrawals below the petty-cash threshold pay out immediately; larger ones go through group review with a contest window and threshold.",
       "Right after creation the app generates one single-use invite link per open seat, signed by your wallet — share those privately to bring in the rest of your group.",
     ],
   },
@@ -43,7 +43,7 @@ const SECTIONS: Section[] = [
     title: "3. Deposit",
     body: [
       "Deposits open once the owner starts the net. Your very first deposit is the initial deposit, paid exactly and in one payment — it activates your membership and sets your recurring dues.",
-      "After that, you owe the recurring deposit every epoch. You can pay it in parts, and you can also pay another member's dues for them (the tokens still come from their wallet — they only save the gas). Every deposit adds 1:1 to your withdrawable balance.",
+      "After that, you owe the recurring deposit every epoch. You can pay it in parts, and you can also pay another member's dues for them (the tokens still come from their wallet — they only save the gas). Every deposit multiplies by the support ratio into your withdrawable balance.",
       "You can also pay ahead: deposit more than this epoch's dues and the extra prepays future epochs — the current epoch's remaining dues fill first, then the next epoch, and so on, up to 12 epochs ahead. The app previews exactly how a deposit will be allocated before you send it.",
       "Short on BREAD? Use the \"Get BREAD\" button in the nav (or the prompt on the deposit form) to mint BREAD 1:1 from xDAI — and, on embedded-wallet sign-ins, to buy xDAI first.",
       "Turn on automatic deposits so the group can cover your dues from a pre-approved allowance — approve the SafetyNet proxy once, flip it on, and a keeper or another member can pay your owed dues so you never miss an epoch. It's non-custodial and you can turn it off any time.",
@@ -54,7 +54,7 @@ const SECTIONS: Section[] = [
     gif: "withdraw",
     title: "4. Withdraw",
     body: [
-      'Withdrawals are measured in "days of income": one day is worth your monthly contribution ÷ 30 (the redeem ratio is ×1 in v1). Pick how many days you need and the app shows the exact amount.',
+      'Withdrawals are measured in "days of support": one day is worth your monthly contribution × your current effective support ratio ÷ 30. The effective ratio ramps up as the group and its pool grow. Pick how many days you need and the app shows the exact amount.',
       "If the amount is at or below the net's instant threshold it's transferred immediately (up to a per-epoch limit of instant withdrawals). Anything larger creates a withdrawal request that your group can review first.",
       "For a large withdrawal you add a short reason (up to 200 words) explaining why you need the funds. It's stored on-chain and shown to every member, so they have the context to decide whether to contest.",
     ],

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -63,3 +63,53 @@ body {
 .nav-account-menu img[alt=""] {
   display: none;
 }
+
+/* --------------------------------------------------------------------------
+   Range sliders (slider-field.tsx). The filled portion of the track is
+   painted by the component with an inline gradient (WebKit has no
+   ::-webkit-range-progress); these rules style the track shape and thumb.
+   -------------------------------------------------------------------------- */
+.slider-input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: var(--color-paper-2, #e5e0d3);
+  cursor: pointer;
+}
+
+.slider-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 1.25rem;
+  width: 1.25rem;
+  border-radius: 9999px;
+  background: var(--color-primary-jade, #286b63);
+  border: 3px solid var(--color-paper-main, #f6f3eb);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.2);
+  transition: transform 120ms ease;
+}
+
+.slider-input::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.slider-input::-moz-range-thumb {
+  height: 1.25rem;
+  width: 1.25rem;
+  border-radius: 9999px;
+  background: var(--color-primary-jade, #286b63);
+  border: 3px solid var(--color-paper-main, #f6f3eb);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.2);
+}
+
+.slider-input::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: transparent; /* the inline gradient on the element paints it */
+}

--- a/web/src/components/addresses-provider.tsx
+++ b/web/src/components/addresses-provider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { ADDRESSES } from "@/lib/config";
+import { hydrateRemoteAddresses } from "@/lib/remote-addresses";
+
+/**
+ * Re-render signal for runtime address hydration. The context value is a
+ * version counter that bumps once when the manifest fetch lands with new
+ * addresses; `useAddresses()` subscribes and returns the (in-place mutated)
+ * ADDRESSES object. Wagmi query keys include the contract address, so the
+ * re-render alone makes every read refetch against the fresh deployment —
+ * no manual cache invalidation needed.
+ */
+const AddressesVersionContext = createContext(0);
+
+export function AddressesProvider({ children }: { children: ReactNode }) {
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void hydrateRemoteAddresses().then((updated) => {
+      if (updated && !cancelled) setVersion((v) => v + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AddressesVersionContext.Provider value={version}>
+      {children}
+    </AddressesVersionContext.Provider>
+  );
+}
+
+/**
+ * Read the live contract addresses inside a component, subscribed to runtime
+ * hydration. Use this for anything render-time (wagmi read configs); event
+ * handlers can read `ADDRESSES` from config directly (call-time is always
+ * fresh).
+ */
+export function useAddresses(): typeof ADDRESSES {
+  useContext(AddressesVersionContext);
+  return ADDRESSES;
+}

--- a/web/src/components/config-warning.tsx
+++ b/web/src/components/config-warning.tsx
@@ -8,7 +8,7 @@ import { isContractConfigured } from "@/lib/config";
  * placeholder (the contract isn't deployed / configured yet).
  */
 export function ConfigWarning() {
-  if (isContractConfigured) return null;
+  if (isContractConfigured()) return null;
   return (
     <div className="section-container pt-4">
       <div className="border-system-warning/40 bg-system-warning/10 text-system-warning flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium">

--- a/web/src/components/create/create-form.tsx
+++ b/web/src/components/create/create-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import {
   FormProvider,
@@ -16,11 +16,18 @@ import { ArrowLeft, ArrowRight, CheckCircle } from "@phosphor-icons/react";
 import { ActionButton } from "@/components/ui/action-button";
 import { TxStatus } from "@/components/ui/tx-status";
 import { Card } from "@/components/ui/ui";
+import { Slider } from "@/components/ui/slider-field";
 import { useCreateSafetyNet } from "@/hooks/use-safety-net-writes";
 import { useIsTokenAllowed } from "@/hooks/use-safety-net";
 import { useTokenInfo } from "@/hooks/use-token";
 import { safetyNetAbi } from "@/lib/abi/safety-net";
-import { BREAD_ADDRESS, REDEEM_RATIO } from "@/lib/config";
+import {
+  BREAD_ADDRESS,
+  BROODFONDS_RATIO,
+  groupRatioCap,
+  MAX_REDEEM_RATIO,
+  MIN_REDEEM_RATIO,
+} from "@/lib/config";
 import { parseAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { createNetSchema, type CreateNetValues } from "./schema";
@@ -45,8 +52,10 @@ const DEFAULTS = {
   monthlyContribution: "50",
   /** Broodfonds caps groups at 50 to keep everyone accountable to each other. */
   memberCount: 50,
-  /** Startable as soon as 2 join (Broodfonds recommends ~25 in practice). */
-  minimumMembers: 2,
+  /** Broodfonds recommends starting around 25 members — the 22x support math
+   *  needs that critical mass. Advanced mode can lower it to the contract
+   *  minimum of 2 (for small trusted circles or testing). */
+  minimumMembers: 25,
   /** Monthly dues. */
   epochDurationDays: 30,
   /** A claim is blocked only if a majority of members object. */
@@ -147,7 +156,7 @@ export function CreateForm() {
       fixedDeposit: DEFAULTS.monthlyContribution,
       // Derived from the monthly amount unless overridden in Advanced.
       initialDeposit: "",
-      redeemRatio: REDEEM_RATIO,
+      redeemRatio: BROODFONDS_RATIO,
       autoThreshold: "",
       contestThreshold: DEFAULTS.contestThreshold,
       contestWindowDays: DEFAULTS.contestWindowDays,
@@ -205,6 +214,18 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
   const tokenChoice = watch("tokenChoice");
   const isBread = tokenChoice === "bread";
   const symbol = useNetSymbol(form);
+  const fixed = watch("fixedDeposit");
+  const memberCount = watch("memberCount");
+  const ratio = watch("redeemRatio");
+
+  // Simple mode manages minimumMembers for the user: the Broodfonds 25, but
+  // never above the chosen group size (the schema cross-checks the two, and a
+  // hidden failing field would block creation invisibly).
+  useEffect(() => {
+    if (mode !== "simple") return;
+    const cap = Number.isFinite(memberCount) ? memberCount : DEFAULTS.minimumMembers;
+    setValue("minimumMembers", Math.max(2, Math.min(DEFAULTS.minimumMembers, cap)));
+  }, [mode, memberCount, setValue]);
 
   const continueToReview = async () => {
     if (await trigger()) onContinue();
@@ -260,10 +281,12 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
       {mode === "simple" && (
         <p className="border-primary-jade/30 bg-primary-jade/5 text-surface-grey-2 rounded-xl border px-4 py-3 text-xs">
           Using Broodfonds defaults: monthly dues, up to {DEFAULTS.memberCount}{" "}
-          members, a one-month join deposit, and larger claims reviewed by the
-          group over {DEFAULTS.contestWindowDays} days. Switch to{" "}
-          <strong>Advanced</strong> to change the join deposit, epoch length,
-          instant-withdrawal threshold, or review rules.
+          members (startable once {DEFAULTS.minimumMembers} have joined), a
+          one-month join deposit, and ×{BROODFONDS_RATIO} monthly support when a
+          member is in need — larger claims are reviewed by the group over{" "}
+          {DEFAULTS.contestWindowDays} days. Switch to <strong>Advanced</strong>{" "}
+          to change the support ratio, join deposit, epoch length, petty-cash
+          threshold, or review rules.
         </p>
       )}
 
@@ -352,6 +375,26 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
           />
           <AmountSuffix isBread={isBread} symbol={symbol} />
         </div>
+        <Slider
+          min={10}
+          max={250}
+          step={5}
+          value={Number(fixed) || 10}
+          onChange={(v) =>
+            setValue("fixedDeposit", String(v), {
+              shouldValidate: true,
+              shouldDirty: true,
+            })
+          }
+          ariaLabel="Monthly contribution slider"
+          className="mt-3"
+        />
+        <SupportRateNote
+          fixed={fixed}
+          ratio={ratio}
+          memberCount={memberCount}
+          symbol={symbol}
+        />
       </Field>
 
       <Field
@@ -367,6 +410,20 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
           className={inputClass}
           {...register("memberCount", { valueAsNumber: true })}
         />
+        <Slider
+          min={2}
+          max={50}
+          step={1}
+          value={Number.isFinite(memberCount) ? memberCount : 2}
+          onChange={(v) =>
+            setValue("memberCount", v, {
+              shouldValidate: true,
+              shouldDirty: true,
+            })
+          }
+          ariaLabel="Group size slider"
+          className="mt-3"
+        />
       </Field>
 
       {mode === "advanced" && (
@@ -374,6 +431,36 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
           <Heading4 className="text-text-standard text-base">
             Advanced settings
           </Heading4>
+
+          <Field
+            id={id("redeem-ratio")}
+            label="Support ratio"
+            help={`How much monthly support a member in need can draw, as a multiple of the monthly contribution. ×1 is a pure savings circle — you only take out what you put in. Broodfonds groups use ≈×${BROODFONDS_RATIO}. The rate members actually get is throttled onchain to what the group size and pool can sustainably back.`}
+            error={errors.redeemRatio?.message}
+          >
+            <input
+              {...fieldAria(id("redeem-ratio"), errors.redeemRatio?.message, "help")}
+              type="number"
+              min={MIN_REDEEM_RATIO}
+              max={MAX_REDEEM_RATIO}
+              className={inputClass}
+              {...register("redeemRatio", { valueAsNumber: true })}
+            />
+            <Slider
+              min={MIN_REDEEM_RATIO}
+              max={MAX_REDEEM_RATIO}
+              step={1}
+              value={Number.isFinite(ratio) ? ratio : BROODFONDS_RATIO}
+              onChange={(v) =>
+                setValue("redeemRatio", v, {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                })
+              }
+              ariaLabel="Support ratio slider"
+              className="mt-3"
+            />
+          </Field>
 
           <Field
             id={id("initial-deposit")}
@@ -419,7 +506,7 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
             <Field
               id={id("min-members")}
               label="Minimum members to start"
-              help="You can only start the net once this many members have joined (contract minimum: 2)."
+              help="You can only start the net once this many members have joined. Broodfonds recommends ~25 — the support math needs critical mass; the contract minimum is 2."
               error={errors.minimumMembers?.message}
             >
               <input
@@ -435,8 +522,8 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field
               id={id("auto-threshold")}
-              label="Instant-withdrawal threshold"
-              help="Withdrawals up to this amount pay out instantly; larger ones go to group review. Defaults to ¼ of the monthly contribution."
+              label="Instant (petty-cash) threshold"
+              help="Small withdrawals up to this amount pay out instantly with no review — petty cash, not the monthly support cap. Defaults to ¼ of the monthly contribution."
               error={errors.autoThreshold?.message}
             >
               <div className="relative">
@@ -541,7 +628,12 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
   const name = watch("name")?.trim();
   const members = watch("memberCount");
   const fixed = watch("fixedDeposit");
+  const ratio = watch("redeemRatio");
   const epochDays = watch("epochDurationDays");
+  const supportPerMonth =
+    Number.isFinite(ratio) && Number(fixed) > 0
+      ? Number(fixed) * ratio
+      : undefined;
   // Show the derived values (Simple mode leaves these blank in form state).
   const initial = watch("initialDeposit")?.trim() || deriveInitial(fixed);
   const autoThreshold = watch("autoThreshold")?.trim() || deriveAuto(fixed);
@@ -594,7 +686,7 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
       members: [],
       initialDeposit,
       fixedDeposit,
-      redeemRatio: BigInt(REDEEM_RATIO), // locked to 1 onchain in v1
+      redeemRatio: BigInt(v.redeemRatio),
       autoThreshold: autoThresholdWei,
       contestWindow: BigInt(Math.round(v.contestWindowDays * 86_400)),
       epochDuration: BigInt(Math.round(v.epochDurationDays * 86_400)),
@@ -624,15 +716,30 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
         <strong className="text-text-standard">{amt(initial)}</strong> to join and{" "}
         <strong className="text-text-standard">{amt(fixed)}</strong> each epoch
         (~<strong className="text-text-standard">{epochDays || "—"}</strong> days).
-        Withdrawals over{" "}
-        <strong className="text-text-standard">{amt(autoThreshold)}</strong> go to
-        a group review.
+        Small withdrawals up to{" "}
+        <strong className="text-text-standard">{amt(autoThreshold)}</strong> pay
+        out instantly; anything larger goes to a group review.
       </Body>
 
-      <p className="text-surface-grey text-xs">
-        Deposits and withdrawal power are 1:1 (redeem ratio ×1) — every token you
-        put in unlocks exactly one token of withdrawable balance.
-      </p>
+      {ratio > 1 ? (
+        <p className="border-primary-jade/30 bg-primary-jade/5 text-surface-grey-2 rounded-xl border px-4 py-3 text-xs">
+          <strong className="text-text-standard">
+            Support ratio ×{ratio}:
+          </strong>{" "}
+          a member in need can draw up to {ratio} × their monthly contribution —
+          about{" "}
+          <strong className="text-text-standard">
+            {supportPerMonth ? `${supportPerMonth} ${symbol}/month` : "—"}
+          </strong>{" "}
+          — from the shared pool, capped by their withdrawable balance and what
+          the group size and pool can sustainably back.
+        </p>
+      ) : (
+        <p className="text-surface-grey text-xs">
+          Pure savings circle (support ratio ×1) — every token you put in
+          unlocks exactly one token of withdrawable balance.
+        </p>
+      )}
 
       {Object.keys(errors).length > 0 && !created && (
         <p className="text-system-red text-xs font-medium">
@@ -700,6 +807,45 @@ function OverviewPanel({ onBack }: { onBack: () => void }) {
         </Button>
       )}
     </Card>
+  );
+}
+
+/**
+ * The headline Broodfonds promise, live-updating under the contribution field:
+ * what monthly support the chosen contribution buys, and what the group size
+ * sustainably backs (mirror of the contract's actuarial group cap).
+ */
+function SupportRateNote({
+  fixed,
+  ratio,
+  memberCount,
+  symbol,
+}: {
+  fixed: string;
+  ratio: number;
+  memberCount: number;
+  symbol: string;
+}) {
+  const n = Number(fixed);
+  if (!Number.isFinite(ratio) || ratio <= 1 || !Number.isFinite(n) || n <= 0)
+    return null;
+  const cap = groupRatioCap(Number.isFinite(memberCount) ? memberCount : 2);
+  const sustained = Math.min(ratio, cap);
+  return (
+    <p className="border-primary-jade/30 bg-primary-jade/5 text-surface-grey-2 mt-3 rounded-xl border px-4 py-3 text-xs">
+      <strong className="text-text-standard">
+        Monthly support when in need: ×{ratio} ≈ {n * ratio} {symbol}/month.
+      </strong>{" "}
+      {sustained < ratio ? (
+        <>
+          A group of {memberCount || "—"} sustainably backs about ×{sustained} (
+          {n * sustained} {symbol}/month) — support ramps toward the full rate
+          as the group and its pool grow.
+        </>
+      ) : (
+        <>This group size fully backs that rate once the pool has built up.</>
+      )}
+    </p>
   );
 }
 

--- a/web/src/components/create/schema.ts
+++ b/web/src/components/create/schema.ts
@@ -1,6 +1,6 @@
 import { isAddress } from "viem";
 import { z } from "zod";
-import { REDEEM_RATIO } from "@/lib/config";
+import { MAX_REDEEM_RATIO, MIN_REDEEM_RATIO } from "@/lib/config";
 
 /** Positive decimal token amount as a string (parsed with token decimals). */
 const amountString = z
@@ -49,9 +49,13 @@ export const createNetSchema = z
     // Derived by default (= one recurring deposit): the one-off join payment.
     // Only edited in Advanced mode, so it's optional here.
     initialDeposit: optionalAmountString,
-    // Locked onchain in v1 (MINIMUM/MAXIMUM_REDEEM_RATIO are both 1):
-    // deposits and withdrawal power are 1:1, leverage disabled.
-    redeemRatio: z.literal(REDEEM_RATIO),
+    // Support ratio, mirroring the contract's MINIMUM/MAXIMUM_REDEEM_RATIO
+    // (1-25). x1 = pure savings circle; ~x22 = classic Broodfonds solidarity.
+    redeemRatio: z
+      .number({ error: "Enter a whole number" })
+      .int("Whole numbers only")
+      .min(MIN_REDEEM_RATIO, `At least ×${MIN_REDEEM_RATIO}`)
+      .max(MAX_REDEEM_RATIO, `At most ×${MAX_REDEEM_RATIO}`),
     // Derived by default (= a quarter of the recurring deposit). Advanced-only.
     autoThreshold: optionalAmountString,
     contestThreshold: z

--- a/web/src/components/landing.tsx
+++ b/web/src/components/landing.tsx
@@ -15,7 +15,7 @@ const FEATURES = [
   {
     icon: HandCoins,
     title: "Save together, steadily",
-    body: "Your group agrees on the rules up front — which token, how much everyone deposits, how often. Dues build a shared pool, 1:1 with your withdrawable balance, and you can prepay months ahead.",
+    body: "Your group agrees on the rules up front — which token, how much everyone deposits, how often. Dues build a shared pool that backs each member's monthly support when in need, and you can prepay months ahead.",
   },
   {
     icon: Lightning,

--- a/web/src/components/net/auto-deposit-toggle.tsx
+++ b/web/src/components/net/auto-deposit-toggle.tsx
@@ -12,7 +12,8 @@ import {
   useToggleDelegated,
 } from "@/hooks/use-delegated-deposits";
 import { useAllowance, useApprove, useTokenInfo } from "@/hooks/use-token";
-import { addressUrl, SAFETYNET_ADDRESS } from "@/lib/config";
+import { addressUrl } from "@/lib/config";
+import { useAddresses } from "@/components/addresses-provider";
 import { formatAmount, shortenAddress } from "@/lib/format";
 import type { SafetyNetDetails } from "@/lib/types";
 
@@ -29,6 +30,7 @@ import type { SafetyNetDetails } from "@/lib/types";
  */
 export function AutoDepositToggle({ details }: { details: SafetyNetDetails }) {
   const { address } = useAccount();
+  const { safetyNet: proxyAddress } = useAddresses();
   const net = details.safetyNet;
   const { symbol, decimals } = useTokenInfo(net.token);
 
@@ -113,12 +115,12 @@ export function AutoDepositToggle({ details }: { details: SafetyNetDetails }) {
             <dt>Spender (proxy)</dt>
             <dd>
               <a
-                href={addressUrl(SAFETYNET_ADDRESS)}
+                href={addressUrl(proxyAddress)}
                 target="_blank"
                 rel="noreferrer"
                 className="text-primary-jade hover:underline"
               >
-                {shortenAddress(SAFETYNET_ADDRESS)}
+                {shortenAddress(proxyAddress)}
               </a>
             </dd>
           </div>

--- a/web/src/components/net/net-overview.tsx
+++ b/web/src/components/net/net-overview.tsx
@@ -38,7 +38,13 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
         <StatCard
           label="My withdrawable"
           value={`${formatAmount(details.withdrawableBalance, decimals)} ${symbol}`}
-          sub={details.isMember ? "1:1 with your deposits" : "not a member"}
+          sub={
+            details.isMember
+              ? net.redeemRatio > 1n
+                ? `×${net.redeemRatio.toString()} support ratio`
+                : "savings circle — 1:1 with deposits"
+              : "not a member"
+          }
           accent={details.isMember}
         />
         <StatCard
@@ -104,14 +110,17 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
             {formatAmount(net.fixedDeposit, decimals)} {symbol} / epoch
           </InfoRow>
           <InfoRow
-            label="Redeem ratio"
-            help="Fixed at ×1 in v1: every token deposited is exactly one token of withdrawable balance — deposits and withdrawal power are 1:1."
+            label="Support ratio"
+            help="A member in need can draw this multiple of their monthly contribution per month, capped by their withdrawable balance and what the group size and pool sustainably back. ×1 = pure savings circle; ≈×22 = classic Broodfonds solidarity."
           >
             ×{net.redeemRatio.toString()}
+            {details.effectiveRedeemRatio < net.redeemRatio
+              ? ` (×${details.effectiveRedeemRatio.toString()} effective now)`
+              : ""}
           </InfoRow>
           <InfoRow
             label="Instant withdrawals"
-            help="Withdrawals up to this amount are paid instantly; larger ones create a contestable request."
+            help="Petty-cash threshold: withdrawals up to this amount pay out instantly with no review. It is not the monthly support cap — larger needs go through a contestable request."
           >
             ≤ {formatAmount(net.autoThreshold, decimals)} {symbol}, max{" "}
             {net.smallWithdrawsLimit.toString()}× per epoch

--- a/web/src/components/net/withdraw-panel.tsx
+++ b/web/src/components/net/withdraw-panel.tsx
@@ -6,6 +6,7 @@ import { Lightning, UsersThree } from "@phosphor-icons/react";
 import { ActionButton } from "@/components/ui/action-button";
 import { TxStatus } from "@/components/ui/tx-status";
 import { Badge, Card } from "@/components/ui/ui";
+import { Slider } from "@/components/ui/slider-field";
 import { useWithdraw } from "@/hooks/use-safety-net-writes";
 import { useTokenInfo } from "@/hooks/use-token";
 import { DAYS_IN_A_MONTH } from "@/lib/config";
@@ -25,9 +26,12 @@ const countWords = (s: string): number =>
 const byteLength = (s: string): number => new TextEncoder().encode(s).length;
 
 /**
- * Withdraw by "days of income": amount = (monthly contribution × redeem
- * ratio ÷ 30) × days. Small amounts (≤ auto threshold) pay out instantly;
- * larger ones open a request the group can contest.
+ * Withdraw by "days of support": amount = (monthly contribution × the member's
+ * EFFECTIVE support ratio ÷ 30) × days. The effective ratio is the configured
+ * ratio throttled by the contract's actuarial caps (group size + pool runway),
+ * so the preview always matches what a withdrawal would pay right now. Small
+ * amounts (≤ the petty-cash threshold) pay out instantly; larger ones open a
+ * request the group can contest.
  */
 export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
   const net = details.safetyNet;
@@ -42,8 +46,12 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
   // ran even if the input changes afterwards.
   const [submittedSmall, setSubmittedSmall] = useState(false);
 
+  const effectiveRatio = details.effectiveRedeemRatio;
   const dailyAmount =
-    (details.monthlyContribute * net.redeemRatio) / DAYS_IN_A_MONTH;
+    (details.monthlyContribute * effectiveRatio) / DAYS_IN_A_MONTH;
+  const monthlySupport = details.monthlyContribute * effectiveRatio;
+  const maxDays =
+    dailyAmount > 0n ? Number(details.withdrawableBalance / dailyAmount) : 0;
 
   const parsedDays = useMemo(() => {
     const n = Number(days);
@@ -76,7 +84,9 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
               <Caption className="text-surface-grey-2">Days requested</Caption>
             </label>
             <span className="text-primary-jade text-xs font-medium">
-              1 day = {formatAmount(dailyAmount, decimals)} {symbol}
+              ×{effectiveRatio.toString()} support ≈{" "}
+              {formatAmount(monthlySupport, decimals)} {symbol}/month · 1 day ={" "}
+              {formatAmount(dailyAmount, decimals)} {symbol}
             </span>
           </div>
           <input
@@ -91,10 +101,25 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
             value={days}
             onChange={(e) => setDays(e.target.value)}
           />
+          <Slider
+            min={1}
+            max={Math.max(1, maxDays)}
+            step={1}
+            value={Number(days) || 1}
+            onChange={(v) => setDays(String(v))}
+            disabled={notOnboarded || maxDays === 0}
+            ariaLabel="Days requested slider"
+            className="mt-3"
+          />
           <p id={`${daysId}-help`} className="text-surface-grey mt-1.5 text-xs">
-            You withdraw in &quot;days of income&quot;: each day is worth your
-            recurring deposit × the redeem ratio (×
-            {net.redeemRatio.toString()}) ÷ 30.
+            You withdraw in &quot;days of support&quot;: each day is worth your
+            monthly contribution × your current support ratio (×
+            {effectiveRatio.toString()}
+            {effectiveRatio < net.redeemRatio
+              ? ` right now, of ×${net.redeemRatio.toString()} configured — the rate grows with the group and its pool`
+              : ""}
+            ) ÷ 30. Your balance covers up to {maxDays} day
+            {maxDays === 1 ? "" : "s"}.
           </p>
         </div>
 
@@ -118,8 +143,8 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
               )}
               <span className="text-surface-grey text-xs">
                 {isSmall
-                  ? `≤ ${formatAmount(net.autoThreshold, decimals)} ${symbol} pays out immediately (max ${net.smallWithdrawsLimit.toString()}× per epoch)`
-                  : `> ${formatAmount(net.autoThreshold, decimals)} ${symbol} opens a request members can contest for ${formatDuration(net.contestWindow)}`}
+                  ? `Petty cash: up to ${formatAmount(net.autoThreshold, decimals)} ${symbol} pays out instantly, no review (max ${net.smallWithdrawsLimit.toString()}× per epoch)`
+                  : `Over the ${formatAmount(net.autoThreshold, decimals)} ${symbol} petty-cash threshold — opens a request members can contest for ${formatDuration(net.contestWindow)}`}
               </span>
             </div>
           </div>

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { PRIVY_ENABLED } from "@/lib/config";
+import { AddressesProvider } from "@/components/addresses-provider";
 import { GeneralProviders } from "@/components/providers-general";
 
 // The Privy tree is code-split behind next/dynamic so `@privy-io/*` only loads
@@ -15,8 +16,18 @@ const PrivyProviders = dynamic(
 );
 
 export function Providers({ children }: { children: ReactNode }) {
+  // AddressesProvider sits outermost: it needs no wagmi/query context, and its
+  // hydration re-render must reach both provider trees.
   if (PRIVY_ENABLED) {
-    return <PrivyProviders>{children}</PrivyProviders>;
+    return (
+      <AddressesProvider>
+        <PrivyProviders>{children}</PrivyProviders>
+      </AddressesProvider>
+    );
   }
-  return <GeneralProviders>{children}</GeneralProviders>;
+  return (
+    <AddressesProvider>
+      <GeneralProviders>{children}</GeneralProviders>
+    </AddressesProvider>
+  );
 }

--- a/web/src/components/ui/slider-field.tsx
+++ b/web/src/components/ui/slider-field.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+
+/**
+ * Styled range input (design-system jade/paper tokens; rules in globals.css).
+ * WebKit has no ::-webkit-range-progress, so the filled track is painted with
+ * an inline gradient sized to the value.
+ *
+ * Controlled and clamp-tolerant: a `value` outside [min, max] renders the
+ * thumb pinned at the edge without mutating the source — pairing text inputs
+ * stay free to hold out-of-range drafts.
+ */
+export function Slider({
+  id,
+  min,
+  max,
+  step = 1,
+  value,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  className = "",
+}: {
+  id?: string;
+  min: number;
+  max: number;
+  step?: number;
+  value: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  const clamped = Math.min(Math.max(value, min), max);
+  const percent = max > min ? ((clamped - min) / (max - min)) * 100 : 0;
+
+  return (
+    <input
+      id={id}
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={clamped}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className={`slider-input ${className}`}
+      style={{
+        background: `linear-gradient(to right, var(--color-primary-jade, #286b63) ${percent}%, var(--color-paper-2, #e5e0d3) ${percent}%)`,
+      }}
+    />
+  );
+}
+
+/**
+ * Slider + compact number box sharing one numeric state (drag OR type).
+ * The parent's `value` is canonical; while the box is focused it holds a local
+ * draft so typing "1" en route to "15" doesn't snap to the minimum, committing
+ * the parsed value on change and clamping only on blur.
+ */
+export function SliderField({
+  id,
+  label,
+  min,
+  max,
+  step = 1,
+  value,
+  onChange,
+  format,
+  suffix,
+  help,
+  disabled = false,
+}: {
+  id?: string;
+  label: ReactNode;
+  min: number;
+  max: number;
+  step?: number;
+  value: number;
+  onChange: (next: number) => void;
+  /** Right-hand readout when no editable box is wanted. */
+  format?: (v: number) => string;
+  suffix?: ReactNode;
+  help?: ReactNode;
+  disabled?: boolean;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  // External changes (slider drags, form resets) overwrite an unfocused draft.
+  useEffect(() => {
+    setDraft(null);
+  }, [value]);
+
+  const commit = (raw: string) => {
+    const n = Number(raw);
+    if (raw.trim() !== "" && Number.isFinite(n)) onChange(n);
+  };
+
+  return (
+    <div>
+      <div className="flex items-end justify-between gap-2">
+        <label htmlFor={id} className="text-surface-grey-2 text-xs font-bold">
+          {label}
+        </label>
+        {format ? (
+          <span className="text-text-standard text-sm font-bold">
+            {format(value)}
+          </span>
+        ) : (
+          <span className="flex items-center gap-1">
+            <input
+              value={draft ?? String(value)}
+              inputMode="numeric"
+              disabled={disabled}
+              aria-label={typeof label === "string" ? label : undefined}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                commit(e.target.value);
+              }}
+              onBlur={() => {
+                setDraft(null);
+                onChange(Math.min(Math.max(value, min), max));
+              }}
+              className="border-paper-2 bg-paper-main text-text-standard focus:border-primary-jade w-20 rounded-xl border px-2 py-1 text-right text-sm outline-none disabled:opacity-60"
+            />
+            {suffix}
+          </span>
+        )}
+      </div>
+      <Slider
+        id={id}
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(v) => {
+          setDraft(null);
+          onChange(v);
+        }}
+        disabled={disabled}
+        ariaLabel={typeof label === "string" ? label : undefined}
+        className="mt-2"
+      />
+      {help && <p className="text-surface-grey mt-1.5 text-xs">{help}</p>}
+    </div>
+  );
+}

--- a/web/src/hooks/use-activity.ts
+++ b/web/src/hooks/use-activity.ts
@@ -5,7 +5,9 @@ import { useQuery } from "@tanstack/react-query";
 import { usePublicClient } from "wagmi";
 import { getAbiItem, type Address, type Hex, type PublicClient } from "viem";
 import { safetyNetAbi } from "@/lib/abi/safety-net";
-import { CHAIN_ID, SAFETYNET_ADDRESS } from "@/lib/config";
+import { CHAIN_ID } from "@/lib/config";
+import { RUNTIME } from "@/lib/remote-addresses";
+import { useAddresses } from "@/components/addresses-provider";
 import {
   ACTIVITY_FROM_BLOCK,
   activityTypeFromSubgraph,
@@ -78,6 +80,7 @@ async function resolveTimestamps(
 
 async function fetchFromLogs(
   client: PublicClient,
+  contractAddress: Address,
   netId: bigint,
   requestIds: readonly bigint[],
 ): Promise<ActivityItem[]> {
@@ -89,10 +92,10 @@ async function fetchFromLogs(
     NET_EVENTS.map(async ({ name, type }) => {
       const event = getAbiItem({ abi: ABI, name }) as never;
       const logs = (await client.getLogs({
-        address: SAFETYNET_ADDRESS,
+        address: contractAddress,
         event,
         args: { id: netId } as never,
-        fromBlock: ACTIVITY_FROM_BLOCK,
+        fromBlock: RUNTIME.activityFromBlock ?? ACTIVITY_FROM_BLOCK,
         toBlock: "latest",
       })) as unknown as RawLog[];
       return logs.map((log) => ({ log, type }));
@@ -100,10 +103,10 @@ async function fetchFromLogs(
   );
 
   const createdLogs = (await client.getLogs({
-    address: SAFETYNET_ADDRESS,
+    address: contractAddress,
     event: getAbiItem({ abi: ABI, name: "RequestCreated" }) as never,
     args: { safetyNetId: netId } as never,
-    fromBlock: ACTIVITY_FROM_BLOCK,
+    fromBlock: RUNTIME.activityFromBlock ?? ACTIVITY_FROM_BLOCK,
     toBlock: "latest",
   })) as unknown as RawLog[];
 
@@ -111,9 +114,9 @@ async function fetchFromLogs(
     REQUEST_EVENTS.map(async ({ name, type }) => {
       const event = getAbiItem({ abi: ABI, name }) as never;
       const logs = (await client.getLogs({
-        address: SAFETYNET_ADDRESS,
+        address: contractAddress,
         event,
-        fromBlock: ACTIVITY_FROM_BLOCK,
+        fromBlock: RUNTIME.activityFromBlock ?? ACTIVITY_FROM_BLOCK,
         toBlock: "latest",
       })) as unknown as RawLog[];
       // These events aren't keyed by net id — keep only this net's requests.
@@ -146,7 +149,7 @@ async function fetchFromLogs(
       (args.member as Address | undefined) ??
       (args.redeemer as Address | undefined) ??
       (args.owner as Address | undefined) ??
-      SAFETYNET_ADDRESS;
+      contractAddress;
     return {
       id: `${log.transactionHash}-${log.logIndex ?? 0}`,
       type,
@@ -256,6 +259,15 @@ export function useNetActivity(
   requestIds: readonly bigint[] = [],
 ): UseNetActivityResult {
   const client = usePublicClient({ chainId: CHAIN_ID });
+  const { safetyNet } = useAddresses();
+
+  // A baked-in subgraph URL indexes the baked-in proxy. When the runtime
+  // manifest moved us to a fresh deployment, that subgraph would return
+  // another contract's nets under colliding ids — worse than no subgraph.
+  // Use a manifest-provided URL when present, else disable and fall back to
+  // the (always-correct) log scan.
+  const subgraphUrl =
+    RUNTIME.subgraphUrl ?? (RUNTIME.addressChanged ? undefined : SUBGRAPH_URL);
 
   // Stable primitive key so react-query doesn't refetch on array identity churn.
   const requestKey = useMemo(
@@ -266,9 +278,9 @@ export function useNetActivity(
   const query = useQuery({
     queryKey: [
       "net-activity",
-      SAFETYNET_ADDRESS,
+      safetyNet,
       netId?.toString() ?? null,
-      SUBGRAPH_URL ?? "logs",
+      subgraphUrl ?? "logs",
       requestKey,
     ],
     enabled: netId !== undefined && client !== undefined,
@@ -276,14 +288,14 @@ export function useNetActivity(
     refetchInterval: 30_000,
     queryFn: async (): Promise<{ items: ActivityItem[]; fromSubgraph: boolean }> => {
       const id = netId as bigint;
-      if (SUBGRAPH_URL) {
+      if (subgraphUrl) {
         try {
-          return { items: await fetchFromSubgraph(SUBGRAPH_URL, id), fromSubgraph: true };
+          return { items: await fetchFromSubgraph(subgraphUrl, id), fromSubgraph: true };
         } catch {
           // Fall through to the log path on any subgraph error.
         }
       }
-      const items = await fetchFromLogs(client as PublicClient, id, requestIds);
+      const items = await fetchFromLogs(client as PublicClient, safetyNet, id, requestIds);
       return { items, fromSubgraph: false };
     },
   });

--- a/web/src/hooks/use-delegated-deposits.ts
+++ b/web/src/hooks/use-delegated-deposits.ts
@@ -3,7 +3,8 @@
 import { zeroAddress, type Address } from "viem";
 import { useReadContract } from "wagmi";
 import { delegatedAbi } from "@/lib/abi/delegated";
-import { CHAIN_ID, DELEGATED_SAFETYNET_ADDRESS } from "@/lib/config";
+import { ADDRESSES, CHAIN_ID } from "@/lib/config";
+import { useAddresses } from "@/components/addresses-provider";
 import { useTx } from "@/hooks/use-tx";
 
 const REFETCH_MS = 12_000;
@@ -11,7 +12,7 @@ const REFETCH_MS = 12_000;
 /**
  * Automatic deposits (DelegatedSafetyNet extension, issue #32).
  *
- * A member opts in by (1) approving the *main proxy* (SAFETYNET_ADDRESS) for
+ * A member opts in by (1) approving the *main proxy* (ADDRESSES.safetyNet) for
  * enough of the net's token to cover future dues, and (2) toggling
  * `setDelegatedDepositsEnabled(true)` on this extension. Then anyone can call
  * `depositIfAllowed(id, member)` to pay that member's owed dues from their
@@ -21,13 +22,14 @@ const REFETCH_MS = 12_000;
  *
  * The token allowance to the proxy is read/written with the existing
  * `useAllowance` / `useApprove` hooks in use-token.ts, which already target
- * SAFETYNET_ADDRESS — this hook covers only the delegated-toggle state.
+ * the SafetyNet proxy — this hook covers only the delegated-toggle state.
  */
 
 /** Whether `member` has opted into automatic (delegated) deposits. */
 export function useDelegatedEnabled(member: Address | undefined) {
+  const { delegated } = useAddresses();
   return useReadContract({
-    address: DELEGATED_SAFETYNET_ADDRESS,
+    address: delegated,
     abi: delegatedAbi,
     chainId: CHAIN_ID,
     functionName: "isDelegatedDepositsEnabled",
@@ -44,7 +46,7 @@ export function useToggleDelegated() {
   const tx = useTx();
   const toggle = (enabled: boolean) =>
     tx.run({
-      address: DELEGATED_SAFETYNET_ADDRESS,
+      address: ADDRESSES.delegated,
       abi: delegatedAbi,
       functionName: "setDelegatedDepositsEnabled",
       args: [enabled],

--- a/web/src/hooks/use-invite.ts
+++ b/web/src/hooks/use-invite.ts
@@ -8,7 +8,7 @@ import {
   inviteTypes,
   randomNonce,
 } from "@/lib/eip712";
-import { CHAIN_ID, SAFETYNET_ADDRESS } from "@/lib/config";
+import { ADDRESSES, CHAIN_ID } from "@/lib/config";
 import { parseContractError } from "@/lib/parse-contract-error";
 import { useTypedDataSigner } from "@/hooks/use-typed-data-signer";
 
@@ -27,7 +27,7 @@ export interface StoredInvite {
 }
 
 const storageKey = (safetyNetId: bigint, signer: string) =>
-  `safety-net:invites:${CHAIN_ID}:${SAFETYNET_ADDRESS.toLowerCase()}:${safetyNetId.toString()}:${signer.toLowerCase()}`;
+  `safety-net:invites:${CHAIN_ID}:${ADDRESSES.safetyNet.toLowerCase()}:${safetyNetId.toString()}:${signer.toLowerCase()}`;
 
 function loadInvites(key: string): StoredInvite[] {
   try {

--- a/web/src/hooks/use-safety-net-writes.ts
+++ b/web/src/hooks/use-safety-net-writes.ts
@@ -2,7 +2,7 @@
 
 import type { Address, ContractFunctionArgs } from "viem";
 import { safetyNetAbi } from "@/lib/abi/safety-net";
-import { SAFETYNET_ADDRESS } from "@/lib/config";
+import { ADDRESSES } from "@/lib/config";
 import { useTx } from "@/hooks/use-tx";
 
 /**
@@ -24,7 +24,7 @@ export function useCreateSafetyNet() {
   const tx = useTx();
   const create = (name: CreateName, safetyNet: CreateInput) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "create",
       args: [name, safetyNet],
@@ -40,7 +40,7 @@ export function useStartSafetyNet() {
   const tx = useTx();
   const start = (id: bigint) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "start",
       args: [id],
@@ -52,7 +52,7 @@ export function useDeposit() {
   const tx = useTx();
   const deposit = (id: bigint, value: bigint) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "deposit",
       args: [id, value],
@@ -64,7 +64,7 @@ export function useDepositFor() {
   const tx = useTx();
   const depositFor = (id: bigint, value: bigint, member: Address) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "depositFor",
       args: [id, value, member],
@@ -76,7 +76,7 @@ export function useWithdraw() {
   const tx = useTx();
   const withdraw = (id: bigint, daysRequested: bigint, reason: string) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "withdraw",
       args: [id, daysRequested, reason],
@@ -88,7 +88,7 @@ export function useContest() {
   const tx = useTx();
   const contest = (requestId: bigint) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "contest",
       args: [requestId],
@@ -100,7 +100,7 @@ export function useExecuteContestedWithdrawal() {
   const tx = useTx();
   const execute = (requestId: bigint) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "executeContestedWithdrawal",
       args: [requestId],
@@ -112,7 +112,7 @@ export function useDecommission() {
   const tx = useTx();
   const decommission = (id: bigint) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "decommission",
       args: [id],
@@ -127,7 +127,7 @@ export function useRedeemInvite() {
     signature: `0x${string}`,
   ) =>
     tx.run({
-      address: SAFETYNET_ADDRESS,
+      address: ADDRESSES.safetyNet,
       abi: safetyNetAbi,
       functionName: "redeemInvite",
       args: [invite, signature],

--- a/web/src/hooks/use-safety-net.ts
+++ b/web/src/hooks/use-safety-net.ts
@@ -4,7 +4,8 @@ import { useMemo } from "react";
 import { useAccount, useReadContract, useReadContracts } from "wagmi";
 import { zeroAddress, type Address } from "viem";
 import { safetyNetAbi } from "@/lib/abi/safety-net";
-import { CHAIN_ID, isContractConfigured, SAFETYNET_ADDRESS } from "@/lib/config";
+import { CHAIN_ID, isContractConfigured } from "@/lib/config";
+import { useAddresses } from "@/components/addresses-provider";
 
 /**
  * Data layer for SafetyNet reads. The contract ships aggregate views
@@ -16,24 +17,25 @@ import { CHAIN_ID, isContractConfigured, SAFETYNET_ADDRESS } from "@/lib/config"
 
 // chainId is pinned to Gnosis on every contract call: the wagmi config also
 // includes mainnet (for ENS reads only), so without this a wallet sitting on
-// mainnet could read the wrong chain.
-const safetyNetContract = {
-  address: SAFETYNET_ADDRESS,
-  abi: safetyNetAbi,
-  chainId: CHAIN_ID,
-} as const;
+// mainnet could read the wrong chain. The address comes from useAddresses()
+// (runtime-hydrated), so this must be built per render — never at module scope.
+function useSafetyNetContract() {
+  const { safetyNet } = useAddresses();
+  return { address: safetyNet, abi: safetyNetAbi, chainId: CHAIN_ID } as const;
+}
 
 const REFETCH_MS = 12_000;
 
 /** Aggregated details for every Safety Net the connected wallet has joined. */
 export function useMemberDashboard() {
+  const safetyNetContract = useSafetyNetContract();
   const { address } = useAccount();
   return useReadContract({
     ...safetyNetContract,
     functionName: "getMemberDashboard",
     args: [address ?? zeroAddress],
     query: {
-      enabled: isContractConfigured && Boolean(address),
+      enabled: isContractConfigured() && Boolean(address),
       refetchInterval: REFETCH_MS,
     },
   });
@@ -44,13 +46,14 @@ export function useMemberDashboard() {
  * the connected wallet (or the zero address when browsing disconnected).
  */
 export function useSafetyNetDetails(id: bigint | undefined) {
+  const safetyNetContract = useSafetyNetContract();
   const { address } = useAccount();
   return useReadContract({
     ...safetyNetContract,
     functionName: "getSafetyNetDetails",
     args: [id ?? 0n, address ?? zeroAddress],
     query: {
-      enabled: isContractConfigured && id !== undefined,
+      enabled: isContractConfigured() && id !== undefined,
       // Keep polling even when the tab is in the background: contest windows
       // can be short, so members must see new requests without a reload.
       refetchInterval: REFETCH_MS,
@@ -61,6 +64,7 @@ export function useSafetyNetDetails(id: bigint | undefined) {
 
 /** Which of the given requests has the connected wallet already contested? */
 export function useHasContested(requestIds: readonly bigint[]) {
+  const safetyNetContract = useSafetyNetContract();
   const { address } = useAccount();
   const { data } = useReadContracts({
     contracts: requestIds.map((id) => ({
@@ -70,7 +74,7 @@ export function useHasContested(requestIds: readonly bigint[]) {
     })),
     query: {
       enabled:
-        isContractConfigured && Boolean(address) && requestIds.length > 0,
+        isContractConfigured() && Boolean(address) && requestIds.length > 0,
       refetchInterval: REFETCH_MS,
       refetchIntervalInBackground: true,
     },
@@ -87,12 +91,13 @@ export function useHasContested(requestIds: readonly bigint[]) {
 
 /** Per-member withdrawable balances of one Safety Net. */
 export function useMemberBalances(id: bigint | undefined) {
+  const safetyNetContract = useSafetyNetContract();
   return useReadContract({
     ...safetyNetContract,
     functionName: "getMemberBalances",
     args: [id ?? 0n],
     query: {
-      enabled: isContractConfigured && id !== undefined,
+      enabled: isContractConfigured() && id !== undefined,
       refetchInterval: REFETCH_MS,
     },
   });
@@ -100,12 +105,13 @@ export function useMemberBalances(id: bigint | undefined) {
 
 /** Members who still owe dues in the current epoch. */
 export function useMembersNeedingDeposit(id: bigint | undefined) {
+  const safetyNetContract = useSafetyNetContract();
   return useReadContract({
     ...safetyNetContract,
     functionName: "getMembersNeedingDeposit",
     args: [id ?? 0n],
     query: {
-      enabled: isContractConfigured && id !== undefined,
+      enabled: isContractConfigured() && id !== undefined,
       refetchInterval: REFETCH_MS,
     },
   });
@@ -120,6 +126,7 @@ export function useMemberDepositInfo(
   id: bigint | undefined,
   member: Address | undefined,
 ) {
+  const safetyNetContract = useSafetyNetContract();
   const { data } = useReadContracts({
     contracts: [
       {
@@ -139,7 +146,7 @@ export function useMemberDepositInfo(
       },
     ],
     query: {
-      enabled: isContractConfigured && id !== undefined && Boolean(member),
+      enabled: isContractConfigured() && id !== undefined && Boolean(member),
       refetchInterval: REFETCH_MS,
     },
   });
@@ -157,23 +164,25 @@ export function useMemberDepositInfo(
  * so this is an extra read. May be "" when the owner left it blank.
  */
 export function useSafetyNetName(id: bigint | undefined) {
+  const safetyNetContract = useSafetyNetContract();
   return useReadContract({
     ...safetyNetContract,
     functionName: "safetyNetNames",
     args: [id ?? 0n],
-    query: { enabled: isContractConfigured && id !== undefined },
+    query: { enabled: isContractConfigured() && id !== undefined },
   });
 }
 
 /** Names for many Safety Nets at once (dashboard cards) — batched multicall. */
 export function useSafetyNetNames(ids: readonly bigint[]) {
+  const safetyNetContract = useSafetyNetContract();
   const { data } = useReadContracts({
     contracts: ids.map((id) => ({
       ...safetyNetContract,
       functionName: "safetyNetNames" as const,
       args: [id] as const,
     })),
-    query: { enabled: isContractConfigured && ids.length > 0 },
+    query: { enabled: isContractConfigured() && ids.length > 0 },
   });
 
   return useMemo(() => {
@@ -188,11 +197,12 @@ export function useSafetyNetNames(ids: readonly bigint[]) {
 
 /** Whether the protocol allows the given ERC20 for Safety Nets. */
 export function useIsTokenAllowed(token: Address | undefined) {
+  const safetyNetContract = useSafetyNetContract();
   return useReadContract({
     ...safetyNetContract,
     functionName: "isTokenAllowed",
     args: [token ?? zeroAddress],
-    query: { enabled: isContractConfigured && Boolean(token) },
+    query: { enabled: isContractConfigured() && Boolean(token) },
   });
 }
 
@@ -205,6 +215,7 @@ export function useInviteNoncesUsed(
   safetyNetId: bigint | undefined,
   nonces: readonly bigint[],
 ) {
+  const safetyNetContract = useSafetyNetContract();
   const { data } = useReadContracts({
     contracts: nonces.map((nonce) => ({
       ...safetyNetContract,
@@ -213,7 +224,7 @@ export function useInviteNoncesUsed(
     })),
     query: {
       enabled:
-        isContractConfigured && safetyNetId !== undefined && nonces.length > 0,
+        isContractConfigured() && safetyNetId !== undefined && nonces.length > 0,
       refetchInterval: REFETCH_MS,
     },
   });
@@ -229,13 +240,14 @@ export function useInviteNonceUsed(
   safetyNetId: bigint | undefined,
   nonce: bigint | undefined,
 ) {
+  const safetyNetContract = useSafetyNetContract();
   return useReadContract({
     ...safetyNetContract,
     functionName: "usedNonces",
     args: [safetyNetId ?? 0n, nonce ?? 0n],
     query: {
       enabled:
-        isContractConfigured &&
+        isContractConfigured() &&
         safetyNetId !== undefined &&
         nonce !== undefined,
       refetchInterval: REFETCH_MS,

--- a/web/src/hooks/use-token.ts
+++ b/web/src/hooks/use-token.ts
@@ -2,7 +2,8 @@
 
 import { erc20Abi, maxUint256, zeroAddress, type Address } from "viem";
 import { useReadContract, useReadContracts } from "wagmi";
-import { CHAIN_ID, KNOWN_TOKENS, SAFETYNET_ADDRESS } from "@/lib/config";
+import { ADDRESSES, CHAIN_ID, KNOWN_TOKENS } from "@/lib/config";
+import { useAddresses } from "@/components/addresses-provider";
 import { useTx } from "@/hooks/use-tx";
 
 const REFETCH_MS = 12_000;
@@ -51,12 +52,13 @@ export function useAllowance(
   token: Address | undefined,
   owner: Address | undefined,
 ) {
+  const { safetyNet } = useAddresses();
   return useReadContract({
     address: token,
     abi: erc20Abi,
     chainId: CHAIN_ID,
     functionName: "allowance",
-    args: [owner ?? zeroAddress, SAFETYNET_ADDRESS],
+    args: [owner ?? zeroAddress, safetyNet],
     query: {
       enabled: Boolean(token) && Boolean(owner),
       refetchInterval: REFETCH_MS,
@@ -72,7 +74,7 @@ export function useApprove() {
       address: token,
       abi: erc20Abi,
       functionName: "approve",
-      args: [SAFETYNET_ADDRESS, amount],
+      args: [ADDRESSES.safetyNet, amount],
     });
   return { approve, ...tx };
 }

--- a/web/src/lib/abi/safety-net.ts
+++ b/web/src/lib/abi/safety-net.ts
@@ -8,7 +8,33 @@ export const safetyNetAbi = [
   },
   {
     "type": "function",
+    "name": "BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "DAYS_IN_A_MONTH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "EXPECTED_SICK_SHARE_BPS",
     "inputs": [],
     "outputs": [
       {
@@ -87,6 +113,32 @@ export const safetyNetAbi = [
   {
     "type": "function",
     "name": "PERCENTAGE_BASE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "POOL_RUNWAY_MONTHS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RISK_LOADING_Z_CENTI",
     "inputs": [],
     "outputs": [
       {
@@ -506,6 +558,30 @@ export const safetyNetAbi = [
   },
   {
     "type": "function",
+    "name": "getEffectiveRedeemRatio",
+    "inputs": [
+      {
+        "name": "_id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getMemberBalances",
     "inputs": [
       {
@@ -665,6 +741,11 @@ export const safetyNetAbi = [
             "name": "isDecommissionable",
             "type": "bool",
             "internalType": "bool"
+          },
+          {
+            "name": "effectiveRedeemRatio",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
             "name": "requests",
@@ -1035,6 +1116,11 @@ export const safetyNetAbi = [
             "name": "isDecommissionable",
             "type": "bool",
             "internalType": "bool"
+          },
+          {
+            "name": "effectiveRedeemRatio",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
             "name": "requests",
@@ -2226,6 +2312,31 @@ export const safetyNetAbi = [
   },
   {
     "type": "event",
+    "name": "SafetyNetShortfallDistributed",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "poolBalance",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalWithdrawable",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "SafetyNetStarted",
     "inputs": [
       {
@@ -2457,6 +2568,11 @@ export const safetyNetAbi = [
   {
     "type": "error",
     "name": "ExceedsSmallWithdrawalLimit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPoolFunds",
     "inputs": []
   },
   {

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -51,6 +51,15 @@ const clientEnvSchema = z.object({
     .optional(),
   // Optional Privy client id (app-stacks passes it; optional in the SDK).
   NEXT_PUBLIC_PRIVY_CLIENT_ID: z.string().min(1).optional(),
+  // Runtime address manifest: "off" disables runtime hydration entirely; an
+  // http(s) URL fetches that manifest directly (tests/previews); unset uses
+  // the GitHub contract-addresses release (see remote-addresses.ts).
+  NEXT_PUBLIC_ADDRESSES_URL: z
+    .string()
+    .refine((v) => v === "off" || v.startsWith("http"), {
+      message: 'must be "off" or an http(s) manifest URL',
+    })
+    .optional(),
 });
 
 const parsedEnv = clientEnvSchema.safeParse({
@@ -64,6 +73,7 @@ const parsedEnv = clientEnvSchema.safeParse({
   NEXT_PUBLIC_SITE_URL: optional(process.env.NEXT_PUBLIC_SITE_URL),
   NEXT_PUBLIC_PRIVY_APP_ID: optional(process.env.NEXT_PUBLIC_PRIVY_APP_ID),
   NEXT_PUBLIC_PRIVY_CLIENT_ID: optional(process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID),
+  NEXT_PUBLIC_ADDRESSES_URL: optional(process.env.NEXT_PUBLIC_ADDRESSES_URL),
 });
 
 if (!parsedEnv.success) {
@@ -101,30 +111,45 @@ export const WALLETCONNECT_PROJECT_ID = withDefault(
 );
 
 /**
- * The SafetyNet proxy on Gnosis (see DEPLOYMENTS.md at the repo root).
- * Overridable via NEXT_PUBLIC_SAFETYNET_ADDRESS for other deployments.
- * `isContractConfigured` gates all reads/writes if set to the zero address.
+ * Contract addresses, MUTABLE on purpose (crowdstake.fun pattern): the deploy
+ * workflow publishes an addresses.json manifest to the rolling GitHub release
+ * `contract-addresses`, and `hydrateRemoteAddresses()` (remote-addresses.ts)
+ * updates this object in place at runtime — so a fresh deployment goes live
+ * without a frontend rebuild. The values below are baked-in fallbacks (see
+ * DEPLOYMENTS.md at the repo root).
+ *
+ * Read addresses at CALL TIME (`ADDRESSES.safetyNet` inside a handler/render),
+ * never capture them at module scope. For wagmi reads, subscribe through
+ * `useAddresses()` (addresses-provider.tsx) so queries refetch on hydration.
  */
-export const SAFETYNET_ADDRESS: Address = withDefault(
-  env.NEXT_PUBLIC_SAFETYNET_ADDRESS,
-  "0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE",
-  "NEXT_PUBLIC_SAFETYNET_ADDRESS",
-) as Address;
-
-export const isContractConfigured = SAFETYNET_ADDRESS !== zeroAddress;
+export const ADDRESSES: { safetyNet: Address; delegated: Address } = {
+  safetyNet: withDefault(
+    env.NEXT_PUBLIC_SAFETYNET_ADDRESS,
+    "0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE",
+    "NEXT_PUBLIC_SAFETYNET_ADDRESS",
+  ) as Address,
+  // The DelegatedSafetyNet extension (issue #32): members opt into automatic
+  // deposits; anyone can then pay their owed dues from a pre-approved allowance.
+  delegated: withDefault(
+    optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS),
+    "0x78ac9A4839E94da38F8535e22e64b004afA4e133",
+    "NEXT_PUBLIC_DELEGATED_ADDRESS",
+  ) as Address,
+};
 
 /**
- * The DelegatedSafetyNet extension on Gnosis (see issue #32). It references
- * the main proxy and lets a member opt into automatic deposits: anyone (a
- * keeper/agent or another member) can then pay that member's owed dues from a
- * pre-approved allowance, so they never miss an epoch. Overridable via
- * NEXT_PUBLIC_DELEGATED_ADDRESS for other deployments.
+ * Build-time env pins always win over the runtime manifest — verify-mode E2E
+ * and preview deployments must stay deterministic.
  */
-export const DELEGATED_SAFETYNET_ADDRESS: Address = withDefault(
-  optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS),
-  "0x78ac9A4839E94da38F8535e22e64b004afA4e133",
-  "NEXT_PUBLIC_DELEGATED_ADDRESS",
-) as Address;
+export const ADDRESSES_ENV_PINNED = {
+  safetyNet: env.NEXT_PUBLIC_SAFETYNET_ADDRESS !== undefined,
+  delegated: optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS) !== undefined,
+} as const;
+
+export const ADDRESSES_URL = env.NEXT_PUBLIC_ADDRESSES_URL;
+
+export const isContractConfigured = (): boolean =>
+  ADDRESSES.safetyNet !== zeroAddress;
 
 /** Optional base path for project-subpath hosting (GitHub Pages). */
 export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
@@ -161,12 +186,33 @@ export const addressUrl = (a: string) => `${BLOCK_EXPLORER}/address/${a}`;
 export const DAYS_IN_A_MONTH = 30n;
 
 /**
- * Redeem ratio bounds (SafetyNet.MINIMUM/MAXIMUM_REDEEM_RATIO). Locked to
- * exactly 1 in v1: deposits and withdrawal power are 1:1, leverage disabled.
+ * Support (redeem) ratio bounds, mirroring SafetyNet.MINIMUM/MAXIMUM_REDEEM_RATIO.
+ * A member in need can draw up to ratio x their monthly contribution per month.
+ * x1 is a pure savings circle; higher ratios are pool-backed solidarity leverage,
+ * throttled onchain by the actuarial effective-ratio caps (getEffectiveRedeemRatio).
  */
 export const MIN_REDEEM_RATIO = 1;
-export const MAX_REDEEM_RATIO = 1;
-export const REDEEM_RATIO = 1;
+export const MAX_REDEEM_RATIO = 25;
+
+/**
+ * The classic Broodfonds support convention (~22x): EUR 33.75-112.50/month dues
+ * map to EUR 750-2,500/month sickness support. Simple-mode default.
+ */
+export const BROODFONDS_RATIO = 22;
+
+/**
+ * Frontend mirror of the contract's group-size risk cap (SafetyNet constants
+ * EXPECTED_SICK_SHARE_BPS = 200, RISK_LOADING_Z_CENTI = 165): the effective
+ * ratio can't exceed 1 / (p + z*sqrt(p(1-p)/N)) for a group of N. Used to show
+ * realistic support numbers on the create page before a net exists onchain.
+ */
+export function groupRatioCap(memberCount: number): number {
+  if (memberCount < 1) return 1;
+  const loadingBps = Math.floor(
+    (165 * Math.floor(Math.sqrt(Math.floor((200 * 9800) / memberCount)))) / 100,
+  );
+  return Math.max(1, Math.floor(10_000 / (200 + loadingBps)));
+}
 
 /**
  * Mirrors SafetyNet.MAX_PREPAY_EPOCHS — a deposit may prepay dues at most

--- a/web/src/lib/contract-errors.ts
+++ b/web/src/lib/contract-errors.ts
@@ -48,7 +48,9 @@ export const SAFETY_NET_ERRORS: Record<string, string> = {
   ContestWindowClosed:
     "The contest window for this request has closed — it can no longer be contested.",
   InvalidEpochDuration: "The epoch duration must be greater than zero.",
-  InvalidRatio: "The redeem ratio must be between 1 and 22.",
+  InvalidRatio: "The support (redeem) ratio must be between 1 and 25.",
+  InsufficientPoolFunds:
+    "The shared pool can't cover this payout right now — try again after the next dues come in, or the group can wind the net down for a pro-rata split.",
   InvalidSmallWithdrawsLimit:
     "The small-withdrawals limit must be greater than zero.",
   InvalidSmallWithdrawalLimit: "The small-withdrawal limit is invalid.",

--- a/web/src/lib/eip712.ts
+++ b/web/src/lib/eip712.ts
@@ -1,5 +1,5 @@
 import type { Address } from "viem";
-import { CHAIN_ID, SAFETYNET_ADDRESS } from "@/lib/config";
+import { ADDRESSES, CHAIN_ID } from "@/lib/config";
 
 /**
  * EIP-712 domains/types for SafetyNet signatures. Values mirror the contract:
@@ -7,7 +7,7 @@ import { CHAIN_ID, SAFETYNET_ADDRESS } from "@/lib/config";
  * authorizations under "SafetyNetRequest" v1 (both bound to chain 100 and the
  * proxy address).
  */
-export const inviteDomain = (verifyingContract: Address = SAFETYNET_ADDRESS) =>
+export const inviteDomain = (verifyingContract: Address = ADDRESSES.safetyNet) =>
   ({
     name: "SafetyNetInvite",
     version: "1",
@@ -23,7 +23,7 @@ export const inviteTypes = {
 } as const;
 
 export const requestAuthorizationDomain = (
-  verifyingContract: Address = SAFETYNET_ADDRESS,
+  verifyingContract: Address = ADDRESSES.safetyNet,
 ) =>
   ({
     name: "SafetyNetRequest",

--- a/web/src/lib/remote-addresses.ts
+++ b/web/src/lib/remote-addresses.ts
@@ -1,0 +1,150 @@
+import { getAddress, isAddress, type Address } from "viem";
+import { z } from "zod";
+import {
+  ADDRESSES,
+  ADDRESSES_ENV_PINNED,
+  ADDRESSES_URL,
+  CHAIN_ID,
+  VERIFY_MODE,
+} from "@/lib/config";
+
+/**
+ * Runtime contract-address hydration (crowdstake.fun pattern).
+ *
+ * The contracts-deploy workflow publishes an addresses.json manifest to the
+ * rolling `contract-addresses` GitHub release on every deploy. Because this
+ * frontend is a static export (GitHub Pages), fetching that manifest at
+ * runtime means fresh deployments go live WITHOUT a frontend rebuild: the
+ * baked-in addresses in config.ts become mere fallbacks.
+ *
+ * Precedence (strongest first):
+ *   1. Build-time NEXT_PUBLIC_* env pins (ADDRESSES_ENV_PINNED — verify/E2E)
+ *   2. This manifest (latest release)
+ *   3. Baked-in fallbacks in config.ts
+ *
+ * CORS note: plain `github.com/releases/download/...` URLs don't send CORS
+ * headers on the redirect, so browsers can't fetch them. api.github.com sends
+ * `access-control-allow-origin: *` on every response (including the asset
+ * redirect when requested with `Accept: application/octet-stream`), so we go
+ * through the API: release-by-tag → asset → download. Both requests are
+ * "simple" (no preflight) and anonymous (60 req/h/IP — fine for one fetch per
+ * page load).
+ */
+
+const REPO = "BreadchainCoop/safety-net";
+const RELEASE_TAG = "contract-addresses";
+const ASSET_NAME = "addresses.json";
+const FETCH_TIMEOUT_MS = 5_000;
+
+const address = z
+  .string()
+  .refine((v) => isAddress(v, { strict: false }))
+  .transform((v) => getAddress(v));
+
+const manifestSchema = z.object({
+  version: z.literal(1),
+  chains: z.record(
+    z.string(),
+    z
+      .object({
+        safetyNet: address.optional(),
+        delegatedSafetyNet: address.optional(),
+        startBlock: z.number().int().positive().optional(),
+        subgraphUrl: z.url().optional(),
+      })
+      // implementation / proxyAdmin / commit / updatedAt ride along untyped
+      .loose(),
+  ),
+});
+
+/**
+ * Manifest-published runtime extras that aren't addresses. `addressChanged`
+ * flags that the live proxy differs from the baked default, so consumers of
+ * per-address services (the subgraph) can disable stale baked-in endpoints.
+ */
+export const RUNTIME: {
+  subgraphUrl?: string;
+  activityFromBlock?: bigint;
+  addressChanged: boolean;
+} = { addressChanged: false };
+
+function fetchJson(url: string, accept?: string): Promise<unknown> {
+  return fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: accept ? { Accept: accept } : undefined,
+  }).then((r) => {
+    if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
+    return r.json();
+  });
+}
+
+/** Fetch the manifest — direct URL override, or via the GitHub API release. */
+async function fetchManifest(): Promise<unknown> {
+  if (ADDRESSES_URL && ADDRESSES_URL !== "off") {
+    return fetchJson(ADDRESSES_URL);
+  }
+  const release = (await fetchJson(
+    `https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG}`,
+  )) as { assets?: { name: string; url: string }[] };
+  const asset = release.assets?.find((a) => a.name === ASSET_NAME);
+  if (!asset) throw new Error(`release has no ${ASSET_NAME} asset`);
+  return fetchJson(asset.url, "application/octet-stream");
+}
+
+// One in-flight fetch per page load (React StrictMode double-mounts effects in dev).
+let inflight: Promise<boolean> | undefined;
+
+/**
+ * Fetch the latest published addresses and merge them into {@link ADDRESSES}
+ * in place, so call-time reads everywhere pick them up. Fail-soft: on any
+ * error the baked-in addresses stay untouched.
+ *
+ * @returns true if anything was updated (the provider re-renders on that signal).
+ */
+export function hydrateRemoteAddresses(): Promise<boolean> {
+  // Verify mode pins everything for deterministic E2E; "off" is the kill switch.
+  if (VERIFY_MODE || ADDRESSES_URL === "off") return Promise.resolve(false);
+  if (typeof window === "undefined") return Promise.resolve(false);
+
+  inflight ??= (async () => {
+    let raw: unknown;
+    try {
+      raw = await fetchManifest();
+    } catch (e) {
+      console.warn("[remote-addresses] using baked-in addresses:", e);
+      return false;
+    }
+
+    const parsed = manifestSchema.safeParse(raw);
+    if (!parsed.success) {
+      console.warn("[remote-addresses] unrecognized manifest — ignoring");
+      return false;
+    }
+    const entry = parsed.data.chains[String(CHAIN_ID)];
+    if (!entry) return false;
+
+    let updated = false;
+    const apply = (
+      key: "safetyNet" | "delegated",
+      next: Address | undefined,
+      pinned: boolean,
+    ) => {
+      if (!next || pinned) return;
+      if (ADDRESSES[key].toLowerCase() !== next.toLowerCase()) {
+        ADDRESSES[key] = next;
+        updated = true;
+        if (key === "safetyNet") RUNTIME.addressChanged = true;
+      }
+    };
+    apply("safetyNet", entry.safetyNet, ADDRESSES_ENV_PINNED.safetyNet);
+    apply("delegated", entry.delegatedSafetyNet, ADDRESSES_ENV_PINNED.delegated);
+
+    if (entry.subgraphUrl) RUNTIME.subgraphUrl = entry.subgraphUrl;
+    if (entry.startBlock) RUNTIME.activityFromBlock = BigInt(entry.startBlock);
+
+    return updated;
+  })();
+
+  return inflight;
+}


### PR DESCRIPTION
## What

Answers "are we enforcing the Wikipedia Broodfonds ratio?" — we weren't (redeemRatio was locked to 1, making the app a pure savings circle). Now we do, with an actuarial risk model on top, researched from Broodfonds practice, historical mutual sickness funds, and small-group insurance pricing.

### Contract (fresh deployment, not an upgrade)
- `redeemRatio` configurable **1–25** (Broodfonds convention ≈×22 is the Simple-mode default): a member in need can draw up to ratio × their monthly contribution per month from the shared pool.
- **Actuarial effective-ratio throttle** (`getEffectiveRedeemRatio`, used by all withdrawal math): `min(configured, groupCap, poolCap)`, floored at the always-solvent ×1.
  - `groupCap = 1/(p + z·√(p(1−p)/N))` — standard-deviation risk loading shrinking with group size (law of large numbers). **p = 2%** expected sick share (Broodfonds reported ~1% of 5,000+ members claiming at a time; historical US industrial sickness funds ~2% of the work-year); **z = 1.65** (~5% ruin target — the strict end of the 5–10% range regulators accept for new insurers, chosen because an onchain fund has no Broodfonds-Alliance reinsurance backstop). Gives ×5 at N=2, ×15 at N=25, ×19 at N=50. Notably Broodfonds' own ×22.2 at N=50 corresponds to z≈1.28 — the model reproduces reality at the loose end.
  - `poolCap = pool/(6·contribution)` — the pool must hold **6 months** of a claimant's support runway (average disability claim ≈ 8 months); young funds ramp up as the buffer builds, exactly how real Broodfondsen behave.
- **Pool-solvency gate**: every payout routes through `_deduct`, which reverts `InsufficientPoolFunds` when the pool can't cover a claim; request views mirror the rule.
- **Pro-rata shortfall decommission**: when claims exceed the pool, wind-down pays `pool×claim/totalClaims` (the historical mutual-fund benefit cut) and emits `SafetyNetShortfallDistributed`. Ratio-1 nets keep v1 behavior byte-identical.
- 202 tests (16 new): hand-computed cap values, solvency reverts on both payout paths, pro-rata conservation, fuzz across ratio 1–25.

### Deploys (crowdstake.fun pattern)
- `Deploy.sol` broadcasts the whole stack (impl + proxy + DelegatedSafetyNet + token allowlist) in one run.
- New **`contracts-deploy.yml`** (manual dispatch): etherform deploy scripts → Blockscout verify → publishes merged `addresses.json` to the rolling **`contract-addresses` release**.
- The frontend **fetches that manifest at runtime** (CORS-safe GitHub API fetch, zod-validated, fail-soft, `NEXT_PUBLIC_*` pins win) — fresh deployments go live with **no frontend rebuild**.

### Frontend
- **Create page**: Simple mode = Broodfonds — ×22 support with a live "monthly support when in need ≈ 1,100 BREAD/month" line that also shows what the chosen group size sustainably backs; contribution + group-size **sliders**; minimum-members defaults to **25** (auto-clamped to group size; Advanced can lower to 2). Advanced adds a support-ratio slider and renames the instant threshold to **petty cash** (that "$12.5" was being misread as the withdrawal cap).
- **Withdraw panel**: days-of-support **slider** bounded by balance; day-value math now uses the contract's `effectiveRedeemRatio` so the preview matches what a withdrawal actually pays right now.
- Activity feed guards against a stale baked subgraph once the runtime address diverges (falls back to log scan).

## After merge
1. Dispatch `contracts-deploy.yml` (gnosis) → publishes the manifest release.
2. Clear the `NEXT_PUBLIC_SAFETYNET_ADDRESS` repo variable (pages.yml) so production unpins.
3. Update subgraph address/startBlock → deploy v0.0.3.
4. Full verify-mode E2E against the fresh stack.