### PR TITLE
fix(config): baked fallback addresses point at frozen ratio-1 stack → InvalidRatio

### DIFF
--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -125,14 +125,14 @@ export const WALLETCONNECT_PROJECT_ID = withDefault(
 export const ADDRESSES: { safetyNet: Address; delegated: Address } = {
   safetyNet: withDefault(
     env.NEXT_PUBLIC_SAFETYNET_ADDRESS,
-    "0x4b1B21A7983EBEC95575d1dac63Db17Cd7eF6FdE",
+    "0x63c3c299CD5C5479E6999189D7827490Ea71cEAe",
     "NEXT_PUBLIC_SAFETYNET_ADDRESS",
   ) as Address,
   // The DelegatedSafetyNet extension (issue #32): members opt into automatic
   // deposits; anyone can then pay their owed dues from a pre-approved allowance.
   delegated: withDefault(
     optional(process.env.NEXT_PUBLIC_DELEGATED_ADDRESS),
-    "0x78ac9A4839E94da38F8535e22e64b004afA4e133",
+    "0x88Fd6D424dd415780f42891F3f699D57Cd5D4C2C",
     "NEXT_PUBLIC_DELEGATED_ADDRESS",
   ) as Address,
 };


### PR DESCRIPTION
## Symptom
A member creating a Safety Net got **"The support (redeem) ratio must be between 1 and 25."** (contract `InvalidRatio`) below the Create button — *after* getting past an earlier no-RPC failure (see #96).

## Root cause — wrong contract, not a bad ratio
There are two live stacks on Gnosis (per `DEPLOYMENTS.md`):

| Stack | Proxy | `MINIMUM_REDEEM_RATIO` | `MAXIMUM_REDEEM_RATIO` |
|---|---|---|---|
| **Frozen ratio-1** (superseded) | `0x4b1B21A7…` | 1 | **1** |
| **Solidarity-ratio (current)** | `0x63c3c299…` | 1 | **25** |

Both rows **verified on-chain** via `eth_call` (`MAXIMUM_REDEEM_RATIO()` → `0xa78d4255`): `0x4b1B…` returns **1**, `0x63c3…` returns **25**.

The frontend is supposed to hydrate the **current** address at runtime from the rolling [`contract-addresses`](https://github.com/BreadchainCoop/safety-net/releases/tag/contract-addresses) manifest (which today points chainId 100 at `0x63c3c299…`). But the **baked-in fallback** in `config.ts` was still the **frozen ratio-1** proxy `0x4b1B…`. The write hook reads `ADDRESSES.safetyNet` at call time (`use-safety-net-writes.ts`), so when hydration hasn't landed — fetch blocked/slow, or a create fired before hydration — `create()` goes to the **MAX-ratio-1** contract. The form defaults the support ratio to **×22** (`BROODFONDS_RATIO`), and the UI validates 1–25, so `22 > 1` → **`InvalidRatio`**. Nothing was wrong with the user's input.

This lines up with the reporter's environment: their console showed RPC hostnames failing DNS (VPN/DNS filtering), and the manifest is fetched from `github.com` releases — the same filtering that starved the RPCs can starve hydration, leaving the stale baked fallback in force.

## Fix
Update the two baked fallbacks in `config.ts` to the **current** manifest (checksummed):
```
safetyNet  0x4b1B21A7…  →  0x63c3c299CD5C5479E6999189D7827490Ea71cEAe   (MAX ratio 1 → 25)
delegated  0x78ac9A48…  →  0x88Fd6D424dd415780f42891F3f699D57Cd5D4C2C
```
Runtime hydration still wins; this only makes the fallback **correct** so a hydration hiccup no longer routes users to a ratio-locked contract.

## Recommended follow-ups (not in this PR)
1. **Pin at build:** set `NEXT_PUBLIC_SAFETYNET_ADDRESS=0x63c3c299…` (and `NEXT_PUBLIC_DELEGATED_ADDRESS=0x88Fd6D42…`) in the host/deploy env so the address is deterministic (`ADDRESSES_ENV_PINNED`), independent of a runtime fetch.
2. **Gate the Create button on hydration** (or block submit until the manifest resolves) so a create can't fire against the fallback during the hydration window.

## Risk
Low — changes two fallback constants to the verified current deployment; no logic/ABI changes. Pairs with #96 (RPC list).