### PR TITLE
feat(funding+mobile): prefill Get-BREAD with shortfall, actions-first on phones (Batch B)

### DIFF
--- a/web/src/components/create/create-form.tsx
+++ b/web/src/components/create/create-form.tsx
@@ -553,7 +553,7 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
             </Field>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field
               id={id("contest-threshold")}
               label="Contest threshold (%)"

--- a/web/src/components/funding/fund-hub.tsx
+++ b/web/src/components/funding/fund-hub.tsx
@@ -32,7 +32,18 @@ interface Rail {
 }
 
 /** "Get BREAD" funding hub — a sectioned set of ways to add funds. */
-export function FundHub({ onClose }: { onClose: () => void }) {
+export function FundHub({
+  onClose,
+  prefillMint,
+}: {
+  onClose: () => void;
+  /**
+   * When opened from a deposit that's short on BREAD, the exact shortfall (18
+   * decimals): the hub opens on the Mint rail with this amount filled in so a
+   * user who already holds xDAI can top up in one click.
+   */
+  prefillMint?: bigint;
+}) {
   const { address } = useAccount();
   const {
     breadBalance,
@@ -105,11 +116,13 @@ export function FundHub({ onClose }: { onClose: () => void }) {
   // PRIVY_ENABLED and PEER_ONRAMP_ENABLED are build-time constants, so the rail
   // set is stable per build — no need to list them as deps.
 
-  const [rail, setRail] = useState<RailId>("bridge");
+  const [rail, setRail] = useState<RailId>(prefillMint ? "mint" : "bridge");
   const active = rails.find((r) => r.id === rail) ?? rails[0];
 
   // ---- Direct mint state ----------------------------------------------------
-  const [amount, setAmount] = useState("");
+  const [amount, setAmount] = useState(
+    prefillMint ? formatUnits(prefillMint, 18) : "",
+  );
   const mintableXdai = useMemo(() => {
     if (xdaiBalance === undefined) return undefined;
     return xdaiBalance > GAS_RESERVE_XDAI ? xdaiBalance - GAS_RESERVE_XDAI : 0n;
@@ -164,6 +177,17 @@ export function FundHub({ onClose }: { onClose: () => void }) {
         Fund your wallet, then mint BREAD — the savings token your Safety Net
         holds. BREAD mints 1:1 from xDAI and redeems back anytime.
       </Body>
+
+      {prefillMint !== undefined && prefillMint > 0n && (
+        <div className="border-primary-jade/40 bg-primary-jade/10 mt-3 rounded-xl border px-3 py-2 text-sm">
+          <p className="text-text-standard font-medium">
+            You need {formatAmount(prefillMint, 18)} more BREAD for your deposit.
+          </p>
+          <p className="text-surface-grey-2 mt-0.5 text-xs">
+            Already have xDAI? Mint it below. Otherwise add xDAI first, then mint.
+          </p>
+        </div>
+      )}
 
       {/* Live balances */}
       <dl className="border-paper-2 bg-paper-main mt-4 grid grid-cols-2 gap-px overflow-hidden rounded-xl border">

--- a/web/src/components/funding/get-bread-modal.tsx
+++ b/web/src/components/funding/get-bread-modal.tsx
@@ -15,9 +15,12 @@ import { FundHub } from "./fund-hub";
 export function GetBreadModal({
   open,
   onClose,
+  prefillMint,
 }: {
   open: boolean;
   onClose: () => void;
+  /** Shortfall (18 decimals) to prefill the Mint rail with — see FundHub. */
+  prefillMint?: bigint;
 }) {
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -52,7 +55,7 @@ export function GetBreadModal({
         <div id={titleId} className="sr-only">
           Add funds
         </div>
-        <FundHub onClose={onClose} />
+        <FundHub onClose={onClose} prefillMint={prefillMint} />
       </div>
     </div>
   );

--- a/web/src/components/net/deposit-panel.tsx
+++ b/web/src/components/net/deposit-panel.tsx
@@ -158,6 +158,11 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
     net.token.toLowerCase() === BREAD_ADDRESS.toLowerCase();
   const canGetBread =
     mode === "self" && isBreadNet && insufficientBalance === true;
+  // The exact top-up needed to afford this deposit — prefilled into Get-BREAD.
+  const shortfall =
+    canGetBread && parsed !== null && balance !== undefined
+      ? parsed - balance
+      : undefined;
   // Upper bound on what the prepay window can absorb: this epoch's remaining
   // dues + MAX_PREPAY_EPOCHS full epochs. (Future-epoch fills can't be read
   // cheaply, so a deposit inside this bound can still revert with
@@ -344,9 +349,11 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
           <button
             type="button"
             onClick={() => setGetBreadOpen(true)}
-            className="border-primary-jade text-primary-jade hover:bg-primary-jade/10 self-start rounded-lg border px-3 py-1.5 text-xs font-bold transition-colors"
+            className="bg-primary-jade hover:bg-primary-jade/90 self-start rounded-lg px-3 py-1.5 text-xs font-bold text-white transition-colors"
           >
-            Not enough BREAD — Get BREAD
+            {shortfall !== undefined && shortfall > 0n
+              ? `Get ${formatAmount(shortfall, decimals)} ${symbol}`
+              : `Get ${symbol}`}
           </button>
         )}
         {exceedsCapacity && (
@@ -360,7 +367,8 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
           <p className="text-system-warning text-xs font-medium">
             Deposits pull tokens from the member&apos;s own wallet — they must
             first approve the SafetyNet contract for at least{" "}
-            {formatAmount(parsed, decimals)} {symbol}.
+            {formatAmount(parsed, decimals)} {symbol}, and need a little xDAI for
+            gas to do it (gas sponsorship only covers in-app wallets).
           </p>
         )}
 
@@ -400,6 +408,7 @@ export function DepositPanel({ details }: { details: SafetyNetDetails }) {
       <GetBreadModal
         open={getBreadOpen}
         onClose={() => setGetBreadOpen(false)}
+        prefillMint={shortfall}
       />
     </Card>
   );

--- a/web/src/components/net/net-overview.tsx
+++ b/web/src/components/net/net-overview.tsx
@@ -31,7 +31,7 @@ export function NetOverview({ details }: { details: SafetyNetDetails }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <StatCard
           label="Pool balance"
           value={`${formatAmount(details.totalBalance, decimals)} ${symbol}`}

--- a/web/src/components/net/net-page-content.tsx
+++ b/web/src/components/net/net-page-content.tsx
@@ -150,14 +150,25 @@ function NetDetail() {
         </>
       ) : (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="flex flex-col gap-4 lg:col-span-2">
+          {/* On phones the single column stacks top-to-bottom; a member's
+              Deposit/Withdraw actions (right) come first so they aren't buried
+              under overview/members/requests. Reverts to the sidebar on lg. */}
+          <div
+            className={`flex flex-col gap-4 lg:col-span-2 ${
+              details.isMember ? "order-2 lg:order-1" : ""
+            }`}
+          >
             <NetOverview details={details} />
             <MembersList details={details} />
             <RequestsList details={details} />
             <ActivityFeed details={details} />
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div
+            className={`flex flex-col gap-4 ${
+              details.isMember ? "order-1 lg:order-2" : ""
+            }`}
+          >
             {details.isMember ? (
               <>
                 <DepositPanel details={details} />


### PR DESCRIPTION
## Batch B — Funding friction & mobile

Second of three app-hardening batches. Removes the two biggest friction points: a member with 0 BREAD dead-ending on a deposit, and member actions being buried below the fold on phones.

### Funding at the moment of need
- A member short on BREAD now sees a prominent **"Get \<shortfall\> BREAD"** button. It opens the funding hub on the **Mint rail with the exact top-up prefilled** (`FundHub`/`GetBreadModal` gain a `prefillMint` prop), so anyone already holding xDAI can cover the deposit in one click. The hub also states how much more is needed and how to get there.
- The **"For a member"** deposit path now notes the member needs a little xDAI for gas to approve (sponsorship only covers in-app wallets).
- The join flow already renders `DepositPanel` inline, so this prefilled Get-BREAD step now guides a brand-new member through their first deposit automatically.

### Mobile & responsive
- **Net page:** on phones the member's Deposit/Withdraw column now comes **first** (via `order` utilities) instead of being buried under overview/members/requests/activity; reverts to the sidebar layout at `lg`. Non-members keep natural order.
- **Stat grid** goes 4-wide at `md` (was `lg`) so tablets use the width.
- **Create-form** contest fields stack on phones (`grid-cols-1 sm:grid-cols-2`), matching their sibling field rows.

### Verification
- `pnpm build` (static export) + `pnpm lint` clean.
- Confirmed Tailwind generated the new `order-1/2`, `lg:order-1/2`, and `md:grid-cols-4` utilities in the exported CSS.

Batch C (a11y, PWA, share previews, root 404s, tiny-amount display) follows as its own PR.