### PR TITLE
chore: baked defaults + subgraph v0.0.3 for the solidarity-ratio stack

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -11,11 +11,21 @@ frontend rebuild. The tables below are historical snapshots; the release is the 
 
 ## Gnosis Chain (chainId 100) — solidarity-ratio stack (current)
 
-Deployed via `contracts-deploy.yml` (see the rolling release for addresses). Enables the
-Broodfonds support ratio (configured 1–25, Simple-mode default ×22) with the actuarial
-effective-ratio throttle (`getEffectiveRedeemRatio`: group-size risk loading p=2%, z=1.65,
-plus a 6-month pool-runway cap), pool-solvency reverts (`InsufficientPoolFunds`), and
+Deployed 2026-07-04 via `contracts-deploy.yml` (run of commit `8dac487`, deploy block 47031243).
+Enables the Broodfonds support ratio (configured 1–25, Simple-mode default ×22) with the
+actuarial effective-ratio throttle (`getEffectiveRedeemRatio`: group-size risk loading p=2%,
+z=1.65, plus a 6-month pool-runway cap), pool-solvency reverts (`InsufficientPoolFunds`), and
 pro-rata shortfall decommission (`SafetyNetShortfallDistributed`).
+
+| Contract | Address |
+|----------|---------|
+| SafetyNet (proxy — use this address) | [`0x63c3c299CD5C5479E6999189D7827490Ea71cEAe`](https://gnosis.blockscout.com/address/0x63c3c299CD5C5479E6999189D7827490Ea71cEAe) |
+| SafetyNet (implementation) | [`0x7763be733f595C3AB7dEE713937f0c2F116acE21`](https://gnosis.blockscout.com/address/0x7763be733f595C3AB7dEE713937f0c2F116acE21) |
+| ProxyAdmin (auto-deployed by proxy) | [`0x83909C3dd3734f8575b65CD2F6bEda63A696d26F`](https://gnosis.blockscout.com/address/0x83909C3dd3734f8575b65CD2F6bEda63A696d26F) |
+| DelegatedSafetyNet (extension) | [`0x88fd6d424Dd415780F42891f3F699d57cD5d4C2c`](https://gnosis.blockscout.com/address/0x88fd6d424Dd415780F42891f3F699d57cD5d4C2c) |
+
+- Owner / admin: `0x6636A1CCBdf54485067304C1a590DE016DeaD9F0` · allowed tokens: WXDAI, BREAD
+- Subgraph: [`safety-net/v0.0.3`](https://api.studio.thegraph.com/query/1756070/safety-net/v0.0.3)
 
 ## Gnosis Chain (chainId 100) — ratio-1 stack (frozen 2026-07-04)
 

--- a/subgraph/abis/SafetyNet.json
+++ b/subgraph/abis/SafetyNet.json
@@ -6,7 +6,33 @@
   },
   {
     "type": "function",
+    "name": "BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "DAYS_IN_A_MONTH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "EXPECTED_SICK_SHARE_BPS",
     "inputs": [],
     "outputs": [
       {
@@ -85,6 +111,32 @@
   {
     "type": "function",
     "name": "PERCENTAGE_BASE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "POOL_RUNWAY_MONTHS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RISK_LOADING_Z_CENTI",
     "inputs": [],
     "outputs": [
       {
@@ -504,6 +556,30 @@
   },
   {
     "type": "function",
+    "name": "getEffectiveRedeemRatio",
+    "inputs": [
+      {
+        "name": "_id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_member",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getMemberBalances",
     "inputs": [
       {
@@ -663,6 +739,11 @@
             "name": "isDecommissionable",
             "type": "bool",
             "internalType": "bool"
+          },
+          {
+            "name": "effectiveRedeemRatio",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
             "name": "requests",
@@ -1033,6 +1114,11 @@
             "name": "isDecommissionable",
             "type": "bool",
             "internalType": "bool"
+          },
+          {
+            "name": "effectiveRedeemRatio",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
             "name": "requests",
@@ -2224,6 +2310,31 @@
   },
   {
     "type": "event",
+    "name": "SafetyNetShortfallDistributed",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "poolBalance",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalWithdrawable",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "SafetyNetStarted",
     "inputs": [
       {
@@ -2455,6 +2566,11 @@
   {
     "type": "error",
     "name": "ExceedsSmallWithdrawalLimit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPoolFunds",
     "inputs": []
   },
   {

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -17,9 +17,9 @@ dataSources:
     source:
       # SafetyNet proxy on Gnosis. graph-node reads logs by address; the
       # implementation ABI only decodes them (standard UUPS pattern).
-      address: "0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE"
+      address: "0x63c3c299CD5C5479E6999189D7827490Ea71cEAe"
       abi: SafetyNet
-      startBlock: 47000324
+      startBlock: 47031243
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -125,14 +125,14 @@ export const WALLETCONNECT_PROJECT_ID = withDefault(
 export const ADDRESSES: { safetyNet: Address; delegated: Address } = {
   safetyNet: withDefault(
     env.NEXT_PUBLIC_SAFETYNET_ADDRESS,
-    "0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE",
+    "0x63c3c299CD5C5479E6999189D7827490Ea71cEAe",
     "NEXT_PUBLIC_SAFETYNET_ADDRESS",
   ) as Address,
   // The DelegatedSafetyNet extension (issue #32): members opt into automatic
   // deposits; anyone can then pay their owed dues from a pre-approved allowance.
   delegated: withDefault(
     optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS),
-    "0x78ac9A4839E94da38F8535e22e64b004afA4e133",
+    "0x88fd6d424Dd415780F42891f3F699d57cD5d4C2c",
     "NEXT_PUBLIC_DELEGATED_ADDRESS",
   ) as Address,
 };


### PR DESCRIPTION
Follow-up to #94 after the first `contracts-deploy.yml` run: baked fallback addresses track the fresh stack (keeps the stale-subgraph guard quiet and makes verify-mode E2E target it natively), subgraph v0.0.3 indexes the new proxy from its deploy block, DEPLOYMENTS.md gets the concrete table. Repo vars already updated (`NEXT_PUBLIC_SAFETYNET_ADDRESS` deleted → runtime manifest unpinned; `NEXT_PUBLIC_SUBGRAPH_URL` → v0.0.3).