### PR TITLE
feat(polish): a11y focus-traps + labels, PWA manifest, footer 404 fix, tiny amounts (Batch C)

### DIFF
--- a/web/src/app/manifest.ts
+++ b/web/src/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+import { SITE_NAME } from "@/lib/metadata";
+
+// Required for `output: export` — emit a static manifest.webmanifest at build.
+export const dynamic = "force-static";
+
+/**
+ * PWA web manifest (Next metadata route → static `manifest.webmanifest`, and
+ * the <link rel="manifest"> is injected automatically). Icon `src` and
+ * `start_url` are RELATIVE so they resolve under the deployed base path
+ * (/safety-net/…) without hardcoding it — the manifest itself is served under
+ * that prefix, and the app icons live at `${basePath}/icon.png` etc.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Safety Net — group savings on Gnosis",
+    short_name: SITE_NAME,
+    description:
+      "Group savings with a social safety net — pooled deposits, mutual accountability, and community-approved withdrawals on Gnosis Chain.",
+    start_url: ".",
+    display: "standalone",
+    background_color: "#f6f3eb",
+    theme_color: "#286b63",
+    icons: [
+      { src: "icon.png", sizes: "any", type: "image/png", purpose: "any" },
+      { src: "apple-icon.png", sizes: "180x180", type: "image/png" },
+    ],
+  };
+}

--- a/web/src/components/create/create-form.tsx
+++ b/web/src/components/create/create-form.tsx
@@ -307,6 +307,7 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
       </Field>
 
       <Field
+        id={id("token")}
         label="Token"
         help="The ERC20 everyone saves in. BREAD is the default; pick Custom for another allowed token."
         error={errors.customToken?.message}
@@ -345,8 +346,12 @@ function FormPanel({ onContinue }: { onContinue: () => void }) {
         </div>
         {tokenChoice === "custom" && (
           <input
+            id={id("token")}
             aria-label="Custom token address"
             aria-invalid={errors.customToken ? true : undefined}
+            aria-describedby={
+              errors.customToken ? `${id("token")}-error` : undefined
+            }
             className={`${inputClass} mt-2`}
             placeholder="0x… token address"
             {...register("customToken")}

--- a/web/src/components/funding/get-bread-modal.tsx
+++ b/web/src/components/funding/get-bread-modal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useId, useRef } from "react";
+import { useId, useRef } from "react";
 import { FundHub } from "./fund-hub";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 /**
  * "Add funds" hub modal. Keeps the original `GetBreadModal({ open, onClose })`
@@ -25,15 +26,8 @@ export function GetBreadModal({
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    dialogRef.current?.querySelector<HTMLElement>("input,button")?.focus();
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  // Focus into the modal on open, trap Tab within it, Escape closes.
+  useFocusTrap(dialogRef, open, onClose);
 
   if (!open) return null;
 

--- a/web/src/components/net/fund-health-panel.tsx
+++ b/web/src/components/net/fund-health-panel.tsx
@@ -54,7 +54,7 @@ export function FundHealthPanel({ details }: { details: SafetyNetDetails }) {
           help="A simple solvency check: if one member drew their full monthly support right now, roughly how many months could the current pool sustain it? Six months or more is comfortable. It's an illustration of the pool's depth, not a guarantee."
         >
           <span className="inline-flex items-center gap-2">
-            ~{runwayMonths.toFixed(1)} months
+            {runwayMonths >= 999 ? "999+" : `~${runwayMonths.toFixed(1)}`} months
             <Badge tone={runwayTone}>{runwayLabel}</Badge>
           </span>
         </InfoRow>

--- a/web/src/components/net/withdraw-panel.tsx
+++ b/web/src/components/net/withdraw-panel.tsx
@@ -183,7 +183,11 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
               rows={3}
               placeholder="Explain your request so the group can decide whether to contest it…"
               aria-invalid={reasonTooLong || undefined}
-              aria-describedby={`${reasonId}-help`}
+              aria-describedby={
+                reasonTooLong
+                  ? `${reasonId}-help ${reasonId}-error`
+                  : `${reasonId}-help`
+              }
               className={`${inputClass} mt-1.5 resize-y`}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
@@ -196,7 +200,10 @@ export function WithdrawPanel({ details }: { details: SafetyNetDetails }) {
               group. Keep it under {MAX_REASON_WORDS} words.
             </p>
             {reasonTooLong && (
-              <p className="text-system-red mt-1 text-xs font-medium">
+              <p
+                id={`${reasonId}-error`}
+                className="text-system-red mt-1 text-xs font-medium"
+              >
                 {reasonWords > MAX_REASON_WORDS
                   ? `Too long — remove ${reasonWords - MAX_REASON_WORDS} word${reasonWords - MAX_REASON_WORDS === 1 ? "" : "s"}.`
                   : "Too long — please shorten it (max 2000 bytes)."}

--- a/web/src/components/site-footer.tsx
+++ b/web/src/components/site-footer.tsx
@@ -1,8 +1,35 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Footer } from "@breadcoop/ui";
+import { BASE_PATH } from "@/lib/config";
 
-/** Breadchain solidarity footer (client component — uses phosphor icons). */
+/**
+ * Breadchain solidarity footer (client component — uses phosphor icons).
+ *
+ * The kit Footer hardcodes two social icons as root-absolute <img> tags
+ * (`/paragraph.png`, `/farcaster-icon.png`) with no prop to override them.
+ * Under our GitHub Pages base path (/safety-net) those resolve to the domain
+ * root and 404 — Next only rewrites its own asset references, not string paths
+ * baked into a third-party component. We ship the PNGs in public/ (served at
+ * `${BASE_PATH}/…`) and repoint any root-absolute footer <img> after mount.
+ */
 export function SiteFooter() {
-  return <Footer mode="transparent" className="section-container mt-auto" />;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!BASE_PATH || !ref.current) return;
+    for (const img of ref.current.querySelectorAll("img")) {
+      const src = img.getAttribute("src");
+      if (src && src.startsWith("/") && !src.startsWith(`${BASE_PATH}/`)) {
+        img.setAttribute("src", `${BASE_PATH}${src}`);
+      }
+    }
+  }, []);
+
+  return (
+    <div ref={ref} className="mt-auto">
+      <Footer mode="transparent" className="section-container" />
+    </div>
+  );
 }

