### PR TITLE
feat(ux): visual How-it-works explainer + fund-health, guided empty-states, clearer claims

### DIFF
--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -101,6 +101,15 @@ export default function DocsPage() {
           deposits build a shared pool, and the group — not an institution —
           approves large withdrawals. Here&apos;s every flow, step by step.
         </p>
+        <p className="text-surface-grey-2 mt-3 text-sm">
+          Prefer a visual walkthrough with an interactive calculator?{" "}
+          <a
+            href="/how"
+            className="text-primary-jade font-bold hover:underline"
+          >
+            See How it works →
+          </a>
+        </p>
       </div>
 
       <nav className="border-paper-2 bg-paper-0 mb-10 rounded-2xl border p-5 text-sm">

--- a/web/src/app/how/page.tsx
+++ b/web/src/app/how/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { HowItWorks } from "@/components/explainer/how-it-works";
+import { buildMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = buildMetadata({
+  title: "How it works",
+  description:
+    "A visual guide to Safety Net: the mutual-aid lifecycle, why the Broodfonds support ratio holds up, and an interactive calculator for your own group.",
+  path: "/how/",
+});
+
+export default function HowPage() {
+  return <HowItWorks />;
+}

--- a/web/src/components/explainer/diagrams/ratio-ramp-chart.tsx
+++ b/web/src/components/explainer/diagrams/ratio-ramp-chart.tsx
@@ -1,0 +1,111 @@
+import { groupRatioCap, MAX_REDEEM_RATIO } from "@/lib/config";
+
+/**
+ * Inline SVG of the sustainable support-ratio cap vs. group size — the exact
+ * on-chain `groupRatioCap(N)` curve (config.ts). Shows why bigger groups can
+ * safely back a higher ratio (law of large numbers). A dashed marker at the
+ * chosen `ratio` shows where a group first fully sustains it. viewBox +
+ * preserveAspectRatio → responsive, no width math, no chart lib.
+ */
+export function RatioRampChart({
+  ratio = 22,
+  highlightN,
+}: {
+  ratio?: number;
+  highlightN?: number;
+}) {
+  const W = 320;
+  const H = 160;
+  const padL = 28;
+  const padR = 10;
+  const padT = 12;
+  const padB = 22;
+  const minN = 2;
+  const maxN = 50;
+  const maxY = MAX_REDEEM_RATIO; // 25
+
+  const x = (n: number) =>
+    padL + ((n - minN) / (maxN - minN)) * (W - padL - padR);
+  const y = (r: number) => padT + (1 - r / maxY) * (H - padT - padB);
+
+  const pts: string[] = [];
+  for (let n = minN; n <= maxN; n++) pts.push(`${x(n)},${y(groupRatioCap(n))}`);
+  const points = pts.join(" ");
+
+  // Smallest group size whose sustainable cap reaches the chosen ratio.
+  let sustainsAt: number | null = null;
+  for (let n = minN; n <= maxN; n++) {
+    if (groupRatioCap(n) >= ratio) {
+      sustainsAt = n;
+      break;
+    }
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="xMidYMid meet"
+      className="w-full"
+      role="img"
+      aria-label={`Sustainable support ratio rises with group size, approaching ×${MAX_REDEEM_RATIO} for large groups`}
+    >
+      {/* axes */}
+      <line x1={padL} y1={H - padB} x2={W - padR} y2={H - padB} stroke="var(--color-paper-2, #e5e0d3)" strokeWidth="1" />
+      <line x1={padL} y1={padT} x2={padL} y2={H - padB} stroke="var(--color-paper-2, #e5e0d3)" strokeWidth="1" />
+      {/* y ticks: 1, 11, 22 */}
+      {[1, 11, 22].map((r) => (
+        <g key={r}>
+          <text x={padL - 6} y={y(r) + 3} textAnchor="end" fontSize="8" fill="var(--color-surface-grey, #8a8577)">
+            ×{r}
+          </text>
+        </g>
+      ))}
+      {/* x ticks */}
+      {[2, 25, 50].map((n) => (
+        <text key={n} x={x(n)} y={H - padB + 12} textAnchor="middle" fontSize="8" fill="var(--color-surface-grey, #8a8577)">
+          {n}
+        </text>
+      ))}
+      <text x={(W + padL) / 2} y={H - 2} textAnchor="middle" fontSize="8" fill="var(--color-surface-grey, #8a8577)">
+        group size (members)
+      </text>
+      {/* target ratio line */}
+      <line
+        x1={padL}
+        y1={y(ratio)}
+        x2={W - padR}
+        y2={y(ratio)}
+        stroke="var(--color-primary-jade, #286b63)"
+        strokeWidth="1"
+        strokeDasharray="3 3"
+        opacity="0.5"
+      />
+      <text x={W - padR} y={y(ratio) - 3} textAnchor="end" fontSize="8" fill="var(--color-primary-jade, #286b63)">
+        ×{ratio} configured
+      </text>
+      {/* the cap curve */}
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--color-primary-jade, #286b63)"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {/* marker where the group first sustains the chosen ratio */}
+      {sustainsAt !== null && (
+        <circle cx={x(sustainsAt)} cy={y(ratio)} r="3.5" fill="var(--color-primary-jade, #286b63)" />
+      )}
+      {highlightN !== undefined && highlightN >= minN && highlightN <= maxN && (
+        <circle
+          cx={x(highlightN)}
+          cy={y(groupRatioCap(highlightN))}
+          r="4"
+          fill="var(--color-paper-0, #fff)"
+          stroke="var(--color-primary-jade, #286b63)"
+          strokeWidth="2"
+        />
+      )}
+    </svg>
+  );
+}

--- a/web/src/components/explainer/diagrams/request-lifecycle.tsx
+++ b/web/src/components/explainer/diagrams/request-lifecycle.tsx
@@ -1,0 +1,37 @@
+import { Badge } from "@/components/ui/ui";
+
+/**
+ * The lifecycle of a large withdrawal request: Created → Contest window →
+ * Executable → Executed, with a Vetoed branch. Uses the same Badge tones the
+ * live requests list uses, so the legend matches what members actually see.
+ */
+export function RequestLifecycle() {
+  const stages = [
+    { label: "Requested", tone: "grey" as const },
+    { label: "Contest window", tone: "jade" as const },
+    { label: "Executable", tone: "warning" as const },
+    { label: "Paid out", tone: "green" as const },
+  ];
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2">
+        {stages.map((s, i) => (
+          <span key={s.label} className="inline-flex items-center gap-1.5">
+            <Badge tone={s.tone}>{s.label}</Badge>
+            {i < stages.length - 1 && (
+              <span aria-hidden className="text-surface-grey text-sm">
+                →
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+      <div className="mt-2 flex items-center gap-1.5">
+        <span aria-hidden className="text-surface-grey pl-1 text-xs">
+          ↳ if enough members contest:
+        </span>
+        <Badge tone="red">Vetoed — no funds move</Badge>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/explainer/diagrams/vault-diagram.tsx
+++ b/web/src/components/explainer/diagrams/vault-diagram.tsx
@@ -1,0 +1,89 @@
+import { Body } from "@breadcoop/ui";
+
+/**
+ * The shared pool as stacked member deposits: individual "your slice stays
+ * yours" bars inside one pool, with the total labelled "× support ratio".
+ * Dependency-free inline SVG. Illustrative (fixed members), not live data.
+ */
+export function VaultDiagram() {
+  const members = [
+    { label: "You", h: 46 },
+    { label: "", h: 46 },
+    { label: "", h: 46 },
+    { label: "", h: 46 },
+  ];
+  const barW = 40;
+  const gap = 10;
+  const startX = 24;
+  const baseY = 120;
+
+  return (
+    <svg
+      viewBox="0 0 320 170"
+      preserveAspectRatio="xMidYMid meet"
+      className="w-full max-w-xs"
+      role="img"
+      aria-label="Each member's deposit stacks into one shared pool; your slice stays yours"
+    >
+      {/* pool container */}
+      <rect
+        x="12"
+        y="18"
+        width="230"
+        height="120"
+        rx="12"
+        fill="var(--color-primary-jade, #286b63)"
+        opacity="0.06"
+        stroke="var(--color-primary-jade, #286b63)"
+        strokeOpacity="0.3"
+      />
+      <text x="127" y="34" textAnchor="middle" fontSize="10" fontWeight="700" fill="var(--color-primary-jade, #286b63)">
+        Shared pool
+      </text>
+      {members.map((m, i) => {
+        const x = startX + i * (barW + gap);
+        return (
+          <g key={i}>
+            <rect
+              x={x}
+              y={baseY - m.h}
+              width={barW}
+              height={m.h}
+              rx="4"
+              fill="var(--color-primary-jade, #286b63)"
+              opacity={i === 0 ? 0.85 : 0.4}
+            />
+            {m.label && (
+              <text x={x + barW / 2} y={baseY - m.h - 4} textAnchor="middle" fontSize="8" fontWeight="700" fill="var(--color-primary-jade, #286b63)">
+                {m.label}
+              </text>
+            )}
+          </g>
+        );
+      })}
+      <text x="127" y="132" textAnchor="middle" fontSize="8" fill="var(--color-surface-grey, #8a8577)">
+        everyone&apos;s deposits
+      </text>
+      {/* multiplier arrow to support */}
+      <text x="270" y="70" textAnchor="middle" fontSize="18" fontWeight="800" fill="var(--color-primary-jade, #286b63)">
+        →
+      </text>
+      <text x="286" y="60" textAnchor="middle" fontSize="9" fontWeight="700" fill="var(--color-primary-jade, #286b63)">
+        × ratio
+      </text>
+      <text x="286" y="82" textAnchor="middle" fontSize="8" fill="var(--color-surface-grey, #8a8577)">
+        support
+      </text>
+    </svg>
+  );
+}
+
+export function VaultDiagramCaption() {
+  return (
+    <Body className="text-surface-grey mt-2 text-center text-xs">
+      Everyone&apos;s deposits form one pool. Your balance is tracked as yours —
+      withdraw it any time — while the pool stands ready to back whoever needs
+      support this month.
+    </Body>
+  );
+}

--- a/web/src/components/explainer/how-it-works.tsx
+++ b/web/src/components/explainer/how-it-works.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import Link from "next/link";
+import { Body, Button, Chip, Heading1, Heading4 } from "@breadcoop/ui";
+import {
+  ArrowRight,
+  Coins,
+  HandCoins,
+  Handshake,
+  Lifebuoy,
+  ShieldCheck,
+  TrendUp,
+} from "@phosphor-icons/react";
+import { Card } from "@/components/ui/ui";
+import { NoteBox } from "@/components/ui/note-box";
+import { StepFlow, type Step } from "@/components/explainer/step-flow";
+import { SupportCalculator } from "@/components/explainer/support-calculator";
+import {
+  VaultDiagram,
+  VaultDiagramCaption,
+} from "@/components/explainer/diagrams/vault-diagram";
+import { RequestLifecycle } from "@/components/explainer/diagrams/request-lifecycle";
+import { RatioRampChart } from "@/components/explainer/diagrams/ratio-ramp-chart";
+import { BROODFONDS_RATIO } from "@/lib/config";
+
+const LIFECYCLE: Step[] = [
+  {
+    icon: Handshake,
+    title: "Agree",
+    body: "Your circle picks the rules together: which token, how much everyone deposits each epoch, and how big a withdrawal needs a group review.",
+  },
+  {
+    icon: HandCoins,
+    title: "Deposit",
+    body: "Everyone pays the same recurring dues into one shared pool. Your money is tracked as yours — deposits stay yours, not the fund's.",
+  },
+  {
+    icon: TrendUp,
+    title: "Build",
+    body: "Each deposit multiplies by the support ratio into your withdrawable balance. The pool grows into a cushion the whole group stands on.",
+  },
+  {
+    icon: Lifebuoy,
+    title: "Support",
+    body: "When a member is in need, they draw monthly support from the pool — up to the support ratio × their dues. Small needs pay out instantly; large ones get a quick group check-in.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Protect",
+    body: "Any member can contest a large request inside the window. Enough contests veto it. If the group ever winds down, everyone gets their balance plus an even split of the pool back.",
+  },
+];
+
+const MECHANISM: Step[] = [
+  {
+    icon: Coins,
+    title: "×22 sounds impossible — until you count who's actually in need",
+    body: "In any given month only a small share of a group is drawing support. The Broodfonds convention assumes about 2%. If 1 in 50 needs help, the other 49 are quietly backing them.",
+  },
+  {
+    title: "So each unit of dues can back roughly ×22 of support",
+    body: "1 ÷ 2% ≈ 50 in theory; the protocol keeps a safety margin on top, landing near ×22 for a large, healthy group. That's the pooling multiplier — not interest, not yield. It only works because most members aren't claiming at once.",
+    extra: (
+      <NoteBox>
+        <strong className="text-text-standard">No magic, no lending.</strong>{" "}
+        Nobody borrows your deposit and nobody pays interest. The multiplier is
+        pure mutual pooling: many small monthly contributions standing behind the
+        few who need help this month.
+      </NoteBox>
+    ),
+  },
+  {
+    title: "Bigger groups make the multiplier safer, not bigger",
+    body: "With just a few members, one unlucky month swings the average hard — so the sustainable ratio is capped lower. As the group grows, the law of large numbers smooths that 2% and the cap climbs toward the full rate.",
+    extra: (
+      <div className="max-w-sm">
+        <RatioRampChart ratio={BROODFONDS_RATIO} />
+      </div>
+    ),
+  },
+  {
+    title: "Your effective ratio ramps as the pool fills",
+    body: "A brand-new net can't pay ×22 on day one — there's nothing pooled yet. The effective ratio starts low and climbs toward the ratio you configured as members deposit. The app always shows both: “×22 configured (×N effective now).”",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Contest + wind-down keep it honest",
+    body: "Large withdrawals are contestable by the group. A member who stops paying makes the net decommissionable, and winding down returns everyone's balance pro-rata. Solidarity leverage only works because the group can always say no.",
+  },
+];
+
+/** The visual, calculator-driven "how it works" page (crowdstake.fun role). */
+export function HowItWorks() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-16 pb-10">
+      {/* Hero */}
+      <section className="pt-6 text-center">
+        <div className="flex justify-center">
+          <Chip size="small">Broodfonds, on-chain</Chip>
+        </div>
+        <div className="mt-4">
+          <Heading1 className="text-text-standard">
+            How a Safety Net works
+          </Heading1>
+        </div>
+        <Body className="text-surface-grey-2 mx-auto mt-4 max-w-xl">
+          A Safety Net is a mutual-aid savings circle: everyone chips in a little
+          each month, and any member who hits hard times can draw real monthly
+          support from the shared pool — many times their own contribution.
+          Here&apos;s exactly how, and why the math holds up.
+        </Body>
+      </section>
+
+      {/* 2.1 Lifecycle */}
+      <section aria-labelledby="how-lifecycle">
+        <h2
+          id="how-lifecycle"
+          className="font-breadDisplay text-text-standard text-2xl font-bold uppercase"
+        >
+          The lifecycle
+        </h2>
+        <div className="mt-6 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-start">
+          <StepFlow steps={LIFECYCLE} />
+          <div className="lg:pt-2">
+            <Card>
+              <VaultDiagram />
+              <VaultDiagramCaption />
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* 2.2 Mechanism deep-dive */}
+      <section aria-labelledby="how-ratio">
+        <h2
+          id="how-ratio"
+          className="font-breadDisplay text-text-standard text-2xl font-bold uppercase"
+        >
+          Why ×22 isn&apos;t magic
+        </h2>
+        <Body className="text-surface-grey-2 mt-2">
+          The support ratio is the one part that looks too good to be true. It
+          isn&apos;t — it&apos;s actuarial pooling, and the contract enforces a
+          cap that keeps it sustainable.
+        </Body>
+        <div className="mt-6">
+          <StepFlow steps={MECHANISM} />
+        </div>
+      </section>
+
+      {/* 2.3 Calculator */}
+      <section aria-labelledby="how-calc">
+        <h2
+          id="how-calc"
+          className="font-breadDisplay text-text-standard text-2xl font-bold uppercase"
+        >
+          Try it with your group
+        </h2>
+        <Body className="text-surface-grey-2 mt-2">
+          Drag the sliders to see what a group like yours could sustainably back
+          — the same numbers you&apos;ll see on the create page.
+        </Body>
+        <div className="mt-6">
+          <SupportCalculator />
+        </div>
+      </section>
+
+      {/* 2.4 Requests */}
+      <section aria-labelledby="how-requests">
+        <h2
+          id="how-requests"
+          className="font-breadDisplay text-text-standard text-2xl font-bold uppercase"
+        >
+          Big claims get a group check-in
+        </h2>
+        <Body className="text-surface-grey-2 mt-2">
+          Small withdrawals pay out instantly. Anything over your group&apos;s
+          petty-cash threshold opens a contest window — a chance for the circle
+          to weigh in before funds move.
+        </Body>
+        <Card className="mt-6">
+          <RequestLifecycle />
+          <Body className="text-surface-grey-2 mt-4 text-sm">
+            The requester writes a short reason, visible to everyone. If more than
+            the group&apos;s threshold of members contest inside the window, the
+            request is vetoed and no funds move. Otherwise it becomes executable
+            and pays out.
+          </Body>
+        </Card>
+      </section>
+
+      {/* CTA */}
+      <section>
+        <Card className="border-primary-jade/40 bg-primary-jade/5 flex flex-col items-center gap-4 py-10 text-center">
+          <Heading4 className="text-text-standard">
+            Ready to build your net?
+          </Heading4>
+          <Body className="text-surface-grey-2 max-w-md">
+            Start one with your people, or read the full step-by-step reference
+            with screen recordings.
+          </Body>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Button
+              as={Link}
+              app="net"
+              variant="primary"
+              rightIcon={<ArrowRight />}
+              href="/create"
+            >
+              Create a Safety Net
+            </Button>
+            <Button as={Link} app="net" variant="secondary" href="/docs">
+              Full reference
+            </Button>
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/explainer/illustration-disclaimer.tsx
+++ b/web/src/components/explainer/illustration-disclaimer.tsx
@@ -1,0 +1,22 @@
+import { NoteBox } from "@/components/ui/note-box";
+
+/**
+ * The required "Illustration, not a promise" disclaimer, placed next to any
+ * projected support figure (calculator, fund-health, create page). Exported so
+ * every surface that shows a projection carries the identical caveat.
+ */
+export function IllustrationDisclaimer() {
+  return (
+    <NoteBox icon>
+      <strong className="text-text-standard">
+        Illustration, not a promise.
+      </strong>{" "}
+      These figures show how the support ratio <em>could</em> work for a group
+      like this — it&apos;s the same math the contract uses — but real support
+      depends on your pool&apos;s actual balance, your group&apos;s size, and how
+      many members need help at once. Your <em>effective</em> ratio ramps up as
+      the pool fills, and no payout is guaranteed. Nothing here is financial
+      advice.
+    </NoteBox>
+  );
+}

--- a/web/src/components/explainer/step-flow.tsx
+++ b/web/src/components/explainer/step-flow.tsx
@@ -1,0 +1,80 @@
+import type { ComponentType, ReactNode } from "react";
+import { Body, Heading4 } from "@breadcoop/ui";
+import { CaretDown, type IconProps } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+export interface Step {
+  title: string;
+  body: ReactNode;
+  icon?: ComponentType<IconProps>;
+  /** Optional extra visual (diagram / stat) shown under the copy. */
+  extra?: ReactNode;
+}
+
+/** Solid jade numbered circle (crowdstake-style emphasis). */
+function StepCircle({ n }: { n: number }) {
+  return (
+    <span
+      aria-hidden
+      className="bg-primary-jade text-paper-0 font-breadDisplay inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base font-bold"
+    >
+      {n}
+    </span>
+  );
+}
+
+/**
+ * A vertical numbered flow with jade connector arrows between steps — the
+ * crowdstake.fun "how it works" treatment, dependency-free (CSS + one Phosphor
+ * glyph). On mobile the steps stack; the connector collapses to a short rule.
+ */
+export function StepFlow({ steps }: { steps: Step[] }) {
+  return (
+    <ol className="flex flex-col">
+      {steps.map((s, i) => {
+        const Icon = s.icon;
+        const last = i === steps.length - 1;
+        return (
+          <li key={i} className="relative">
+            <div className="flex gap-4">
+              <div className="flex flex-col items-center">
+                <StepCircle n={i + 1} />
+                {!last && (
+                  <span
+                    aria-hidden
+                    className="bg-primary-jade/30 my-1 w-0.5 flex-1"
+                  />
+                )}
+              </div>
+              <div className={cn("min-w-0 flex-1", last ? "pb-0" : "pb-8")}>
+                <div className="flex items-center gap-2">
+                  {Icon && (
+                    <Icon
+                      size={22}
+                      weight="duotone"
+                      className="text-primary-jade shrink-0"
+                      aria-hidden
+                    />
+                  )}
+                  <Heading4 className="text-text-standard">{s.title}</Heading4>
+                </div>
+                <Body className="text-surface-grey-2 mt-1.5 text-sm">
+                  {s.body}
+                </Body>
+                {s.extra && <div className="mt-3">{s.extra}</div>}
+                {!last && (
+                  <CaretDown
+                    aria-hidden
+                    size={16}
+                    weight="bold"
+                    className="text-primary-jade/40 mt-4 hidden sm:block"
+                  />
+                )}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/web/src/components/explainer/support-calculator.tsx
+++ b/web/src/components/explainer/support-calculator.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Body, Button, Caption } from "@breadcoop/ui";
+import { ArrowRight } from "@phosphor-icons/react";
+import { Card } from "@/components/ui/ui";
+import { NoteBox } from "@/components/ui/note-box";
+import { SliderField } from "@/components/ui/slider-field";
+import { RatioRampChart } from "@/components/explainer/diagrams/ratio-ramp-chart";
+import { IllustrationDisclaimer } from "@/components/explainer/illustration-disclaimer";
+import {
+  BROODFONDS_RATIO,
+  groupRatioCap,
+  MAX_REDEEM_RATIO,
+  MIN_REDEEM_RATIO,
+} from "@/lib/config";
+
+/** Round to at most 2 decimals, trimming trailing zeros. */
+const money = (n: number) =>
+  Number.isFinite(n)
+    ? n.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : "—";
+
+/**
+ * Interactive "what would a group like this get?" calculator — the crowdstake
+ * landing calculator, mapped to Broodfonds solidarity. Pure frontend math (the
+ * same `groupRatioCap` + support-rate formula the create form and the contract
+ * use), so it renders for disconnected/SSG visitors with no wallet or reads.
+ */
+export function SupportCalculator() {
+  const [contribution, setContribution] = useState(50);
+  const [members, setMembers] = useState(30);
+  const [ratio, setRatio] = useState(BROODFONDS_RATIO);
+
+  const cap = groupRatioCap(members);
+  const sustained = Math.min(ratio, cap);
+  const monthlyConfigured = contribution * ratio;
+  const monthlySustained = contribution * sustained;
+  const daily = monthlySustained / 30;
+
+  return (
+    <Card className="flex flex-col gap-5">
+      <div className="grid gap-5 sm:grid-cols-3">
+        <SliderField
+          label="Monthly contribution"
+          min={10}
+          max={250}
+          step={5}
+          value={contribution}
+          onChange={setContribution}
+          suffix={<span className="text-surface-grey text-sm">BREAD</span>}
+        />
+        <SliderField
+          label="Group size"
+          min={2}
+          max={50}
+          step={1}
+          value={members}
+          onChange={setMembers}
+        />
+        <SliderField
+          label="Support ratio"
+          min={MIN_REDEEM_RATIO}
+          max={MAX_REDEEM_RATIO}
+          step={1}
+          value={ratio}
+          onChange={setRatio}
+          suffix={<span className="text-surface-grey text-sm">×</span>}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="border-primary-jade/30 bg-primary-jade/5 rounded-xl border p-4">
+          <Caption className="text-surface-grey-2">
+            Monthly support when in need
+          </Caption>
+          <p className="font-breadDisplay text-primary-jade mt-1 text-3xl font-bold">
+            ≈ {money(monthlySustained)}{" "}
+            <span className="text-lg">BREAD/mo</span>
+          </p>
+          <Body className="text-surface-grey-2 mt-1 text-xs">
+            at ×{sustained} · about {money(daily)} BREAD/day
+          </Body>
+          {sustained < ratio && (
+            <Body className="text-surface-grey mt-2 text-xs">
+              You picked ×{ratio} (≈ {money(monthlyConfigured)} BREAD/mo). A group
+              of {members} sustainably backs about ×{sustained} today; support
+              ramps toward the full rate as the group and its pool grow.
+            </Body>
+          )}
+        </div>
+        <div>
+          <Caption className="text-surface-grey-2">
+            What a group this size safely backs
+          </Caption>
+          <div className="mt-2">
+            <RatioRampChart ratio={ratio} highlightN={members} />
+          </div>
+        </div>
+      </div>
+
+      <NoteBox>
+        <strong className="text-text-standard">The math, in the open.</strong>{" "}
+        Support = your contribution × the ratio your group sustainably backs.
+        That sustainable cap is{" "}
+        <code className="text-primary-jade">
+          ⌊10000 / (200 + z·√(200·9800/N))⌋
+        </code>{" "}
+        — the same actuarial formula the contract enforces on-chain (expected
+        in-need share ≈ 2%, safety factor z = 1.65).
+      </NoteBox>
+
+      <IllustrationDisclaimer />
+
+      <div>
+        <Button
+          as={Link}
+          app="net"
+          variant="primary"
+          rightIcon={<ArrowRight />}
+          href="/create"
+        >
+          Start a net like this
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/components/landing.tsx
+++ b/web/src/components/landing.tsx
@@ -82,7 +82,7 @@ export function Landing() {
           >
             Connect wallet
           </Button>
-          <Button as={Link} app="net" variant="secondary" href="/docs">
+          <Button as={Link} app="net" variant="secondary" href="/how">
             How it works
           </Button>
         </div>
@@ -135,12 +135,19 @@ export function Landing() {
           ))}
         </ol>
         <p className="text-surface-grey-2 mt-4 text-sm">
-          Want the full walkthrough with screen recordings?{" "}
+          See it visually with an interactive calculator on{" "}
+          <Link
+            href="/how"
+            className="text-primary-jade font-bold hover:underline"
+          >
+            How it works
+          </Link>
+          , or the full walkthrough with screen recordings in the{" "}
           <Link
             href="/docs"
             className="text-primary-jade font-bold hover:underline"
           >
-            Read the docs
+            docs
           </Link>
           .
         </p>

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 const LINKS = [
   { href: "/", label: "My Safety Nets" },
   { href: "/create", label: "Create" },
+  { href: "/how", label: "How it works" },
   { href: "/docs", label: "Docs" },
 ];
 

--- a/web/src/components/net/deposit-panel.tsx
+++ b/web/src/components/net/deposit-panel.tsx
@@ -8,6 +8,7 @@ import { ActionButton } from "@/components/ui/action-button";
 import { AmountField } from "@/components/ui/amount-field";
 import { TxStatus } from "@/components/ui/tx-status";
 import { Card } from "@/components/ui/ui";
+import { NoteBox } from "@/components/ui/note-box";
 import { GetBreadModal } from "@/components/funding/get-bread-modal";
 import { useMemberDepositInfo } from "@/hooks/use-safety-net";
 import { useDeposit, useDepositFor } from "@/hooks/use-safety-net-writes";
@@ -268,6 +269,16 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
       </div>
 
       <div className="mt-4 flex flex-col gap-3">
+        {onboarding && mode === "self" && (
+          <NoteBox icon>
+            <strong className="text-text-standard">
+              First deposit — your join payment.
+            </strong>{" "}
+            Pay exactly {formatAmount(net.initialDeposit, decimals)} {symbol} once
+            to activate your membership. It sets your recurring dues and unlocks
+            withdrawals. Your deposit stays yours.
+          </NoteBox>
+        )}
         {mode === "other" && (
           <div>
             <label htmlFor={otherInputId}>

--- a/web/src/components/net/fund-health-panel.tsx
+++ b/web/src/components/net/fund-health-panel.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Caption } from "@breadcoop/ui";
+import { Card, InfoRow, ProgressBar, Badge, type BadgeTone } from "@/components/ui/ui";
+import { NoteBox } from "@/components/ui/note-box";
+import { useMembersNeedingDeposit } from "@/hooks/use-safety-net";
+import { useTokenInfo } from "@/hooks/use-token";
+import { formatAmount } from "@/lib/format";
+import type { SafetyNetDetails } from "@/lib/types";
+
+/**
+ * Fund-health panel: turns the abstract solidarity math into a trust signal —
+ * how many months of a member's support the pool can sustain, how far the
+ * effective support ratio has ramped toward the configured one, and whether
+ * anyone is behind on dues (which makes the net decommissionable). All computed
+ * from getSafetyNetDetails + the already-available needs-deposit read; no new
+ * contract surface. Shown on started nets only (a pending net has no runway).
+ */
+export function FundHealthPanel({ details }: { details: SafetyNetDetails }) {
+  const net = details.safetyNet;
+  const { symbol, decimals } = useTokenInfo(net.token);
+  const { data: needing } = useMembersNeedingDeposit(net.id);
+
+  const configured = net.redeemRatio;
+  const effective = details.effectiveRedeemRatio;
+  const ramp =
+    configured > 0n ? Number(effective) / Number(configured) : 1;
+
+  // Reserve proxy: if one member drew their FULL monthly support, how many
+  // months could today's pool sustain it? monthly = recurring dues × effective
+  // support ratio. 6 months is the actuarial anchor (see contract POOL_RUNWAY).
+  const monthlySupport = net.fixedDeposit * effective;
+  const runwayMonths =
+    monthlySupport > 0n ? Number(details.totalBalance) / Number(monthlySupport) : 0;
+  const runwayTone: BadgeTone =
+    runwayMonths >= 6 ? "green" : runwayMonths >= 3 ? "warning" : "red";
+  const runwayLabel =
+    runwayMonths >= 6 ? "Healthy" : runwayMonths >= 3 ? "Building" : "Thin";
+
+  const overdue = needing?.length ?? 0;
+  const memberCount = Number(details.memberCount);
+  const paymentsHealthy = overdue === 0 && !details.isDecommissionable;
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-2">
+        <Caption className="text-surface-grey-2">Fund health</Caption>
+        <Badge tone={runwayTone}>{runwayLabel}</Badge>
+      </div>
+
+      <div className="mt-4">
+        <InfoRow
+          label="Pool runway"
+          help="A simple solvency check: if one member drew their full monthly support right now, roughly how many months could the current pool sustain it? Six months or more is comfortable. It's an illustration of the pool's depth, not a guarantee."
+        >
+          <span className="inline-flex items-center gap-2">
+            ~{runwayMonths.toFixed(1)} months
+            <Badge tone={runwayTone}>{runwayLabel}</Badge>
+          </span>
+        </InfoRow>
+
+        <InfoRow
+          label="Support ratio"
+          help="Members draw support at the EFFECTIVE ratio, which ramps toward the configured ratio as the pool fills and the group grows. A new net starts low; a full, healthy group reaches the configured rate."
+        >
+          ×{effective.toString()}
+          {effective < configured ? (
+            <span className="text-surface-grey">
+              {" "}
+              of ×{configured.toString()}
+            </span>
+          ) : (
+            ""
+          )}
+        </InfoRow>
+
+        {effective < configured && (
+          <div className="py-2">
+            <div className="flex items-center justify-between gap-2">
+              <Caption className="text-surface-grey-2">
+                Effective ratio ramp
+              </Caption>
+              <Caption className="text-surface-grey">
+                {Math.round(ramp * 100)}%
+              </Caption>
+            </div>
+            <div className="mt-1.5">
+              <ProgressBar value={ramp} />
+            </div>
+          </div>
+        )}
+
+        <InfoRow
+          label="Member payments"
+          help="Whether every member is current on their dues this epoch. A member who falls behind lets anyone wind the net down, so staying paid up keeps the pool intact."
+        >
+          {paymentsHealthy ? (
+            <span className="inline-flex items-center gap-2">
+              All paid up
+              <Badge tone="green">✓</Badge>
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-2">
+              {overdue > 0 ? `${overdue} of ${memberCount} behind` : "At risk"}
+              <Badge tone="warning">check dues</Badge>
+            </span>
+          )}
+        </InfoRow>
+      </div>
+
+      {details.isDecommissionable && (
+        <div className="mt-3">
+          <NoteBox tone="warning" icon>
+            <strong className="text-text-standard">
+              This net can be wound down now.
+            </strong>{" "}
+            A member is behind on dues, so any member can decommission it —
+            everyone gets their withdrawable balance back plus an even split of
+            whatever&apos;s left in the pool.
+          </NoteBox>
+        </div>
+      )}
+
+      <p className="text-surface-grey mt-3 text-xs">
+        Runway assumes one member drawing full support from{" "}
+        {formatAmount(details.totalBalance, decimals)} {symbol} pooled. It&apos;s
+        an illustration of the pool&apos;s depth, not a promise of any payout.
+      </p>
+    </Card>
+  );
+}

--- a/web/src/components/net/net-overview.tsx
+++ b/web/src/components/net/net-overview.tsx
@@ -3,6 +3,7 @@
 import { Caption } from "@breadcoop/ui";
 import { AddressDisplay } from "@/components/ui/address-display";
 import { Card, InfoRow, ProgressBar, StatCard } from "@/components/ui/ui";
+import { FundHealthPanel } from "@/components/net/fund-health-panel";
 import { useNow } from "@/hooks/use-now";
 import { useTokenInfo } from "@/hooks/use-token";
 import { useSafetyNetName } from "@/hooks/use-safety-net";
@@ -86,6 +87,8 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
           <ProgressBar value={epochProgress} />
         </div>
       </Card>
+
+      {started && <FundHealthPanel details={details} />}
 
       <Card>
         <Caption className="text-surface-grey-2">Rules</Caption>

--- a/web/src/components/net/net-page-content.tsx
+++ b/web/src/components/net/net-page-content.tsx
@@ -4,6 +4,8 @@ import { Suspense, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { zeroAddress } from "viem";
+import { Button } from "@breadcoop/ui";
+import { ArrowRight } from "@phosphor-icons/react";
 import {
   EmptyState,
   ErrorState,
@@ -121,14 +123,27 @@ function NetDetail() {
             <div className="flex flex-col gap-4">
               {details.isMember ? (
                 <EmptyState>
-                  Deposits open once the owner starts the net — withdrawals
-                  and requests do too.
+                  You&apos;re in. Once{" "}
+                  {details.safetyNet.minimumMembers.toString()} members have
+                  joined, the owner starts the net and epoch 1 begins —
+                  deposits, support, and requests all open then.
                 </EmptyState>
               ) : (
-                <EmptyState>
-                  You&apos;re not a member of this Safety Net. Ask the owner
-                  for an invite link to join before it starts.
-                </EmptyState>
+                <div className="flex flex-col gap-3">
+                  <EmptyState>
+                    You&apos;re not a member of this Safety Net. Ask the owner
+                    for an invite link to join before it starts.
+                  </EmptyState>
+                  <Button
+                    as={Link}
+                    app="net"
+                    variant="secondary"
+                    rightIcon={<ArrowRight />}
+                    href="/how"
+                  >
+                    See how it works
+                  </Button>
+                </div>
               )}
             </div>
           </div>
@@ -151,10 +166,21 @@ function NetDetail() {
                 <WithdrawPanel details={details} />
               </>
             ) : (
-              <EmptyState>
-                You&apos;re not a member of this Safety Net — it has already
-                started, so joining is closed.
-              </EmptyState>
+              <div className="flex flex-col gap-3">
+                <EmptyState>
+                  You&apos;re not a member of this Safety Net — it has already
+                  started, so joining is closed.
+                </EmptyState>
+                <Button
+                  as={Link}
+                  app="net"
+                  variant="secondary"
+                  rightIcon={<ArrowRight />}
+                  href="/how"
+                >
+                  How Safety Nets work
+                </Button>
+              </div>
             )}
             <DecommissionPanel details={details} />
           </div>

--- a/web/src/components/net/requests-list.tsx
+++ b/web/src/components/net/requests-list.tsx
@@ -8,7 +8,8 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { TimeDisplay } from "@/components/ui/time-display";
 import { TxStatus } from "@/components/ui/tx-status";
 import { ActionButton } from "@/components/ui/action-button";
-import { Badge, Card, EmptyState } from "@/components/ui/ui";
+import { Badge, Card, EmptyState, ProgressBar } from "@/components/ui/ui";
+import { NoteBox } from "@/components/ui/note-box";
 import { useNow } from "@/hooks/use-now";
 import { useHasContested } from "@/hooks/use-safety-net";
 import {
@@ -16,7 +17,7 @@ import {
   useExecuteContestedWithdrawal,
 } from "@/hooks/use-safety-net-writes";
 import { useTokenInfo } from "@/hooks/use-token";
-import { formatAmount, shortenAddress } from "@/lib/format";
+import { formatAmount, formatDuration, shortenAddress } from "@/lib/format";
 import {
   requestStatus,
   type RequestView,
@@ -48,6 +49,15 @@ function RequestRow({
   const memberCount = Number(details.memberCount);
   const votesToVeto =
     Math.floor((memberCount * Number(net.contestThreshold)) / 100) + 1;
+  const remainingToVeto = Math.max(
+    0,
+    votesToVeto - Number(view.request.contestCount),
+  );
+  // Fraction of the contest window that has elapsed (0..1), for the drain bar.
+  const windowStart = Number(view.request.timestamp);
+  const windowLen = Number(net.contestWindow);
+  const windowElapsed =
+    windowLen > 0 ? (now - windowStart) / windowLen : 1;
   const isMine = view.request.owner.toLowerCase() === address?.toLowerCase();
 
   return (
@@ -85,21 +95,53 @@ function RequestRow({
           &ldquo;{view.reason}&rdquo;
         </blockquote>
       ) : (
-        <p className="text-surface-grey mt-3 text-sm italic">No reason given</p>
+        <p className="text-system-warning mt-3 text-sm font-medium italic">
+          No reason given — consider that when deciding whether to contest.
+        </p>
       )}
 
       <div className="text-surface-grey mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
         <span>
           Requested <TimeDisplay timestamp={view.request.timestamp} />
         </span>
-        <span>
-          {view.request.contestCount.toString()} of {votesToVeto} contests
-          needed to veto
-        </span>
         <span className="text-surface-grey-2">
           Request #{view.id.toString()}
         </span>
       </div>
+
+      {/* Contest-window drain (contestable rows only) */}
+      {status === "contestable" && (
+        <div className="mt-3">
+          <div className="text-surface-grey mb-1 flex items-center justify-between text-xs">
+            <span>Contest window</span>
+            <span>
+              closes <TimeDisplay timestamp={contestEnds} />
+            </span>
+          </div>
+          <ProgressBar value={windowElapsed} tone="warning" />
+        </div>
+      )}
+
+      {/* Veto progress toward the threshold */}
+      {(status === "contestable" || status === "vetoed") && (
+        <div className="mt-3">
+          <div className="text-surface-grey mb-1 flex items-center justify-between text-xs">
+            <span>
+              {view.request.contestCount.toString()} of {votesToVeto} contests to
+              veto
+            </span>
+            <span>
+              {status === "vetoed"
+                ? "vetoed"
+                : `${remainingToVeto} more would veto this`}
+            </span>
+          </div>
+          <ProgressBar
+            value={Number(view.request.contestCount) / votesToVeto}
+            tone="red"
+          />
+        </div>
+      )}
 
       {status === "contestable" && details.isMember && (
         <div className="mt-3 max-w-xs">
@@ -121,6 +163,10 @@ function RequestRow({
             error={contestTx.error}
             successLabel="Contest recorded"
           />
+          <p className="text-surface-grey mt-1.5 text-xs">
+            A veto vote — cast it if the timing or need doesn&apos;t look right.
+            You can contest once, and it can&apos;t be undone.
+          </p>
           <ConfirmDialog
             open={confirmingContest}
             title="Contest this withdrawal?"
@@ -164,6 +210,8 @@ function RequestRow({
 
 /** All withdrawal requests of a net, newest first, with contest/execute actions. */
 export function RequestsList({ details }: { details: SafetyNetDetails }) {
+  const net = details.safetyNet;
+  const { symbol, decimals } = useTokenInfo(net.token);
   const requests = useMemo(
     () => [...details.requests].reverse(),
     [details.requests],
@@ -184,6 +232,16 @@ export function RequestsList({ details }: { details: SafetyNetDetails }) {
       <Caption className="text-surface-grey-2">
         Withdrawal requests ({requests.length})
       </Caption>
+      <div className="mt-3">
+        <NoteBox icon>
+          <strong className="text-text-standard">How requests work.</strong>{" "}
+          Small withdrawals (≤ {formatAmount(net.autoThreshold, decimals)}{" "}
+          {symbol}) pay out instantly. Larger ones open a{" "}
+          {formatDuration(net.contestWindow)} contest window — if more than{" "}
+          {net.contestThreshold.toString()}% of members contest, the request is
+          vetoed and no funds move.
+        </NoteBox>
+      </div>
       <ul className="mt-2">
         {requests.map((view) => (
           <RequestRow

--- a/web/src/components/ui/note-box.tsx
+++ b/web/src/components/ui/note-box.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import { Info } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+export type NoteTone = "jade" | "warning" | "red";
+
+const TONES: Record<NoteTone, string> = {
+  jade: "border-primary-jade/30 bg-primary-jade/5 text-surface-grey-2",
+  warning: "border-system-warning/40 bg-system-warning/10 text-surface-grey-2",
+  red: "border-system-red/40 bg-red-0/40 text-surface-grey-2",
+};
+
+const ICON_TONES: Record<NoteTone, string> = {
+  jade: "text-primary-jade",
+  warning: "text-system-warning",
+  red: "text-red-main",
+};
+
+/**
+ * The canonical "explain a mechanic" callout — the jade/5 border box used
+ * across the create form (SupportRateNote), the /how explainer, and the panels.
+ * Extracted so every explanatory surface renders identically. Optional `icon`
+ * shows the Info glyph; `tone` switches to warning/red for cautions.
+ */
+export function NoteBox({
+  children,
+  tone = "jade",
+  icon = false,
+  className,
+}: {
+  children: ReactNode;
+  tone?: NoteTone;
+  icon?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border px-4 py-3 text-xs leading-relaxed",
+        TONES[tone],
+        className,
+      )}
+    >
+      {icon ? (
+        <div className="flex items-start gap-2">
+          <Info
+            size={16}
+            weight="fill"
+            className={cn("mt-0.5 shrink-0", ICON_TONES[tone])}
+            aria-hidden
+          />
+          <div>{children}</div>
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/ui.tsx
+++ b/web/src/components/ui/ui.tsx
@@ -69,12 +69,25 @@ export function StatCard({
   );
 }
 
-/** A horizontal progress bar (0..1), jade fill. */
-export function ProgressBar({ value }: { value: number }) {
+/** A horizontal progress bar (0..1). Jade fill by default; `tone` recolors it
+ * (e.g. red for veto progress, warning for a draining window). */
+export function ProgressBar({
+  value,
+  tone = "jade",
+}: {
+  value: number;
+  tone?: "jade" | "red" | "warning" | "green";
+}) {
+  const fill = {
+    jade: "bg-primary-jade",
+    red: "bg-red-main",
+    warning: "bg-system-warning",
+    green: "bg-system-green",
+  }[tone];
   return (
     <div className="bg-paper-2 h-2 w-full overflow-hidden rounded-full">
       <div
-        className="bg-primary-jade h-full rounded-full transition-all"
+        className={cn("h-full rounded-full transition-all", fill)}
         style={{ width: `${Math.min(100, Math.max(0, value * 100))}%` }}
       />
     </div>


### PR DESCRIPTION
Tier-2 UX to make the Broodfonds solidarity model **legible**, in the crowdstake.fun visual-explainer style. Design standards distilled from a parallel read of **app-stacks** and **crowdstaking-v2**: Safety Net already conforms to the shared `@breadcoop/ui` system, so this is additive — same jade/paper tokens, semantic typography, **CSS-only motion, hand-rolled SVG, zero new deps**.

## Visual explainer — new `/how` route
A scannable, calculator-driven "How it works" (the crowdstake landing role; `/docs` stays the exhaustive text+GIF reference):
- **Numbered Broodfonds lifecycle** — Agree → Deposit → Build → Support → Protect, with a pool/vault SVG.
- **"Why ×22 isn't magic"** actuarial deep-dive (only ~2% in need at once; law of large numbers) with a live `groupRatioCap(N)` **ramp chart** — the exact on-chain cap curve.
- **Interactive calculator** — contribution / group-size / ratio sliders → live "monthly support ≈ …", using the *same* math as the create form and the contract (e.g. a 30-person group at ×22 → "sustainably backs ×16 today").
- **Request-lifecycle** diagram + a required **"Illustration, not a promise"** disclaimer.
- Linked from nav, landing, and docs.

## Tier-2 app UX
- **FundHealthPanel** (started nets): pool **runway** (~months of one member's full support, green/amber/red "Healthy/Building/Thin"), **effective-ratio ramp** toward the configured ratio, member-payment status, decommission-risk note.
- **Guided empty-states**: first-deposit guidance in the deposit panel, richer waiting-for-members copy, "How it works" CTAs for non-members.
- **Clearer claims/contests** (requests list): a "how requests work" banner, a draining **contest-window bar**, a **veto-progress bar** ("N more would veto this"), a warning-toned missing-reason, and an inline "a veto can't be undone" note.
- Shared **`NoteBox`** primitive (extracts the jade/5 callout) + a `ProgressBar` `tone` prop (red/amber for veto/window bars).

## Verification
`pnpm build` (static export, `/how` prerenders with no wallet/reads) + `pnpm lint` clean. Screenshotted in verify mode: the full `/how` explainer + calculator, the FundHealthPanel on a live net (correctly "Thin"/×1-of-×22 ramp on a young pool), and a live **contestable request** showing the window-drain + veto-progress bars.