### PR TITLE
fix(privy): serialize BigInt in typed-data so invite signing works

### DIFF
--- a/web/src/hooks/use-invite.ts
+++ b/web/src/hooks/use-invite.ts
@@ -105,6 +105,10 @@ export function useInviteLinks(safetyNetId: bigint | undefined) {
           });
         }
       } catch (e) {
+        // Keep the raw error visible: parseContractError collapses non-contract
+        // failures (SDK/serialization/network) into the generic fallback, which
+        // made the Privy BigInt-serialization bug invisible in production logs.
+        console.error("[invites] signature failed:", e);
         setError(parseContractError(e, "Signature failed."));
       } finally {
         setProgress(null);

--- a/web/src/hooks/use-sign-typed-data-privy.ts
+++ b/web/src/hooks/use-sign-typed-data-privy.ts
@@ -5,6 +5,25 @@ import { useSignTypedData } from "@privy-io/react-auth";
 import type { TypedDataParams } from "@/hooks/use-typed-data-signer";
 
 /**
+ * Recursively convert BigInt values to decimal strings. viem signs typed data
+ * locally and accepts BigInt, but Privy ships the payload to its embedded
+ * wallet as JSON — and `JSON.stringify` THROWS on BigInt ("Do not know how to
+ * serialize a BigInt"), killing e.g. invite generation before any network
+ * call. EIP-712 accepts decimal strings for uintN, and the typed-data hash is
+ * computed from the semantic value, so signatures are byte-identical.
+ */
+function toJsonSafe(value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map(toJsonSafe);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, toJsonSafe(v)]),
+    );
+  }
+  return value;
+}
+
+/**
  * Privy EIP-712 signer (app-stacks `stack-result.tsx` pattern): signs typed
  * data silently via `useSignTypedData` from `@privy-io/react-auth` with
  * `uiOptions: { showWalletUIs: false }`, so batch invite generation happens
@@ -18,7 +37,7 @@ export function useSignTypedDataPrivy() {
   return useCallback(
     async (params: TypedDataParams): Promise<`0x${string}`> => {
       const { signature } = await signTypedData(
-        params as unknown as Parameters<typeof signTypedData>[0],
+        toJsonSafe(params) as Parameters<typeof signTypedData>[0],
         { uiOptions: { showWalletUIs: false } },
       );
       return signature as `0x${string}`;


### PR DESCRIPTION
## Symptom

The **create transaction succeeds** (gasless via Privy — confirmed on-chain: [0xb41b778c…](https://gnosisscan.io/tx/0xb41b778cea9e4179a670aa3920df196d7f676b0956178b9a0b87a4159bb6e5d4)), but the auto-generated **invite links then fail** with "Signature failed. Links signed before the interruption were kept below."

## Root cause

Invite links are owner-signed EIP-712 messages. Privy's `useSignTypedData` JSON-serializes the payload to hand it to the embedded wallet, and `JSON.stringify` **throws on BigInt** ("Do not know how to serialize a BigInt"). Our invite message passes `safetyNetId` and `nonce` as `bigint`. viem's local signer (general/verify path) tolerates BigInt, so this only ever bit the Privy path — and it stayed invisible because the invite hook funneled the error through `parseContractError` into the generic "Signature failed" fallback.

## Fix

- Recursively convert BigInt → decimal string before handing typed data to Privy. EIP-712 hashes `uintN` from the semantic value, so the digest and signature are byte-identical — **proven**: `hashTypedData` over the BigInt message equals over the string message (`digests equal: true`).
- Log the raw error in the invite `generate()` loop so an SDK/serialization failure like this can't hide behind the generic message again.

The withdraw-request signature path (`RequestAuthorization`, also BigInt fields) went through the same signer, so it's fixed too.

## Verification

`pnpm build` + `pnpm lint` clean; digest-equality and JSON-serialization checks pass. The Privy embedded path needs a real login, so **operator to confirm** invite generation now completes after a create on the live site.