### PR TITLE
feat(resilience): toasts, error boundary, version banner, invite backups, stuck-tx (Batch A)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,9 @@ jobs:
         working-directory: web
         env:
           NEXT_PUBLIC_BASE_PATH: /safety-net
+          # Baked into the bundle so the client can tell when it's running a
+          # stale (cached) build vs. the one currently deployed (build-id.txt).
+          NEXT_PUBLIC_BUILD_ID: ${{ github.sha }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
           NEXT_PUBLIC_SAFETYNET_ADDRESS: ${{ vars.NEXT_PUBLIC_SAFETYNET_ADDRESS }}
           # Privy embedded wallets go live when this repo variable is set. Leave
@@ -52,6 +55,12 @@ jobs:
           # Activity feed reads the subgraph when set, else falls back to logs.
           NEXT_PUBLIC_SUBGRAPH_URL: ${{ vars.NEXT_PUBLIC_SUBGRAPH_URL }}
         run: pnpm build
+
+      # Version signal for the client refresh banner (see version-check.tsx).
+      # Served at /safety-net/build-id.txt; must match NEXT_PUBLIC_BUILD_ID above.
+      - name: Emit build id
+        working-directory: web
+        run: echo "${{ github.sha }}" > out/build-id.txt
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { BASE_PATH } from "@/lib/config";
+
+/**
+ * Route-level error boundary: a render/runtime throw in any page shows this
+ * instead of a blank screen, and the raw error is logged (a money app must
+ * never fail invisibly). Reset re-renders the segment; the reload link is a
+ * hard fallback.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[app error boundary]", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-md py-16 text-center">
+      <h1 className="font-breadDisplay text-text-standard text-2xl font-bold">
+        Something went wrong
+      </h1>
+      <p className="text-surface-grey-2 mt-3">
+        The page hit an unexpected error. Your funds are safe on-chain — this is
+        just the interface. Try again, or reload the page.
+      </p>
+      <div className="mt-6 flex items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="bg-primary-jade rounded-xl px-4 py-2 font-bold text-white transition-opacity hover:opacity-90"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            window.location.href = `${BASE_PATH}/`;
+          }}
+          className="border-paper-2 text-text-standard rounded-xl border px-4 py-2 font-bold transition-colors hover:border-primary-jade"
+        >
+          Go home
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Last-resort boundary for errors thrown in the root layout itself (before the
+ * route error.tsx can catch them). Must render its own <html>/<body>.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[global error boundary]", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily: "system-ui, sans-serif",
+          background: "#f6f3eb",
+          color: "#1a1a1a",
+          display: "flex",
+          minHeight: "100vh",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+          padding: "2rem",
+        }}
+      >
+        <div style={{ maxWidth: "24rem" }}>
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 800 }}>
+            Something went wrong
+          </h1>
+          <p style={{ marginTop: "0.75rem", color: "#5c5850" }}>
+            The app hit an unexpected error. Reload to continue — your funds are
+            safe on-chain.
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              marginTop: "1.5rem",
+              background: "#286b63",
+              color: "white",
+              border: "none",
+              borderRadius: "0.75rem",
+              padding: "0.5rem 1rem",
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Providers } from "@/components/providers";
 import { Navbar } from "@/components/navbar";
 import { VerifyBanner } from "@/components/verify-banner";
+import { VersionCheck } from "@/components/version-check";
 import { NotificationBanner } from "@/components/notification-banner";
 import { ConfigWarning } from "@/components/config-warning";
 import { SiteFooter } from "@/components/site-footer";
@@ -27,6 +28,7 @@ export default function RootLayout({
           <VerifyBanner />
           <Navbar />
           <ConfigWarning />
+          <VersionCheck />
           <NotificationBanner />
           <main className="section-container flex-1 py-8">{children}</main>
           <SiteFooter />

--- a/web/src/components/net/invite-panel.tsx
+++ b/web/src/components/net/invite-panel.tsx
@@ -3,11 +3,13 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
 import { Caption, CopyButtonIcon } from "@breadcoop/ui";
-import { PaperPlaneTilt } from "@phosphor-icons/react";
+import { CopySimple, DownloadSimple, PaperPlaneTilt } from "@phosphor-icons/react";
 import { ActionButton } from "@/components/ui/action-button";
 import { Badge, Card } from "@/components/ui/ui";
 import { inviteLink, useInviteLinks } from "@/hooks/use-invite";
-import { useInviteNoncesUsed } from "@/hooks/use-safety-net";
+import { useInviteNoncesUsed, useSafetyNetName } from "@/hooks/use-safety-net";
+import { useToast } from "@/hooks/use-toast";
+import { ADDRESSES, CHAIN_ID } from "@/lib/config";
 import type { SafetyNetDetails } from "@/lib/types";
 
 /**
@@ -32,7 +34,22 @@ export function InviteLinksBody({
   const net = details.safetyNet;
   const { invites, isLoaded, generate, progress, isGenerating, error } =
     useInviteLinks(net.id);
+  const { toast } = useToast();
   const countId = useId();
+
+  // Invites live only in this browser's localStorage; if it's blocked (private
+  // mode / storage disabled) they vanish on refresh, so nudge the owner to
+  // export. We probe once on mount rather than trusting the silent save.
+  const [storageBlocked, setStorageBlocked] = useState(false);
+  useEffect(() => {
+    try {
+      const probe = "__sn_invite_probe__";
+      window.localStorage.setItem(probe, "1");
+      window.localStorage.removeItem(probe);
+    } catch {
+      setStorageBlocked(true);
+    }
+  }, []);
 
   const remaining = Math.max(
     0,
@@ -56,6 +73,57 @@ export function InviteLinksBody({
   );
   const used = useInviteNoncesUsed(net.id, nonces);
   const acceptedCount = used.filter(Boolean).length;
+  const { data: netName } = useSafetyNetName(net.id);
+
+  const links = useMemo(
+    () => invites.map((inv) => inviteLink(net.id, inv)),
+    [invites, net.id],
+  );
+
+  const copyAll = async () => {
+    try {
+      await navigator.clipboard.writeText(links.join("\n"));
+      toast({
+        tone: "success",
+        message: `Copied ${links.length} invite ${links.length === 1 ? "link" : "links"}.`,
+      });
+    } catch {
+      toast({
+        tone: "error",
+        message: "Couldn't copy — use the copy button on each link instead.",
+      });
+    }
+  };
+
+  // Download a self-contained JSON backup so links survive a cleared browser or
+  // a move to a new device (the only place they otherwise exist).
+  const downloadJson = () => {
+    const payload = {
+      safetyNet: netName || `Safety Net #${net.id.toString()}`,
+      safetyNetId: net.id.toString(),
+      chainId: CHAIN_ID,
+      contract: ADDRESSES.safetyNet,
+      exportedAt: new Date().toISOString(),
+      note: "Each link is single-use. Anyone with a pending link can join this net — keep this file private.",
+      invites: invites.map((inv, i) => ({
+        index: i + 1,
+        nonce: inv.nonce,
+        status: used[i] === true ? "accepted" : "pending",
+        link: links[i],
+      })),
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `safety-net-${net.id.toString()}-invites.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
 
   const clamped = Math.min(
     Math.max(1, Math.floor(count) || 1),
@@ -64,6 +132,13 @@ export function InviteLinksBody({
 
   return (
     <div>
+      {storageBlocked && invites.length > 0 && (
+        <p className="border-red-1 bg-red-0/60 text-red-main mt-2 rounded-xl border px-3 py-2 text-xs font-medium">
+          This browser is blocking local storage, so these links won&apos;t be
+          saved. Download or copy them now — they&apos;ll be lost on refresh.
+        </p>
+      )}
+
       {full && (
         <p className="text-system-warning mt-2 text-xs font-medium">
           The group is at its maximum of {net.maximumMembers.toString()} members
@@ -134,6 +209,23 @@ export function InviteLinksBody({
             </span>
           </div>
 
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={copyAll}
+              className="border-paper-2 text-surface-grey-2 hover:border-primary-jade hover:text-primary-jade inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors"
+            >
+              <CopySimple size={14} weight="bold" /> Copy all
+            </button>
+            <button
+              type="button"
+              onClick={downloadJson}
+              className="border-paper-2 text-surface-grey-2 hover:border-primary-jade hover:text-primary-jade inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors"
+            >
+              <DownloadSimple size={14} weight="bold" /> Download backup
+            </button>
+          </div>
+
           <ul className="mt-2 flex max-h-96 flex-col gap-2 overflow-y-auto">
             {invites.map((inv, i) => {
               const link = inviteLink(net.id, inv);
@@ -169,8 +261,10 @@ export function InviteLinksBody({
 
           <p className="text-surface-grey mt-3 text-xs">
             <span className="text-system-warning font-bold">Reminder: </span>
-            each link is unique and can only be used once. Links are saved only
-            in this browser — share them privately.
+            each link is unique and can only be used once. They&apos;re saved
+            only in this browser — <strong>download a backup</strong> so you
+            don&apos;t lose them if you clear your browser or switch devices, and
+            share them privately.
           </p>
         </>
       )}

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { PRIVY_ENABLED } from "@/lib/config";
 import { AddressesProvider } from "@/components/addresses-provider";
+import { ToastProvider } from "@/hooks/use-toast";
 import { GeneralProviders } from "@/components/providers-general";
 
 // The Privy tree is code-split behind next/dynamic so `@privy-io/*` only loads
@@ -16,18 +17,17 @@ const PrivyProviders = dynamic(
 );
 
 export function Providers({ children }: { children: ReactNode }) {
-  // AddressesProvider sits outermost: it needs no wagmi/query context, and its
-  // hydration re-render must reach both provider trees.
-  if (PRIVY_ENABLED) {
-    return (
-      <AddressesProvider>
-        <PrivyProviders>{children}</PrivyProviders>
-      </AddressesProvider>
-    );
-  }
+  // AddressesProvider + ToastProvider sit outermost: they need no wagmi/query
+  // context, and both must be ancestors of every tree (the toast surface is
+  // shared, and the addresses re-render must reach both provider trees).
+  const tree = PRIVY_ENABLED ? (
+    <PrivyProviders>{children}</PrivyProviders>
+  ) : (
+    <GeneralProviders>{children}</GeneralProviders>
+  );
   return (
     <AddressesProvider>
-      <GeneralProviders>{children}</GeneralProviders>
+      <ToastProvider>{tree}</ToastProvider>
     </AddressesProvider>
   );
 }

--- a/web/src/components/ui/tx-status.tsx
+++ b/web/src/components/ui/tx-status.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   ArrowSquareOut,
   CheckCircle,
@@ -8,6 +9,9 @@ import {
 } from "@phosphor-icons/react";
 import { txUrl } from "@/lib/config";
 import type { TxStatus as TxStatusValue } from "@/hooks/use-tx";
+
+/** After this long "confirming", warn the tx may be stuck (dropped/underpriced). */
+const STUCK_AFTER_MS = 120_000;
 
 /**
  * Inline feedback line for a transaction (signing → confirming →
@@ -25,6 +29,18 @@ export function TxStatus({
   error?: string | null;
   successLabel?: string;
 }) {
+  // Surface a "may be stuck" hint if a tx sits in "confirming" too long
+  // (dropped mempool / underpriced) instead of spinning forever.
+  const [stuck, setStuck] = useState(false);
+  useEffect(() => {
+    if (status !== "confirming") {
+      setStuck(false);
+      return;
+    }
+    const t = setTimeout(() => setStuck(true), STUCK_AFTER_MS);
+    return () => clearTimeout(t);
+  }, [status]);
+
   return (
     <div role="status" aria-live="polite">
       {status === "error" && (
@@ -57,6 +73,23 @@ export function TxStatus({
           {status === "signing"
             ? "Confirm in your wallet…"
             : "Waiting for confirmation…"}
+        </p>
+      )}
+
+      {status === "confirming" && stuck && (
+        <p className="text-system-warning mt-2 flex items-center gap-2 text-sm font-medium">
+          <Warning size={18} weight="fill" className="shrink-0" />
+          Taking longer than usual — check your wallet or try again.
+          {hash && (
+            <a
+              href={txUrl(hash)}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary-jade inline-flex items-center gap-1 hover:underline"
+            >
+              View <ArrowSquareOut size={14} />
+            </a>
+          )}
         </p>
       )}
     </div>

--- a/web/src/components/version-check.tsx
+++ b/web/src/components/version-check.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowClockwise, X } from "@phosphor-icons/react";
+import { BASE_PATH } from "@/lib/config";
+
+/** How often to re-check the deployed build id (ms). */
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Baked into the bundle at build time (github.sha in CI). When the deployed
+ * build-id.txt differs from this, the loaded bundle is stale.
+ */
+const BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? "";
+
+async function fetchDeployedId(): Promise<string | null> {
+  try {
+    // Cache-bust so a CDN/browser cache can't mask a fresh deploy — the whole
+    // point is to detect a bundle the cache is otherwise still serving.
+    const res = await fetch(`${BASE_PATH}/build-id.txt?t=${Date.now()}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.text()).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Static export has no built-in version signal, so users get stuck on a cached
+ * bundle after a deploy (this bit us twice). Poll the deployed build-id.txt and,
+ * when it no longer matches the bundle we're running, offer a one-tap refresh.
+ * No-ops in dev / when BUILD_ID isn't set (nothing to compare against).
+ */
+export function VersionCheck() {
+  const [stale, setStale] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!BUILD_ID) return;
+    let active = true;
+
+    const check = async () => {
+      const deployed = await fetchDeployedId();
+      if (active && deployed && deployed !== BUILD_ID) setStale(true);
+    };
+
+    check();
+    const timer = setInterval(check, POLL_INTERVAL_MS);
+    // Re-check when the tab regains focus (users leave it open for days).
+    const onVisible = () => {
+      if (document.visibilityState === "visible") check();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      active = false;
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+
+  if (!stale || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="section-container flex flex-col gap-2 pt-4"
+    >
+      <div className="border-primary-jade/40 bg-primary-jade/10 text-primary-jade flex items-center justify-between gap-3 rounded-xl border px-4 py-2.5 text-sm font-medium">
+        <span className="inline-flex items-center gap-2">
+          <ArrowClockwise size={16} weight="bold" className="shrink-0" />
+          <span>
+            A new version of the app is available.{" "}
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="font-bold underline underline-offset-2"
+            >
+              Refresh to update
+            </button>
+            .
+          </span>
+        </span>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => setDismissed(true)}
+          className="shrink-0 opacity-70 hover:opacity-100"
+        >
+          <X size={16} weight="bold" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-invite.ts
+++ b/web/src/hooks/use-invite.ts
@@ -11,6 +11,7 @@ import {
 import { ADDRESSES, CHAIN_ID } from "@/lib/config";
 import { parseContractError } from "@/lib/parse-contract-error";
 import { useTypedDataSigner } from "@/hooks/use-typed-data-signer";
+import { useToast } from "@/hooks/use-toast";
 
 /**
  * A generated invite persisted in this browser. app-stacks keeps its invite
@@ -62,6 +63,7 @@ export function inviteLink(safetyNetId: bigint, invite: StoredInvite): string {
  */
 export function useInviteLinks(safetyNetId: bigint | undefined) {
   const { address } = useAccount();
+  const { toast } = useToast();
   // Privy mode signs silently (showWalletUIs:false); general/verify uses wagmi.
   const signTypedData = useTypedDataSigner();
   const [invites, setInvites] = useState<StoredInvite[]>([]);
@@ -109,7 +111,11 @@ export function useInviteLinks(safetyNetId: bigint | undefined) {
         // failures (SDK/serialization/network) into the generic fallback, which
         // made the Privy BigInt-serialization bug invisible in production logs.
         console.error("[invites] signature failed:", e);
-        setError(parseContractError(e, "Signature failed."));
+        const friendly = parseContractError(e, "Couldn't sign the invite links.");
+        setError(friendly);
+        if (!/rejected in wallet/i.test(friendly)) {
+          toast({ tone: "error", message: friendly });
+        }
       } finally {
         setProgress(null);
         if (generated.length > 0) {
@@ -121,7 +127,7 @@ export function useInviteLinks(safetyNetId: bigint | undefined) {
         }
       }
     },
-    [key, safetyNetId, signTypedData],
+    [key, safetyNetId, signTypedData, toast],
   );
 
   return {

--- a/web/src/hooks/use-toast.tsx
+++ b/web/src/hooks/use-toast.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Warning, CheckCircle, Info, X } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+export type ToastTone = "error" | "success" | "info";
+
+export interface Toast {
+  id: number;
+  tone: ToastTone;
+  message: ReactNode;
+  /** Optional inline action (e.g. "Retry"). */
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastInput {
+  tone?: ToastTone;
+  message: ReactNode;
+  action?: { label: string; onClick: () => void };
+  /** ms before auto-dismiss; 0 keeps it until dismissed. Default 8000. */
+  duration?: number;
+}
+
+interface ToastApi {
+  toast: (input: ToastInput) => number;
+  dismiss: (id: number) => void;
+}
+
+const ToastContext = createContext<ToastApi | null>(null);
+
+const TONE_STYLE: Record<ToastTone, string> = {
+  error: "border-red-1 bg-red-0/95 text-red-main",
+  success: "border-system-green/40 bg-paper-0/95 text-system-green",
+  info: "border-primary-jade/40 bg-paper-0/95 text-primary-jade",
+};
+
+const ICON: Record<ToastTone, typeof Warning> = {
+  error: Warning,
+  success: CheckCircle,
+  info: Info,
+};
+
+/**
+ * App-wide toast surface. A money app must never fail silently: every write /
+ * read failure is dispatched here (see use-tx, use-invite) so it stays visible
+ * even if the originating component unmounts, alongside the inline TxStatus.
+ * Reuses the notification-banner tone language; no new dependency.
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const nextId = useRef(1);
+  const timers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const toast = useCallback(
+    ({ tone = "info", message, action, duration = 8000 }: ToastInput) => {
+      const id = nextId.current++;
+      setToasts((prev) => [...prev.slice(-3), { id, tone, message, action }]);
+      if (duration > 0) {
+        timers.current.set(
+          id,
+          setTimeout(() => dismiss(id), duration),
+        );
+      }
+      return id;
+    },
+    [dismiss],
+  );
+
+  const api = useMemo(() => ({ toast, dismiss }), [toast, dismiss]);
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <div
+        role="region"
+        aria-label="Notifications"
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-[100] flex flex-col items-center gap-2 p-4 sm:items-end"
+      >
+        {toasts.map((t) => {
+          const Icon = ICON[t.tone];
+          return (
+            <div
+              key={t.id}
+              role={t.tone === "error" ? "alert" : "status"}
+              className={cn(
+                "pointer-events-auto flex w-full max-w-sm items-start gap-2 rounded-xl border px-4 py-3 text-sm font-medium shadow-lg backdrop-blur",
+                TONE_STYLE[t.tone],
+              )}
+            >
+              <Icon size={18} weight="fill" className="mt-0.5 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-text-standard break-words">
+                  {t.message}
+                </div>
+                {t.action && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      t.action?.onClick();
+                      dismiss(t.id);
+                    }}
+                    className="text-primary-jade mt-1 font-bold hover:underline"
+                  >
+                    {t.action.label}
+                  </button>
+                )}
+              </div>
+              <button
+                type="button"
+                aria-label="Dismiss"
+                onClick={() => dismiss(t.id)}
+                className="text-surface-grey hover:text-text-standard shrink-0"
+              >
+                <X size={16} weight="bold" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+/**
+ * Access the toast API. Safe to call even outside a provider (returns no-ops),
+ * so shared hooks like useTx don't crash in tests or non-app contexts.
+ */
+export function useToast(): ToastApi {
+  return useContext(ToastContext) ?? { toast: () => 0, dismiss: () => {} };
+}

--- a/web/src/hooks/use-tx.ts
+++ b/web/src/hooks/use-tx.ts
@@ -7,6 +7,7 @@ import type { Abi, Address } from "viem";
 import { CHAIN_ID } from "@/lib/config";
 import { parseContractError } from "@/lib/parse-contract-error";
 import { useTxSender } from "@/hooks/use-tx-sender";
+import { useToast } from "@/hooks/use-toast";
 
 export type TxStatus = "idle" | "signing" | "confirming" | "success" | "error";
 
@@ -33,6 +34,7 @@ export function useTx() {
   const [hash, setHash] = useState<`0x${string}` | undefined>(undefined);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const queryClient = useQueryClient();
+  const { toast } = useToast();
 
   const {
     data: receipt,
@@ -57,11 +59,20 @@ export function useTx() {
         setHash(txHash);
         return txHash;
       } catch (e) {
-        setSubmitError(parseContractError(e));
+        const friendly = parseContractError(e);
+        // Always log the raw error: a money app must never fail silently, and a
+        // non-contract SDK error (like the Privy BigInt bug) would otherwise
+        // collapse into the generic message with no way to diagnose it.
+        console.error(`[tx:${request.functionName}] failed:`, e);
+        setSubmitError(friendly);
+        // A user rejecting the wallet prompt isn't an error worth a toast.
+        if (!/rejected in wallet/i.test(friendly)) {
+          toast({ tone: "error", message: friendly });
+        }
         return undefined;
       }
     },
-    [send],
+    [send, toast],
   );
 
   const reset = useCallback(() => {

--- a/web/src/lib/parse-contract-error.ts
+++ b/web/src/lib/parse-contract-error.ts
@@ -29,13 +29,33 @@ export function parseContractError(
   }
 
   const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
 
-  if (message.toLowerCase().includes("user rejected"))
+  if (
+    lower.includes("user rejected") ||
+    lower.includes("user denied") ||
+    lower.includes("rejected the request")
+  )
     return "Rejected in wallet.";
 
   for (const [name, friendly] of Object.entries(SAFETY_NET_ERRORS)) {
     if (message.includes(name)) return friendly;
   }
+
+  // Network / RPC failures (fetch, timeout, CORS, HTTP) — distinct from a
+  // contract revert, and actionable ("try again") rather than a hard failure.
+  if (
+    lower.includes("failed to fetch") ||
+    lower.includes("timed out") ||
+    lower.includes("timeout") ||
+    lower.includes("network") ||
+    lower.includes("fetch failed") ||
+    /http (4|5)\d\d/.test(lower)
+  )
+    return "Network error reaching Gnosis — check your connection and try again.";
+
+  if (lower.includes("insufficient funds"))
+    return "Not enough gas (xDAI) to send this transaction.";
 
   if (error instanceof BaseError && error.shortMessage)
     return error.shortMessage;


### PR DESCRIPTION
## Batch A — Resilience & trust

First of three app-hardening batches. The theme: **nothing should fail silently again.** This session had two production failures (Privy sponsored-tx 400, invite BigInt serialization) that failed silently or behind a generic message, and users hit a stale cached bundle twice. This batch closes those gaps — dependency-free (no Sentry/PostHog).

### What's in it
- **Global toast surface** (`use-toast.tsx`) — every write/read failure is dispatched here so it stays visible even if the originating component unmounts, alongside the inline `TxStatus`. The **raw error is always `console.error`'d** (the Privy BigInt bug was invisible for exactly this reason). Wired from `use-tx` and `use-invite`; user-rejections skip the toast.
- **Error classification** (`parse-contract-error.ts`) — RPC/timeout/network and insufficient-gas failures now get distinct, actionable messages instead of the generic "Transaction failed."
- **Root error boundaries** (`error.tsx` + `global-error.tsx`) — a render throw shows a "Something went wrong — your funds are safe on-chain" fallback instead of blanking the app, and logs the error.
- **Version-refresh banner** (`version-check.tsx`) — static export has no version signal, so users got stuck on cached bundles (twice). Bakes `github.sha` as `NEXT_PUBLIC_BUILD_ID`, emits `build-id.txt` in `pages.yml`, polls it (every 5 min + on tab focus), and offers a one-tap refresh when it changes.
- **Invite-link durability** (`invite-panel.tsx`) — invites live only in the owner's `localStorage`, so a cleared browser or new device loses every unredeemed link. Adds **Copy-all** and **Download-backup (JSON)**, a storage-blocked warning, and a stronger reminder.
- **Stuck-tx timeout** (`tx-status.tsx`) — after ~2 min confirming with no receipt, shows "Taking longer than usual — check your wallet" instead of spinning forever.

### Verification
- `pnpm build` (static export) + `pnpm lint` clean.
- Version banner verified in a headless browser both ways: differing build-ids → banner shown; matching → no banner.

### Not included (per plan)
- Third-party observability (Sentry/PostHog) — dropped to stay dependency-free; Batch A's always-`console.error` rule is the dependency-free substitute.
- QR codes per invite link — deferred (would need a QR encoder dep or ~600 lines); Copy-all + JSON backup covers the durability risk.

Batches B (funding friction & mobile) and C (a11y, PWA, share previews, 404s) follow as their own PRs.