### PR TITLE
fix(addresses): serve contract manifest same-origin (fix GH Pages CORS)

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -22,3 +22,6 @@ next-env.d.ts
 
 # parallel dev/build dirs (NEXT_DIST_DIR)
 .next-*/
+
+# build-generated same-origin contract manifest (scripts/fetch-addresses.mjs)
+public/addresses.json

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3000",
-    "build": "next build",
+    "build": "node scripts/fetch-addresses.mjs && next build",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/web/scripts/fetch-addresses.mjs
+++ b/web/scripts/fetch-addresses.mjs
@@ -1,0 +1,52 @@
+// Build-time fetch of the published contract-addresses manifest into
+// public/addresses.json, so the client can read it SAME-ORIGIN.
+//
+// Why: this app is a static export on GitHub Pages. The previous runtime path
+// fetched the manifest cross-origin from the GitHub *release asset*, whose
+// download 302-redirects to release-assets.githubusercontent.com WITHOUT an
+// `Access-Control-Allow-Origin` header — so the browser blocked it and the app
+// silently fell back to the baked-in addresses in config.ts. Fetching here at
+// build time (Node — no CORS) and serving the file from our own origin removes
+// the cross-origin hop entirely.
+//
+// Fail-soft: on any error we skip writing. The client then 404s the same-origin
+// file and falls back to the baked-in addresses (unchanged behaviour, minus the
+// console error), so a flaky release fetch never fails the build.
+
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const REPO = "BreadchainCoop/safety-net";
+const TAG = "contract-addresses";
+const ASSET = "addresses.json";
+const PUBLIC_DIR = join(process.cwd(), "public");
+const OUT = join(PUBLIC_DIR, ASSET);
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const auth = token ? { Authorization: `Bearer ${token}` } : {};
+  const rel = await fetch(
+    `https://api.github.com/repos/${REPO}/releases/tags/${TAG}`,
+    { headers: { Accept: "application/vnd.github+json", ...auth } },
+  );
+  if (!rel.ok) throw new Error(`release ${TAG} -> HTTP ${rel.status}`);
+  const release = await rel.json();
+  const asset = (release.assets ?? []).find((a) => a.name === ASSET);
+  if (!asset) throw new Error(`release has no ${ASSET} asset`);
+  const dl = await fetch(asset.url, {
+    headers: { Accept: "application/octet-stream", ...auth },
+  });
+  if (!dl.ok) throw new Error(`asset download -> HTTP ${dl.status}`);
+  const text = await dl.text();
+  JSON.parse(text); // validate JSON before writing
+  await mkdir(PUBLIC_DIR, { recursive: true });
+  await writeFile(OUT, text);
+  console.log(`[fetch-addresses] wrote public/${ASSET} (${text.length} bytes)`);
+}
+
+main().catch((e) => {
+  console.warn(
+    `[fetch-addresses] skipped (${e.message}); app will use baked-in addresses`,
+  );
+  process.exit(0); // never fail the build
+});

--- a/web/src/lib/remote-addresses.ts
+++ b/web/src/lib/remote-addresses.ts
@@ -4,6 +4,7 @@ import {
   ADDRESSES,
   ADDRESSES_ENV_PINNED,
   ADDRESSES_URL,
+  BASE_PATH,
   CHAIN_ID,
   VERIFY_MODE,
 } from "@/lib/config";
@@ -22,18 +23,18 @@ import {
  *   2. This manifest (latest release)
  *   3. Baked-in fallbacks in config.ts
  *
- * CORS note: plain `github.com/releases/download/...` URLs don't send CORS
- * headers on the redirect, so browsers can't fetch them. api.github.com sends
- * `access-control-allow-origin: *` on every response (including the asset
- * redirect when requested with `Accept: application/octet-stream`), so we go
- * through the API: release-by-tag → asset → download. Both requests are
- * "simple" (no preflight) and anonymous (60 req/h/IP — fine for one fetch per
- * page load).
+ * Same-origin note: on GitHub Pages the app is served from breadchaincoop.
+ * github.io, and fetching the manifest cross-origin from the GitHub *release
+ * asset* fails — the asset download 302-redirects to
+ * release-assets.githubusercontent.com, which omits `Access-Control-Allow-
+ * Origin`, so the browser blocks it. Instead, `scripts/fetch-addresses.mjs`
+ * pulls the manifest server-side at build time and writes it to
+ * `public/addresses.json`; the client then fetches it from its OWN origin
+ * (`${BASE_PATH}/addresses.json`) — no CORS hop. A contract-only redeploy now
+ * needs a Pages rebuild to surface (the workflow can trigger one); the
+ * `NEXT_PUBLIC_ADDRESSES_URL` override still bypasses this for previews.
  */
 
-const REPO = "BreadchainCoop/safety-net";
-const RELEASE_TAG = "contract-addresses";
-const ASSET_NAME = "addresses.json";
 const FETCH_TIMEOUT_MS = 5_000;
 
 const address = z
@@ -79,17 +80,16 @@ function fetchJson(url: string, accept?: string): Promise<unknown> {
   });
 }
 