--- a/web/src/components/ui/confirm-dialog.tsx
+++ b/web/src/components/ui/confirm-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useId, useRef, type ReactNode } from "react";
+import { useId, useRef, type ReactNode } from "react";
 import { Body, Button, Heading4 } from "@breadcoop/ui";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 /**
  * Confirmation step for irreversible actions (decommission, contest) — the
@@ -31,16 +32,8 @@ export function ConfirmDialog({
   const titleId = useId();
   const confirmRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    // Move focus into the dialog so keyboard users aren't left behind it.
-    confirmRef.current?.querySelector("button")?.focus();
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onCancel]);
+  // Focus into the dialog on open, trap Tab within it, Escape cancels.
+  useFocusTrap(confirmRef, open, onCancel);
 
   if (!open) return null;
 

--- a/web/src/components/ui/slider-field.tsx
+++ b/web/src/components/ui/slider-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 
 /**
  * Styled range input (design-system jade/paper tokens; rules in globals.css).
@@ -87,6 +87,9 @@ export function SliderField({
   disabled?: boolean;
 }) {
   const [draft, setDraft] = useState<string | null>(null);
+  // Label the number box by the visible label element (works even when `label`
+  // is a ReactNode, where a string aria-label can't be derived).
+  const labelId = useId();
 
   // External changes (slider drags, form resets) overwrite an unfocused draft.
   useEffect(() => {
@@ -101,7 +104,11 @@ export function SliderField({
   return (
     <div>
       <div className="flex items-end justify-between gap-2">
-        <label htmlFor={id} className="text-surface-grey-2 text-xs font-bold">
+        <label
+          id={labelId}
+          htmlFor={id}
+          className="text-surface-grey-2 text-xs font-bold"
+        >
           {label}
         </label>
         {format ? (
@@ -114,7 +121,7 @@ export function SliderField({
               value={draft ?? String(value)}
               inputMode="numeric"
               disabled={disabled}
-              aria-label={typeof label === "string" ? label : undefined}
+              aria-labelledby={labelId}
               onChange={(e) => {
                 setDraft(e.target.value);
                 commit(e.target.value);

--- a/web/src/hooks/use-focus-trap.ts
+++ b/web/src/hooks/use-focus-trap.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Keyboard containment for modal dialogs. While `active`, focuses the first
+ * focusable element inside `containerRef` on open, cycles Tab / Shift+Tab
+ * within the container (so focus can't escape behind the backdrop), and calls
+ * `onEscape` on Escape. No-op while inactive.
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  active: boolean,
+  onEscape?: () => void,
+) {
+  // Kept in a ref so a fresh inline onEscape each render doesn't re-run the
+  // effect (which would steal focus back to the first element on every render).
+  const escapeRef = useRef(onEscape);
+  escapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusable = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement,
+      );
+
+    // Initial focus so keyboard users start inside the dialog, not behind it.
+    focusable()[0]?.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        escapeRef.current?.();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const els = focusable();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (activeEl === last || !container.contains(activeEl)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [active, containerRef]);
+}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -10,6 +10,11 @@ export function formatAmount(
   const s = formatUnits(value, decimals);
   const n = Number(s);
   if (Number.isNaN(n)) return s;
+  // A tiny but non-zero amount would round to "0.00" and read as nothing —
+  // show a "< smallest" marker instead so it's clearly not zero.
+  const smallest = 1 / 10 ** maxFrac;
+  if (n > 0 && n < smallest)
+    return `<${smallest.toLocaleString("en-US", { maximumFractionDigits: maxFrac })}`;
   return n.toLocaleString("en-US", {
     minimumFractionDigits: n === 0 ? 0 : Math.min(2, maxFrac),
     maximumFractionDigits: maxFrac,

--- a/web/src/lib/metadata.ts
+++ b/web/src/lib/metadata.ts
@@ -42,6 +42,7 @@ export function buildMetadata({
         ? title
         : { default: DEFAULT_TITLE, template: `%s — ${SITE_NAME}` },
     description,
+    alternates: { canonical: absolute(path) },
     openGraph: {
       type: "website",
       siteName: SITE_NAME,


### PR DESCRIPTION
## Batch C — Polish

Final app-hardening batch: accessibility, PWA/share polish, the two root-absolute 404s, and small/large amount display. Dependency-free.

### Accessibility
- **New shared `useFocusTrap` hook** — focuses into a dialog on open, cycles Tab / Shift+Tab within it, Escape closes. Wired into `ConfirmDialog` and `GetBreadModal` (both previously only did Escape + initial focus), replacing duplicated logic.
- **SliderField** number box is now labelled via `aria-labelledby` to the visible label element, so it has an accessible name even when `label` is a ReactNode (a string `aria-label` couldn't be derived before).
- **Create-form** custom-token input wires `aria-describedby` to its error; **withdraw** reason textarea includes its "too long" error in `aria-describedby`. (Navbar "Get BREAD" is a text button — already accessible.)

### PWA + share
- **Web manifest** (`src/app/manifest.ts` → static `manifest.webmanifest`, `<link>` auto-injected). Relative icon `src`/`start_url` resolve correctly under the `/safety-net` base path — verified the manifest link, icons, and canonical are all base-path-correct in a production build.
- `buildMetadata` now emits **`rel="canonical"`**. (og.png is already 44K — no compression needed. Per-net `og:title` isn't feasible in a static export; `document.title` already reflects the net name for the browser tab.)

### Root 404s (investigated)
- Root-caused: the `@breadcoop/ui` `Footer` hardcodes two social icons as root-absolute `<img>` (`/paragraph.png`, `/farcaster-icon.png`) with no override prop — under our base path they resolve to the domain root and 404. `SiteFooter` now repoints any root-absolute footer `<img>` to `${BASE_PATH}/…` after mount (the PNGs already ship in `public/`).
- **Verified in a headless browser** (production base-path build served under `/safety-net/`): both icons rewrite to `/safety-net/*` and actually load (naturalWidth > 0); the root path 404s as expected, the base-path path 200s.

### Tiny/huge amounts
- `formatAmount` shows **`<0.0001`** for a non-zero amount that would otherwise round to `0.00` and read as nothing (unit-tested).
- Fund-health **"Pool runway" clamps to "999+ months"** instead of an absurd number when monthly support is tiny.

### Verification
- `pnpm build` + `pnpm lint` clean; `manifest.webmanifest` emitted.
- Footer rewrite + tiny-amount formatting checked at runtime; manifest/canonical/icon hrefs inspected in the production build.

This completes the A → B → C hardening plan.