### PR TITLE
fix(rpc): refresh Gnosis RPC fallback list (drop dead 1rpc.io/blastapi)

### DIFF
--- a/web/src/lib/wagmi.ts
+++ b/web/src/lib/wagmi.ts
@@ -69,14 +69,25 @@ const connectors: CreateConnectorFn[] =
  */
 export const chains = [gnosis, mainnet] as const;
 
+// Gnosis read endpoints, tried in order via wagmi `fallback`. RPC_URL
+// (NEXT_PUBLIC_RPC_URL, defaulting to rpc.gnosischain.com) stays primary; the
+// rest are verified keyless public endpoints kept intentionally diverse
+// (different operators) so one provider being down, rate-limited, or blocked
+// on a given network doesn't blank the app. NOTE: this is a static-export dapp
+// (next.config `output: "export"`), so there is no server runtime to proxy
+// through — the browser talks to these hosts directly. A client whose
+// VPN/DNS/ad-blocker null-routes RPC hostnames (ERR_NAME_NOT_RESOLVED) will
+// still need a first-party endpoint (private RPC on our own domain) to be
+// fully immune; that is infra, not a code change.
 export const transports = {
   [gnosis.id]: fallback([
     http(RPC_URL, { timeout: 7_000, retryCount: 1 }),
-    http("https://1rpc.io/gnosis", { timeout: 7_000, retryCount: 1 }),
-    http("https://gnosis-mainnet.public.blastapi.io", {
+    http("https://gnosis.drpc.org", { timeout: 7_000, retryCount: 1 }),
+    http("https://gnosis-rpc.publicnode.com", {
       timeout: 7_000,
       retryCount: 1,
     }),
+    http("https://rpc.gnosis.gateway.fm", { timeout: 7_000, retryCount: 1 }),
   ]),
   // ENS-only public fallback (no key). Reads never write, so no risk.
   [mainnet.id]: fallback([


### PR DESCRIPTION
## What Josh hit
Creating a Safety Net failed with **"Transaction failed. Please try again."** The console was full of `net::ERR_NAME_NOT_RESOLVED` for **every** RPC host in our gnosis `fallback([...])`, plus `400`s from Privy's own RPC. With no reachable RPC, wagmi can't estimate gas or broadcast, so the tx dies **before** the signing prompt ever appears.

## Two findings, one of them a real bug for everyone
I probed the endpoints from outside Josh's network:

| Endpoint | Result |
|---|---|
| `rpc.gnosischain.com` (RPC_URL default) | ✅ 200, chainId `0x64` |
| `1rpc.io/gnosis` | ❌ **403 forbidden** (globally) |
| `gnosis-mainnet.public.blastapi.io` | ❌ errors on `eth_` calls |

So two of our three fallbacks are dead for **all** users — the redundancy was illusory. This PR replaces them with three verified, keyless, operator-diverse endpoints:
- `gnosis.drpc.org` (✅ 200, ~0.1s)
- `gnosis-rpc.publicnode.com` (✅ 200, ~0.05s)
- `rpc.gnosis.gateway.fm` (✅ 200, ~0.4s)

`RPC_URL` (env-configurable, defaults to `rpc.gnosischain.com`) stays primary.

## Honest scope / what this does NOT fix
Josh's errors are `ERR_NAME_NOT_RESOLVED` **across two browsers** → his OS/router-level DNS or VPN is null-routing crypto-RPC hostnames (same class of issue daopunk hit — VPN off → worked). Swapping endpoints improves reliability for everyone and *may* dodge his blocklist, but if his network blocks **all** RPC hostnames, new public hosts can be blocked too.

The airtight fix would be a **first-party RPC endpoint on our own domain** so the browser only resolves the app's own host — but this app is a **static export** (`next.config.ts` → `output: "export"`), so we can **not** add a Next.js `/api/rpc` proxy route like app-stacks did (no server runtime). Options for a follow-up, for the team to decide (infra, not code):
1. Point `NEXT_PUBLIC_RPC_URL` at a private RPC (Alchemy/dRPC key) on a subdomain of the app's own domain, or
2. Move off static export to a serverful deploy and add the same-origin proxy.

## Separate item (not in this PR): Privy 400
`auth.privy.io/api/v1/apps/<appId>/rpc` returns `400` — server-side, on the Privy dashboard config. @RonTuretzky worth confirming Gnosis (100) is enabled and the gas-sponsorship/RPC override for Gnosis is valid; that 400 is likely why the signing prompt never popped.

## Risk
Low — read-only transport list change, no ABI/logic/write-path changes. Static export build is unaffected.