### PR TITLE
fix(privy): sponsor embedded-wallet transactions (gasless create)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,6 +46,9 @@ jobs:
           # Privy embedded wallets go live when this repo variable is set. Leave
           # it UNSET to keep the RainbowKit path; the app is byte-identical then.
           NEXT_PUBLIC_PRIVY_APP_ID: ${{ vars.NEXT_PUBLIC_PRIVY_APP_ID }}
+          # Gas sponsorship is ON by default; set this repo var to "false" only
+          # for a Privy app without a Gnosis gas-sponsorship policy.
+          NEXT_PUBLIC_PRIVY_SPONSOR_GAS: ${{ vars.NEXT_PUBLIC_PRIVY_SPONSOR_GAS }}
           # Activity feed reads the subgraph when set, else falls back to logs.
           NEXT_PUBLIC_SUBGRAPH_URL: ${{ vars.NEXT_PUBLIC_SUBGRAPH_URL }}
         run: pnpm build

--- a/web/.env.example
+++ b/web/.env.example
@@ -37,10 +37,11 @@ NEXT_PUBLIC_BASE_PATH=
 NEXT_PUBLIC_PRIVY_APP_ID=
 # Optional Privy client id (passed alongside the app id).
 NEXT_PUBLIC_PRIVY_CLIENT_ID=
-# Request Privy gas sponsorship for embedded-wallet transactions ("true" to
-# enable). REQUIRES an active Gnosis gas-sponsorship policy in the Privy
-# dashboard — without one, Privy rejects sponsored sends with a 400. Leave
-# unset so embedded wallets self-pay gas (Privy prompts funding when short).
+# Privy gas sponsorship for embedded-wallet transactions. ON by default; set to
+# "false" to disable. Requires, in the Privy dashboard: a Gnosis gas-sponsorship
+# policy AND "Allow transactions from the client" enabled — otherwise Privy
+# rejects client-initiated sends with a 400. When disabled, embedded wallets
+# self-pay gas (Privy prompts funding when short).
 NEXT_PUBLIC_PRIVY_SPONSOR_GAS=
 
 # Verify mode (E2E onchain testing) is dev-only and intentionally NOT listed

--- a/web/.env.example
+++ b/web/.env.example
@@ -37,6 +37,11 @@ NEXT_PUBLIC_BASE_PATH=
 NEXT_PUBLIC_PRIVY_APP_ID=
 # Optional Privy client id (passed alongside the app id).
 NEXT_PUBLIC_PRIVY_CLIENT_ID=
+# Request Privy gas sponsorship for embedded-wallet transactions ("true" to
+# enable). REQUIRES an active Gnosis gas-sponsorship policy in the Privy
+# dashboard — without one, Privy rejects sponsored sends with a 400. Leave
+# unset so embedded wallets self-pay gas (Privy prompts funding when short).
+NEXT_PUBLIC_PRIVY_SPONSOR_GAS=
 
 # Verify mode (E2E onchain testing) is dev-only and intentionally NOT listed
 # here — never put key material next to production config. See

--- a/web/src/hooks/use-tx-sender-privy.ts
+++ b/web/src/hooks/use-tx-sender-privy.ts
@@ -16,13 +16,15 @@ import type { TxRequest } from "@/hooks/use-tx";
  *   3. Privy `sendTransaction`.
  *
  * Gas modes:
- *   - PRIVY_SPONSOR_GAS: request `sponsor: true` and sign silently. This ONLY
- *     works when a Gnosis gas-sponsorship policy is configured in the Privy
- *     dashboard — otherwise Privy's wallet RPC rejects with a 400. Off by
- *     default for that reason.
- *   - Unsponsored (default): the embedded wallet pays its own gas. We show the
- *     Privy UI and pass a Gnosis `fundWalletConfig` so a wallet with no xDAI is
- *     prompted to fund instead of failing silently.
+ *   - PRIVY_SPONSOR_GAS (default ON): request `sponsor: true` and sign
+ *     silently — gasless for the user. Requires, in the Privy dashboard, a
+ *     Gnosis gas-sponsorship policy AND "Allow transactions from the client"
+ *     enabled; without either, Privy's wallet RPC rejects the client-initiated
+ *     send with a 400 (surfaced below as a clear message).
+ *   - Unsponsored (NEXT_PUBLIC_PRIVY_SPONSOR_GAS=false): the embedded wallet
+ *     pays its own gas. We show the Privy UI and pass a Gnosis
+ *     `fundWalletConfig` so a wallet with no xDAI is prompted to fund instead
+ *     of failing silently.
  *
  * Returns the tx hash so the caller's existing
  * useWaitForTransactionReceipt/invalidation flow is unchanged.