-/** Fetch the manifest — direct URL override, or via the GitHub API release. */
+/**
+ * Fetch the manifest — direct URL override, or the build-shipped same-origin
+ * `public/addresses.json` (written by scripts/fetch-addresses.mjs). The browser
+ * only ever talks to our own origin, so there's no cross-origin/CORS hop.
+ */
 async function fetchManifest(): Promise<unknown> {
   if (ADDRESSES_URL && ADDRESSES_URL !== "off") {
     return fetchJson(ADDRESSES_URL);
   }
-  const release = (await fetchJson(
-    `https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG}`,
-  )) as { assets?: { name: string; url: string }[] };
-  const asset = release.assets?.find((a) => a.name === ASSET_NAME);
-  if (!asset) throw new Error(`release has no ${ASSET_NAME} asset`);
-  return fetchJson(asset.url, "application/octet-stream");
+  return fetchJson(`${BASE_PATH}/addresses.json`);
 }
 
 // One in-flight fetch per page load (React StrictMode double-mounts effects in dev).


### PR DESCRIPTION
## The origin bug
On `breadchaincoop.github.io`, the console shows:
```
Access to fetch at 'https://release-assets.githubusercontent.com/…addresses.json…'
(redirected from 'https://api.github.com/repos/BreadchainCoop/safety-net/releases/assets/…')
from origin 'https://breadchaincoop.github.io' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present
→ [remote-addresses] using baked-in addresses: TypeError: Failed to fetch
```
The runtime manifest fetch went to the GitHub **release asset**, whose download **302-redirects** to `release-assets.githubusercontent.com`, and *that* host omits `Access-Control-Allow-Origin`. So the browser blocked it and the app **silently fell back to baked-in addresses on every page load** — the runtime manifest never actually worked on Pages. (I verified with `curl`: `api.github.com` sends ACAO `*`, but the redirect target does **not**.)

## Fix — no cross-origin hop
- **`web/scripts/fetch-addresses.mjs`** (new): at build time, pulls the manifest **server-side** (Node, no CORS) into `public/addresses.json`. Fail-soft — any error just skips writing, so a flaky release fetch never breaks the build.
- **`web/package.json`**: `build` now runs the fetch before `next build`.
- **`web/src/lib/remote-addresses.ts`**: `fetchManifest()` now fetches the **same-origin** `${BASE_PATH}/addresses.json`. The browser only talks to our own origin → CORS can't apply. The `NEXT_PUBLIC_ADDRESSES_URL` override and the baked-in fallback are unchanged; removed the now-dead release-asset code + the stale "api.github.com sends CORS" comment.
- **`web/.gitignore`**: ignores the build-generated `public/addresses.json`.

## Trade-off (called out honestly)
This moves the manifest to build time, so a **contract-only redeploy** now needs a Pages rebuild to surface (previously it was *supposed* to be live without one — but that path was CORS-broken anyway, so nothing regresses). If we want true no-rebuild updates back, the follow-up is to have `contracts-deploy.yml` commit the manifest to a raw-fetchable ref and fetch it via `raw.githubusercontent.com` (which **does** send ACAO `*`); happy to do that separately.

## crowdstake.fun
Checked — **crowdstaking-v2 does not use this pattern** (its addresses/subgraph URL are hardcoded constants; no `releases`/`addresses.json` fetch). No change needed there.

## Risk
Low — read-path only; no ABI/contract/write changes. Fixes the console error and makes hydration actually work on Pages.