@@ -88,12 +90,13 @@ export function useTxSenderPrivy() {
             : { sponsor: false, fundWalletConfig: { chain: CHAIN } },
         );
       } catch (err) {
-        // A 400 from Privy's wallet RPC on a *sponsored* send almost always
-        // means no gas-sponsorship policy is configured for Gnosis. Surface a
-        // clear, actionable message instead of the raw HTTP error.
+        // A 400 from Privy's wallet RPC on a *sponsored* send means the Privy
+        // app can't run this client-initiated sponsored transaction — usually
+        // "Allow transactions from the client" is off or there's no Gnosis
+        // gas-sponsorship policy. Surface something actionable, not the raw 400.
         if (sponsor) {
           throw new Error(
-            "Gas sponsorship isn't set up for this network. Ask the operator to enable Gnosis gas sponsorship in the Privy dashboard, or disable NEXT_PUBLIC_PRIVY_SPONSOR_GAS so the wallet pays its own gas.",
+            "Couldn't send the sponsored transaction. In the Privy dashboard, enable Gnosis gas sponsorship and \"Allow transactions from the client\" — or set NEXT_PUBLIC_PRIVY_SPONSOR_GAS=false so the wallet pays its own gas.",
             { cause: err },
           );
         }

--- a/web/src/hooks/use-tx-sender-privy.ts
+++ b/web/src/hooks/use-tx-sender-privy.ts
@@ -6,17 +6,25 @@ import { encodeFunctionData, type Abi } from "viem";
 import { useSendTransaction } from "@privy-io/react-auth";
 import { useConnectedUser } from "@breadcoop/ui";
 import { wagmiConfigPrivy } from "@/lib/wagmi-privy";
-import { CHAIN_ID } from "@/lib/config";
+import { CHAIN, CHAIN_ID, PRIVY_SPONSOR_GAS } from "@/lib/config";
 import type { TxRequest } from "@/hooks/use-tx";
 
 /**
- * Privy sponsored-tx sender (app-stacks `use-simulate-and-sponsor-tx.ts` +
- * `use-sponsored-tx.ts`):
- *   1. simulate via wagmi to catch reverts before Privy's UI,
+ * Privy embedded-wallet tx sender (app-stacks `use-simulate-and-sponsor-tx.ts`):
+ *   1. simulate via wagmi to catch reverts before Privy takes over,
  *   2. encode calldata,
- *   3. Privy `sendTransaction` with `{ sponsor: true on Gnosis,
- *      uiOptions: { showWalletUIs: false } }` (silent signing),
- * returning the tx hash so the caller's existing
+ *   3. Privy `sendTransaction`.
+ *
+ * Gas modes:
+ *   - PRIVY_SPONSOR_GAS: request `sponsor: true` and sign silently. This ONLY
+ *     works when a Gnosis gas-sponsorship policy is configured in the Privy
+ *     dashboard — otherwise Privy's wallet RPC rejects with a 400. Off by
+ *     default for that reason.
+ *   - Unsponsored (default): the embedded wallet pays its own gas. We show the
+ *     Privy UI and pass a Gnosis `fundWalletConfig` so a wallet with no xDAI is
+ *     prompted to fund instead of failing silently.
+ *
+ * Returns the tx hash so the caller's existing
  * useWaitForTransactionReceipt/invalidation flow is unchanged.
  *
  * This module is only imported from `use-tx-sender.ts` when `PRIVY_ENABLED`,
@@ -62,23 +70,37 @@ export function useTxSenderPrivy() {
         args: request.args,
       } as Parameters<typeof encodeFunctionData>[0]);
 
-      const { hash } = await sendTransaction(
-        {
-          to: request.address,
-          data,
-          value: request.value,
-          chainId: CHAIN_ID,
-        },
-        {
-          // Gas sponsorship is a Privy dashboard setting; the code only opts in
-          // on Gnosis. If sponsorship is off there the tx still works, paid
-          // from the embedded wallet.
-          sponsor: CHAIN_ID === 100,
-          uiOptions: { showWalletUIs: false },
-        },
-      );
+      // Sponsorship needs a dashboard policy; when off, the wallet self-pays,
+      // so keep the Privy UI visible and offer funding on an empty balance.
+      const sponsor = PRIVY_SPONSOR_GAS && CHAIN_ID === 100;
 
-      return hash as `0x${string}`;
+      let result: { hash: `0x${string}` };
+      try {
+        result = await sendTransaction(
+          {
+            to: request.address,
+            data,
+            value: request.value,
+            chainId: CHAIN_ID,
+          },
+          sponsor
+            ? { sponsor: true, uiOptions: { showWalletUIs: false } }
+            : { sponsor: false, fundWalletConfig: { chain: CHAIN } },
+        );
+      } catch (err) {
+        // A 400 from Privy's wallet RPC on a *sponsored* send almost always
+        // means no gas-sponsorship policy is configured for Gnosis. Surface a
+        // clear, actionable message instead of the raw HTTP error.
+        if (sponsor) {
+          throw new Error(
+            "Gas sponsorship isn't set up for this network. Ask the operator to enable Gnosis gas sponsorship in the Privy dashboard, or disable NEXT_PUBLIC_PRIVY_SPONSOR_GAS so the wallet pays its own gas.",
+            { cause: err },
+          );
+        }
+        throw err;
+      }
+
+      return result.hash as `0x${string}`;
     },
     [sendTransaction, account],
   );

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -269,12 +269,13 @@ export const PRIVY_ENABLED = PRIVY_APP_ID !== undefined && !VERIFY_MODE;
 /**
  * Whether to request Privy gas sponsorship for embedded-wallet transactions.
  *
- * OFF by default: sponsorship requires an active gas-sponsorship policy for
- * Gnosis in the Privy dashboard. Requesting `sponsor: true` without one makes
- * Privy's wallet RPC reject the transaction with a 400 — so we only opt in when
- * the operator has set this up and flipped the flag. When off, embedded-wallet
- * transactions are self-paid and Privy prompts the user to fund with a little
- * xDAI when the balance is short (see use-tx-sender-privy.ts).
+ * ON by default (this deployment runs a Privy app with Gnosis gas sponsorship
+ * configured), so embedded-wallet users transact gaslessly. Sponsorship also
+ * requires "Allow transactions from the client" to be enabled in the Privy
+ * dashboard — without it, Privy's wallet RPC rejects client-initiated sends
+ * with a 400. Set NEXT_PUBLIC_PRIVY_SPONSOR_GAS=false for a Privy app that has
+ * no sponsorship policy (then embedded wallets self-pay and Privy prompts
+ * funding when short — see use-tx-sender-privy.ts).
  */
 export const PRIVY_SPONSOR_GAS =
-  process.env.NEXT_PUBLIC_PRIVY_SPONSOR_GAS === "true";
+  process.env.NEXT_PUBLIC_PRIVY_SPONSOR_GAS !== "false";

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -265,3 +265,16 @@ export const PRIVY_CLIENT_ID: string | undefined =
  * app id is set AND we are not in verify mode.
  */
 export const PRIVY_ENABLED = PRIVY_APP_ID !== undefined && !VERIFY_MODE;
+
+/**
+ * Whether to request Privy gas sponsorship for embedded-wallet transactions.
+ *
+ * OFF by default: sponsorship requires an active gas-sponsorship policy for
+ * Gnosis in the Privy dashboard. Requesting `sponsor: true` without one makes
+ * Privy's wallet RPC reject the transaction with a 400 — so we only opt in when
+ * the operator has set this up and flipped the flag. When off, embedded-wallet
+ * transactions are self-paid and Privy prompts the user to fund with a little
+ * xDAI when the balance is short (see use-tx-sender-privy.ts).
+ */
+export const PRIVY_SPONSOR_GAS =
+  process.env.NEXT_PUBLIC_PRIVY_SPONSOR_GAS === "true";

--- a/web/src/lib/wagmi.ts
+++ b/web/src/lib/wagmi.ts
@@ -90,12 +90,16 @@ export const transports = {
     http("https://rpc.gnosis.gateway.fm", { timeout: 7_000, retryCount: 1 }),
   ]),
   // ENS-only public fallback (no key). Reads never write, so no risk.
+  // publicnode + cloudflare send permissive CORS headers from a browser;
+  // eth.merkle.io does not (its CORS preflight fails from the GH Pages origin),
+  // so it goes last — the fallback still reaches it as a last resort.
   [mainnet.id]: fallback([
-    http("https://eth.merkle.io", { timeout: 7_000, retryCount: 1 }),
     http("https://ethereum-rpc.publicnode.com", {
       timeout: 7_000,
       retryCount: 1,
     }),
+    http("https://cloudflare-eth.com", { timeout: 7_000, retryCount: 1 }),
+    http("https://eth.merkle.io", { timeout: 7_000, retryCount: 1 }),
   ]),
 } as const;
 


### PR DESCRIPTION
## Symptom

Creating a net on the live site with a Privy embedded wallet 400'd:
`POST https://auth.privy.io/api/v1/wallets/…/rpc 400 (Bad Request)` on the create `sendTransaction`.

## Root cause

Privy was **blocking client-initiated wallet RPC calls** — the app's **"Allow transactions from the client"** setting was off in the Privy dashboard (now enabled by the operator). That rejects every browser-initiated `sendTransaction` with a 400, independent of gas sponsorship (which was already configured). The transaction itself is valid: the wagmi `simulateContract` that runs first (same params/chain, live contract) succeeds.

## Fix

- **Sponsorship ON by default** (`PRIVY_SPONSOR_GAS`, opt out with `NEXT_PUBLIC_PRIVY_SPONSOR_GAS=false`), passed through the Pages build. Sponsored sends stay silent (`showWalletUIs:false`) for a gasless UX — the intended experience for this deployment.
- A sponsored 400 now throws a clear message naming both dashboard requirements (Gnosis sponsorship policy **and** "Allow transactions from the client") instead of a raw HTTP error.
- Unsponsored mode (`=false`) keeps a funding-prompt fallback for Privy apps without a sponsorship policy.
- Reorder the mainnet (ENS-only) transport so CORS-safe endpoints (publicnode, cloudflare) are tried before `eth.merkle.io` (which fails CORS preflight from the GH Pages origin — unrelated console noise in the report).

## Verification

`pnpm build` (static export) + `pnpm lint` clean. The Privy embedded-wallet path needs a real login (email OTP), so it can't run in verify-mode E2E — **operator to confirm a gasless create on the live site** after this deploys.